### PR TITLE
Max iterations minimum should be 0

### DIFF
--- a/splink/files/settings_jsonschema.json
+++ b/splink/files/settings_jsonschema.json
@@ -60,7 +60,7 @@
         150
       ],
       "maximum": 200,
-      "minimum": 1
+      "minimum": 0
     },
     "unique_id_column_name": {
       "$id": "#/properties/unique_id_column_name",


### PR DESCRIPTION
If the user explicitly sets their m and u probabilities, they may not want any iterations at all.