### PR TITLE
Add support for custom case expressions which use arbitrary/multiple column(s)

### DIFF
--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -79,6 +79,7 @@ class Splink:
                     f"For link_type = '{link_type}', you must pass two Spark dataframes to Splink using the df_l and df_r argument. "
                     "The df argument should be omitted or set to None. "
                     "e.g. linker = Splink(settings, spark, df_l=my_first_df, df_r=df_to_link_to_first_one)"
+
                 )
 
     def _get_df_comparison(self):
@@ -97,9 +98,6 @@ class Splink:
         return run_expectation_step(df_gammas, self.params, self.settings, self.spark)
 
     def get_scored_comparisons(self, num_iterations=None):
-
-        if (num_iterations is None):
-            num_iterations=self.settings["max_iterations"]
 
         df_comparison = self._get_df_comparison()
 

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -99,6 +99,9 @@ class Splink:
 
     def get_scored_comparisons(self, num_iterations=None):
 
+        if not num_iterations:
+            num_iterations = self.settings["max_iterations"]
+
         df_comparison = self._get_df_comparison()
 
         df_gammas = add_gammas(df_comparison, self.settings, self.spark)
@@ -110,7 +113,6 @@ class Splink:
             self.params,
             self.settings,
             self.spark,
-            num_iterations=num_iterations,
             compute_ll=False,
         )
         df_gammas.unpersist()

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -27,8 +27,11 @@ def _get_columns_to_retain_blocking(settings):
     columns_to_retain[settings["unique_id_column_name"]] = None
 
     for c in settings["comparison_columns"]:
-        if c["col_is_in_input_df"]:
+        if "col_name" in c:
             columns_to_retain[c["col_name"]] = None
+        if "custom_columns_used" in c:
+            for c2 in c["custom_columns_used"]:
+                columns_to_retain[c2] = None
 
     for c in settings["additional_columns_to_retain"]:
         columns_to_retain[c] = None

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -162,7 +162,7 @@ def block_using_rules(
         pyspark.sql.dataframe.DataFrame: A dataframe of each record comparison
     """
 
-    if len(settings["blocking_rules"])==0:
+    if "blocking_rules" not in settings or len(settings["blocking_rules"])==0:
         return cartesian_block(settings, spark, df_l, df_r, df)
 
     link_type = settings["link_type"]

--- a/splink/case_statements.py
+++ b/splink/case_statements.py
@@ -34,7 +34,7 @@ def _add_null_treatment_to_case_statement(case_statement: str):
 
     if "then -1" not in sl:
         try:
-            variable_name = re.search(r"when ([\w_]{1,100})_l", case_statement)[1]
+            variable_name = re.search(r"when ([\w_]{1,100})_l", case_statement.lower())[1]
         except:
             raise ValueError(("Your case statement needs to reference a variable on the left hand "
                               "side of the comparison i.e. a variable ending with _l "

--- a/splink/case_statements.py
+++ b/splink/case_statements.py
@@ -20,34 +20,6 @@ def _check_jaro_registered(spark):
     return False
 
 
-def _add_null_treatment_to_case_statement(case_statement: str):
-    """Add null treatment to user provided case statement if not already exists
-
-    Args:
-        case_statement (str): The select case statement we want to add null treatment to
-
-    Returns:
-        str: case statement with null treatment added
-    """
-
-    sl = case_statement.lower()
-
-    if "then -1" not in sl:
-        try:
-            variable_name = re.search(r"when ([\w_]{1,100})_l", case_statement.lower())[1]
-        except:
-            raise ValueError(("Your case statement needs to reference a variable on the left hand "
-                              "side of the comparison i.e. a variable ending with _l "
-                             f"current case statement: \n{case_statement}"))
-        find = r"(case)(\s+)(when)"
-        replace = r"\1 \nwhen {col_name}_l is null or {col_name}_r is null then -1\n\3"
-        new_case_statement = re.sub(find, replace, case_statement)
-        new_case_statement = new_case_statement.format(col_name=variable_name)
-
-        return new_case_statement
-    else:
-        return case_statement
-
 
 def _add_as_gamma_to_case_statement(case_statement: str, gamma_col_name):
     """As the correct column alias to the case statement if it does not exist

--- a/splink/expectation_step.py
+++ b/splink/expectation_step.py
@@ -105,8 +105,6 @@ def _sql_gen_gamma_prob_columns(params, settings, table_name="df_with_gamma"):
                     select_cols = _add_left_right(select_cols, c2)
 
             select_cols["gamma_" + col_name] = "gamma_" + col_name
-            print("gamma_" + col_name)
-
 
         select_cols[f"prob_gamma_{col_name}_non_match"] = case_statements[f"prob_gamma_{col_name}_non_match"]
         select_cols[f"prob_gamma_{col_name}_match"] = case_statements[f"prob_gamma_{col_name}_match"]

--- a/splink/expectation_step.py
+++ b/splink/expectation_step.py
@@ -88,12 +88,25 @@ def _sql_gen_gamma_prob_columns(params, settings, table_name="df_with_gamma"):
     select_cols = _add_left_right(select_cols, settings["unique_id_column_name"])
 
     for col in settings["comparison_columns"]:
-        col_name = col["col_name"]
-        if settings["retain_matching_columns"]:
-            select_cols = _add_left_right(select_cols, col_name)
-        if col["term_frequency_adjustments"]:
-            select_cols = _add_left_right(select_cols, col_name)
-        select_cols["gamma_" + col_name] = "gamma_" + col_name
+        if "col_name" in col:
+            col_name = col["col_name"]
+            if settings["retain_matching_columns"]:
+                select_cols = _add_left_right(select_cols, col_name)
+            if col["term_frequency_adjustments"]:
+                select_cols = _add_left_right(select_cols, col_name)
+
+            select_cols["gamma_" + col_name] = "gamma_" + col_name
+
+        if "custom_name" in col:
+            col_name = col["custom_name"]
+
+            if settings["retain_matching_columns"]:
+                for c2 in col["custom_columns_used"]:
+                    select_cols = _add_left_right(select_cols, c2)
+
+            select_cols["gamma_" + col_name] = "gamma_" + col_name
+            print("gamma_" + col_name)
+
 
         select_cols[f"prob_gamma_{col_name}_non_match"] = case_statements[f"prob_gamma_{col_name}_non_match"]
         select_cols[f"prob_gamma_{col_name}_match"] = case_statements[f"prob_gamma_{col_name}_match"]
@@ -122,12 +135,22 @@ def _column_order_df_e_select_expr(settings, tf_adj_cols=False):
     select_cols = _add_left_right(select_cols, settings["unique_id_column_name"])
 
     for col in settings["comparison_columns"]:
-        col_name = col["col_name"]
-        if settings["retain_matching_columns"]:
-            select_cols = _add_left_right(select_cols, col_name)
-        if col["term_frequency_adjustments"]:
-            select_cols = _add_left_right(select_cols, col_name)
-        select_cols["gamma_" + col_name] = "gamma_" + col_name
+        if "col_name" in col:
+            col_name = col["col_name"]
+
+            # Note adding cols is idempotent so don't need to worry about adding twice
+            if settings["retain_matching_columns"]:
+                select_cols = _add_left_right(select_cols, col_name)
+            if col["term_frequency_adjustments"]:
+                select_cols = _add_left_right(select_cols, col_name)
+            select_cols["gamma_" + col_name] = "gamma_" + col_name
+
+        if "custom_name" in col:
+            col_name = col["custom_name"]
+            if settings["retain_matching_columns"]:
+                for c2 in col["custom_columns_used"]:
+                    select_cols = _add_left_right(select_cols, c2)
+            select_cols["gamma_" + col_name] = "gamma_" + col_name
 
         if settings["retain_intermediate_calculation_columns"]:
             select_cols[f"prob_gamma_{col_name}_non_match"] = f"prob_gamma_{col_name}_non_match"
@@ -135,6 +158,8 @@ def _column_order_df_e_select_expr(settings, tf_adj_cols=False):
             if tf_adj_cols:
                 if col["term_frequency_adjustments"]:
                     select_cols[col_name+"_adj"] =  col_name+"_adj"
+
+
 
     if settings["link_type"] == 'link_and_dedupe':
         select_cols = _add_left_right(select_cols, "_source_table")

--- a/splink/files/settings_jsonschema.json
+++ b/splink/files/settings_jsonschema.json
@@ -175,11 +175,11 @@
           "case_expression": {
             "$id": "#/properties/comparison_columns/items/properties/case_expression",
             "type": "string",
-            "title": "A SELECT CASE expression that compares the values of the input column and returns integer values corresponding to num_levels. ",
-            "description": "This is an override which allows the user to cusomise how similarity is computed for this column.  If given, this overrides the default mechanism of comparing columns and ignores data_type",
+            "title": "A SELECT CASE expression that compares the values of the input column and returns integer values corresponding to num_levels. Nulls should be explicitly dealt with in the case expression, and should be assigned a value of -1, see examples.",
+            "description": "This is an override which allows the user to customise how similarity is computed.  If given, this overrides the default mechanism of comparing columns and ignores data_type",
             "examples": [
-              "CASE WHEN first_name_l = first_name_r THEN 1 ELSE 0 END",
-              "CASE \n WHEN jaro_winkler_sim(first_name_l, first_name_r) < 0.94 THEN 2 \n WHEN jaro_winkler_sim(first_name_l, first_name_r) < 0.8 THEN 1 \n  ELSE 0 END"
+              "CASE \nWHEN first_name_l is null or first_name_r is null then -1 \nWHENfirst_name_l = first_name_r THEN 1 ELSE 0 END",
+              "CASE \nWHEN first_name_l is null or first_name_r is null then -1 \nWHEN jaro_winkler_sim(first_name_l, first_name_r) < 0.94 THEN 2 \n WHEN jaro_winkler_sim(first_name_l, first_name_r) < 0.8 THEN 1 \n  ELSE 0 END"
             ],
             "allOf": [
               {

--- a/splink/files/settings_jsonschema.json
+++ b/splink/files/settings_jsonschema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "title": "Splink settings",
   "required": ["comparison_columns", "link_type"],
+  "additionalProperties": false,
   "properties": {
     "link_type": {
       "$id": "#/properties/link_type",
@@ -54,12 +55,13 @@
       "$id": "#/properties/max_iterations",
       "type": "number",
       "title": "The maximum number of iterations to run even if convergence has not been reached",
-      "default": 10,
+      "description": "Set this value to zero if you do not want to use the EM algorithm and just want to score matches from m and u probabilities",
+      "default": 25,
       "examples": [
         20,
         150
       ],
-      "maximum": 200,
+      "maximum": 500,
       "minimum": 0
     },
     "unique_id_column_name": {
@@ -99,13 +101,14 @@
       "title": "A list of columns to use for probabalistic matching",
       "description": "Comparisons between the values in these columns will be used to determine match scores",
       "minItems": 1,
+
       "items": {
         "$id": "#/properties/comparison_columns/items",
         "type": "object",
-        "title": "A column that is used for probabalistic matching",
-        "required": [
-          "col_name"
-        ],
+        "title": "A comparison of input column(s) that is used for probabalistic matching",
+        "oneOf": [{"required": ["col_name"]},
+                {"required": ["custom_name", "custom_columns_used", "case_expression", "num_levels"]}
+            ],
         "additionalProperties": false,
         "properties": {
           "col_name": {
@@ -145,6 +148,29 @@
               "string",
               "numeric"
             ]
+          },
+          "custom_name": {
+            "$id": "#/properties/comparison_columns/items/properties/custom_name",
+            "type": "string",
+            "title": "Custom name to identify this comparison in charts and calculations",
+            "description": "If supplying a custom case expression that is not specific to a single input column, you must provide ",
+            "default": "",
+            "examples": [
+              "name_inversion_comparison",
+              "whole_row_concat_cosine_similarity"
+            ]
+          },
+          "custom_columns_used": {
+            "$id": "#/properties/comparison_columns/items/properties/custom_columns_used",
+            "type": "array",
+            "title": "A list of the columns required by the custom case expression used for this custom column",
+            "description": "When using a custom comparison, this is needed so Sparklink knows what columns to retain",
+            "default": [],
+            "examples": [
+              ["first_name"],
+              ["first_nsme","surname"]
+            ],
+            "minItems": 1
           },
           "case_expression": {
             "$id": "#/properties/comparison_columns/items/properties/case_expression",
@@ -211,12 +237,6 @@
             "$id": "#/properties/comparison_columns/items/properties/gamma_index",
             "type": "integer",
             "description": "Gamma values in the comparison vector will be put in columns called gamma_0, gamma_1 etc.  This is the gamma index corresponding to this column"
-          },
-          "col_is_in_input_df": {
-            "$id": "#/properties/comparison_columns/items/properties/is_col_in_input_df",
-            "type": "boolean",
-            "description": "Usually, an entry in comparison columns corresponds one to one with the columns in the input dataframe.  However, if the user specifies a custom case_expression, this could refer to one or more columns in combination.  In this case, col_name will not be in the input dataframe, and is_col_in_input_df should be set to false. This will usually happen automatically",
-            "default": true
           }
         }
       }

--- a/splink/gammas.py
+++ b/splink/gammas.py
@@ -39,12 +39,20 @@ def _get_select_expression_gammas(settings: dict):
     cols_to_retain = _add_left_right(cols_to_retain, settings["unique_id_column_name"])
 
     for col in settings["comparison_columns"]:
-        col_name = col["col_name"]
-        if settings["retain_matching_columns"]:
-            cols_to_retain = _add_left_right(cols_to_retain, col_name)
-        if col["term_frequency_adjustments"]:
-            cols_to_retain = _add_left_right(cols_to_retain, col_name)
-        cols_to_retain["gamma_" + col_name] = col["case_expression"]
+        if "col_name" in col:
+            col_name = col["col_name"]
+            if settings["retain_matching_columns"]:
+                cols_to_retain = _add_left_right(cols_to_retain, col_name)
+            if col["term_frequency_adjustments"]:
+                cols_to_retain = _add_left_right(cols_to_retain, col_name)
+            cols_to_retain["gamma_" + col_name] = col["case_expression"]
+        if "custom_name" in col:
+            custon_name = col["custom_name"]
+            if settings["retain_matching_columns"]:
+                for c2 in col["custom_columns_used"]:
+                    cols_to_retain = _add_left_right(cols_to_retain, c2)
+            cols_to_retain["gamma_" + custon_name] = col["case_expression"]
+
 
     if settings["link_type"] == 'link_and_dedupe':
         cols_to_retain = _add_left_right(cols_to_retain, "_source_table")

--- a/splink/intuition.py
+++ b/splink/intuition.py
@@ -48,8 +48,12 @@ def intuition_report(row_dict, params):
 
         d["col_name"] = col_params["column_name"]
         col_name = d["col_name"]
-        d["value_l"] = row_dict[col_name + "_l"]
-        d["value_r"] = row_dict[col_name + "_r"]
+        try:
+            d["value_l"] = row_dict[col_name + "_l"]
+            d["value_r"] = row_dict[col_name + "_r"]
+        except KeyError:
+            d["value_l"] = "Custom comparison, value cannot be shown"
+            d["value_r"] = "Custom comparison, value cannot be shown"
         d["num_levels"] = col_params["num_levels"]
 
         d["gamma_col_name"] = gk

--- a/splink/intuition.py
+++ b/splink/intuition.py
@@ -48,12 +48,12 @@ def intuition_report(row_dict, params):
 
         d["col_name"] = col_params["column_name"]
         col_name = d["col_name"]
-        try:
+        if pi[gk]["custom_comparison"] == False:
             d["value_l"] = row_dict[col_name + "_l"]
             d["value_r"] = row_dict[col_name + "_r"]
-        except KeyError:
-            d["value_l"] = "Custom comparison, value cannot be shown"
-            d["value_r"] = "Custom comparison, value cannot be shown"
+        else:
+            d["value_l"] = ", ".join([row_dict[c + "_l"] for c in pi[gk]["custom_columns_used"] ])
+            d["value_r"] = ", ".join([row_dict[c + "_r"] for c in pi[gk]["custom_columns_used"] ])
         d["num_levels"] = col_params["num_levels"]
 
         d["gamma_col_name"] = gk

--- a/splink/iterate.py
+++ b/splink/iterate.py
@@ -21,7 +21,6 @@ def iterate(
     params: Params,
     settings: dict,
     spark: SparkSession,
-    num_iterations:int=10,
     compute_ll:bool=False,
 ):
     """Repeatedly run expectation and maximisation step until convergence or max itations is reached.

--- a/splink/iterate.py
+++ b/splink/iterate.py
@@ -40,6 +40,8 @@ def iterate(
     """
 
     df_gammas.persist()
+
+    num_iterations = settings["max_iterations"]
     for i in range(num_iterations):
         df_e = run_expectation_step(
             df_gammas, params, settings, spark, compute_ll=compute_ll

--- a/splink/params.py
+++ b/splink/params.py
@@ -78,7 +78,11 @@ class Params:
         """
 
         for col_dict in self.settings["comparison_columns"]:
-            col_name = col_dict["col_name"]
+            if "col_name" in col_dict:
+                col_name = col_dict["col_name"]
+            else:
+                col_name = col_dict["custom_name"]
+
             i = col_dict["gamma_index"]
 
             self.params["π"][f"gamma_{col_name}"] = {}

--- a/splink/params.py
+++ b/splink/params.py
@@ -80,7 +80,7 @@ class Params:
         for col_dict in self.settings["comparison_columns"]:
             if "col_name" in col_dict:
                 col_name = col_dict["col_name"]
-            else:
+            elif "custom_name" in col_dict:
                 col_name = col_dict["custom_name"]
 
             i = col_dict["gamma_index"]
@@ -90,6 +90,12 @@ class Params:
 
             self.params["π"][f"gamma_{col_name}"]["desc"] = f"Comparison of {col_name}"
             self.params["π"][f"gamma_{col_name}"]["column_name"] = f"{col_name}"
+
+            if "custom_name" in col_dict:
+                self.params["π"][f"gamma_{col_name}"]["custom_comparison"] = True
+                self.params["π"][f"gamma_{col_name}"]["custom_columns_used"] = col_dict["custom_columns_used"]
+            else:
+                self.params["π"][f"gamma_{col_name}"]["custom_comparison"] = False
 
             num_levels = col_dict["num_levels"]
             self.params["π"][f"gamma_{col_name}"]["num_levels"] = num_levels

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -11,7 +11,6 @@ except ImportError:
 
 
 from .case_statements import (
-    _add_null_treatment_to_case_statement,
     _check_jaro_registered,
     _check_no_obvious_problem_with_case_statement,
     _add_as_gamma_to_case_statement,
@@ -137,8 +136,7 @@ def _complete_case_expression(col_settings, spark):
             col_settings["case_expression"]
         )
         old_case_stmt = col_settings["case_expression"]
-        new_case_stmt = _add_null_treatment_to_case_statement(old_case_stmt)
-        new_case_stmt = _add_as_gamma_to_case_statement(new_case_stmt, col_name_for_case_fn)
+        new_case_stmt = _add_as_gamma_to_case_statement(old_case_stmt, col_name_for_case_fn)
         col_settings["case_expression"] = new_case_stmt
 
 

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -3,8 +3,10 @@ import warnings
 
 
 try:
+    from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.session import SparkSession
 except ImportError:
+    DataFrame = None
     SparkSession = None
 
 
@@ -113,6 +115,58 @@ def _get_probabilities(m_or_u, levels):
     return _normalise_prob_list(probabilities)
 
 
+def _complete_case_expression(col_settings, spark):
+
+    default_case_statements = _get_default_case_statements_functions(spark)
+    levels = col_settings["num_levels"]
+
+    if "custom_name" in col_settings:
+        col_name_for_case_fn = col_settings["custom_name"]
+    else:
+        col_name_for_case_fn = col_settings["col_name"]
+
+    if "case_expression" not in col_settings:
+        data_type = col_settings["data_type"]
+        col_name = col_settings["col_name"]
+        case_fn = _get_default_case_statement_fn(
+            default_case_statements, data_type, levels
+        )
+        col_settings["case_expression"] = case_fn(col_name_for_case_fn, col_name_for_case_fn)
+    else:
+        _check_no_obvious_problem_with_case_statement(
+            col_settings["case_expression"]
+        )
+        old_case_stmt = col_settings["case_expression"]
+        new_case_stmt = _add_null_treatment_to_case_statement(old_case_stmt)
+        new_case_stmt = _add_as_gamma_to_case_statement(new_case_stmt, col_name_for_case_fn)
+        col_settings["case_expression"] = new_case_stmt
+
+
+def _complete_probabilities(col_settings: dict, setting_name: str):
+    """
+
+    Args:
+        col_settings (dict): Column settings dictionary
+        setting_name (str): Either 'm_probabilities' or 'u_probabilities'
+
+    """
+
+    if setting_name not in col_settings:
+        levels = col_settings["num_levels"]
+        probs = _get_probabilities("m", levels)
+        col_settings[setting_name] = probs
+    else:
+        levels = col_settings["num_levels"]
+        probs = col_settings[setting_name]
+
+        if len(probs) != levels:
+            raise ValueError(
+                f"Number of {setting_name} provided is not equal to number of levels specified"
+            )
+
+    col_settings[setting_name] = _normalise_prob_list(col_settings[setting_name])
+
+
 def complete_settings_dict(settings_dict: dict, spark: SparkSession):
     """Auto-populate any missing settings from the settings dictionary using the 'sensible defaults' that
     are specified in the json schema (./splink/files/settings_jsonschema.json)
@@ -125,104 +179,51 @@ def complete_settings_dict(settings_dict: dict, spark: SparkSession):
         dict: A `splink` settings dictionary with all keys populated.
     """
     validate_settings(settings_dict)
-    default_case_statements = _get_default_case_statements_functions(spark)
 
-    # Complete non-column settings
+    # Complete non-column settings from their default values if not exist
     non_col_keys = [
-        "blocking_rules",
         "em_convergence",
         "unique_id_column_name",
         "additional_columns_to_retain",
         "retain_matching_columns",
         "retain_intermediate_calculation_columns",
-        "max_iterations"
+        "max_iterations",
+        "proportion_of_matches"
     ]
     for key in non_col_keys:
         if key not in settings_dict:
             settings_dict[key] = _get_default_value(key, is_column_setting=False)
 
-    if len(settings_dict["blocking_rules"])==0:
-        warnings.warn(
-            """
-            You have not specified any blocking rules, meaning all comparisons between the 
-            input dataset(s) will be generated and blocking will not be used. 
-            For large input datasets, this will generally be computationally intractable 
-            because it will generate comparisons equal to the number of rows squared.
-            """)        
-            
-    if "proportion_of_matches" not in settings_dict:
-        settings_dict["proportion_of_matches"] = _get_default_value(
-            "proportion_of_matches", is_column_setting=False
-        )
+    if "blocking_rules" in settings_dict:
+        if len(settings_dict["blocking_rules"])==0:
+            warnings.warn(
+                "You have not specified any blocking rules, meaning all comparisons between the "
+                "input dataset(s) will be generated and blocking will not be used."
+                "For large input datasets, this will generally be computationally intractable "
+                "because it will generate comparisons equal to the number of rows squared.")
 
     gamma_counter = 0
-    for gamma_counter, column_settings in enumerate(
-        settings_dict["comparison_columns"]
-    ):
+    c_cols = settings_dict["comparison_columns"]
+    for gamma_counter, col_settings in enumerate(c_cols):
 
-        column_settings["gamma_index"] = gamma_counter
-        col_name = column_settings["col_name"]
+        col_settings["gamma_index"] = gamma_counter
 
         # Populate non-existing keys from defaults
-        for key in [
+        keys_for_defaults = [
             "num_levels",
             "data_type",
             "term_frequency_adjustments",
-            "col_is_in_input_df",
-        ]:
-            if key not in column_settings:
+        ]
+
+        for key in keys_for_defaults:
+            if key not in col_settings:
                 default = _get_default_value(key, is_column_setting=True)
-                column_settings[key] = default
+                col_settings[key] = default
 
-        levels = column_settings["num_levels"]
-
-        if "case_expression" not in column_settings:
-            data_type = column_settings["data_type"]
-            col_name = column_settings["col_name"]
-            case_fn = _get_default_case_statement_fn(
-                default_case_statements, data_type, levels
-            )
-            column_settings["case_expression"] = case_fn(col_name, col_name)
-        else:
-            _check_no_obvious_problem_with_case_statement(
-                column_settings["case_expression"]
-            )
-            old_case_stmt = column_settings["case_expression"]
-            new_case_stmt = _add_null_treatment_to_case_statement(old_case_stmt)
-            new_case_stmt = _add_as_gamma_to_case_statement(new_case_stmt, col_name)
-            column_settings["case_expression"] = new_case_stmt
-
-        if "m_probabilities" not in column_settings:
-            levels = column_settings["num_levels"]
-            probs = _get_probabilities("m", levels)
-            column_settings["m_probabilities"] = probs
-        else:
-            levels = column_settings["num_levels"]
-            probs = column_settings["m_probabilities"]
-
-            if len(probs) != levels:
-                raise ValueError(
-                    "Number of m probabilities provided is not equal to number of levels specified"
-                )
-
-        if "u_probabilities" not in column_settings:
-            levels = column_settings["num_levels"]
-            probs = _get_probabilities("u", levels)
-            column_settings["u_probabilities"] = probs
-        else:
-            levels = column_settings["num_levels"]
-            probs = column_settings["u_probabilities"]
-            if len(probs) != levels:
-                raise ValueError(
-                    "Number of m probabilities provided is not equal to number of levels specified"
-                )
-
-        column_settings["m_probabilities"] = _normalise_prob_list(
-            column_settings["m_probabilities"]
-        )
-        column_settings["u_probabilities"] = _normalise_prob_list(
-            column_settings["u_probabilities"]
-        )
+        # Doesn't need assignment because we're modify the col_settings dictionary
+        _complete_case_expression(col_settings, spark)
+        _complete_probabilities(col_settings, "m_probabilities")
+        _complete_probabilities(col_settings, "u_probabilities")
 
         gamma_counter += 1
 

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -150,10 +150,14 @@ def _complete_probabilities(col_settings: dict, setting_name: str):
         setting_name (str): Either 'm_probabilities' or 'u_probabilities'
 
     """
+    if setting_name == 'm_probabilities':
+        letter = "m"
+    elif setting_name == 'u_probabilities':
+        letter = "u"
 
     if setting_name not in col_settings:
         levels = col_settings["num_levels"]
-        probs = _get_probabilities("m", levels)
+        probs = _get_probabilities(letter, levels)
         col_settings[setting_name] = probs
     else:
         levels = col_settings["num_levels"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def gamma_settings_1():
                 "num_levels": 3,
                 "case_expression": """
             case
+            when surname_l is null or surname_r is null then -1
             when surname_l = surname_r then 2
             when substr(surname_l,1, 3) =  substr(surname_r, 1, 3) then 1
             else 0
@@ -258,6 +259,7 @@ def gamma_settings_2():
                 "num_levels": 3,
                 "case_expression": """
         case
+        when surname_l is null or surname_r is null then -1
         when surname_l = surname_r then 2
         when substr(surname_l,1, 3) =  substr(surname_r, 1, 3) then 1
         else 0

--- a/tests/test_case_statements.py
+++ b/tests/test_case_statements.py
@@ -5,8 +5,6 @@ from pandas.util.testing import assert_frame_equal
 import pytest
 
 from splink.case_statements import *
-from splink.case_statements import _add_null_treatment_to_case_statement
-
 
 def test_case(sqlite_con_3):
 
@@ -28,8 +26,6 @@ def test_case(sqlite_con_3):
     else 0 end as gamma_0 from str_comp
     """
 
-    sql = _add_null_treatment_to_case_statement(sql)
-
     cur.execute(sql)
     result = cur.fetchall()
     result = [dict(r) for r in result]
@@ -37,8 +33,7 @@ def test_case(sqlite_con_3):
     assert result[0]['gamma_0'] == 2
     assert result[1]['gamma_0'] == 0
     assert result[2]['gamma_0'] == 0
-    assert result[3]['gamma_0'] == -1
-    assert result[4]['gamma_0'] == -1
+
 
     case_statement = sql_gen_case_stmt_numeric_abs_3("float_col", gamma_col_name="0", abs_amount=1)
     sql = f"""select {case_statement} from float_comp"""

--- a/tests/test_gammas.py
+++ b/tests/test_gammas.py
@@ -52,6 +52,7 @@ def test_add_gammas(db):
                 "num_levels": 3,
                 "case_expression": """
                                     case
+                                    when sname_l is null or sname_r is null then -1
                                     when sname_l = sname_r then 2
                                     when substr(sname_l,1, 3) =  substr(sname_r, 1, 3) then 1
                                     else 0

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -175,7 +175,8 @@ def test_iterate(spark, sqlite_con_1, params_1, gamma_settings_1):
 
     df_gammas = add_gammas(df_comparison, gamma_settings_1, spark)
 
-    df_e = iterate(df_gammas, params_1, gamma_settings_1, spark, num_iterations=1)
+    gamma_settings_1["max_iterations"] = 1
+    df_e = iterate(df_gammas, params_1, gamma_settings_1, spark)
 
     assert params_1.params["λ"] == pytest.approx(0.540922141)
 
@@ -207,8 +208,8 @@ def test_iterate(spark, sqlite_con_1, params_1, gamma_settings_1):
         assert i[0] == pytest.approx(i[1], abs=0.0001)
 
     # Does it still work with another iteration?
-
-    df_e = iterate(df_gammas, params_1, gamma_settings_1, spark, num_iterations=1)
+    gamma_settings_1["max_iterations"] = 1
+    df_e = iterate(df_gammas, params_1, gamma_settings_1, spark)
     assert params_1.params["λ"] == pytest.approx(0.534993426, abs=0.0001)
 
     assert params_1.params["π"]["gamma_mob"]["prob_dist_match"]["level_0"][
@@ -396,13 +397,12 @@ def test_iteration_known_data_generating_process(
 
     gamma_settings_4["retain_matching_columns"] = False
     gamma_settings_4["em_convergence"] = 0.001
-
+    gamma_settings_4["max_iterations"] = 40
     df_e = iterate(
         df_gammas,
         params_4,
         gamma_settings_4,
         spark,
-        num_iterations=40,
         compute_ll=False,
     )
 
@@ -485,8 +485,7 @@ def test_link_option_link_dedupe(spark, link_dedupe_data_repeat_ids):
     settings = {
         "link_type": "link_and_dedupe",
         "comparison_columns": [{"col_name": "first_name"},
-                            {"col_name": "surname"}],
-        "cartesian_product": True
+                            {"col_name": "surname"}]
     }
     settings = complete_settings_dict(settings, spark=None)
     dfpd_l = pd.read_sql("select * from df_l", link_dedupe_data_repeat_ids)


### PR DESCRIPTION
Closes #65 

A relatively advanced use case that is fairly common is for values in the comparison vectors to be derived from multiple columns.

For example, to deal with the possibility of name inversions, the user might want something like:

```
CASE WHEN
first_name_l = first_name_r AND surname_l = surname_r THEN 2
first_name_l = surname_r AND surname_l = first_name_r THEN 1
ELSE 0 
END
```

It's also a bit tricky to think about how this should be dealt with in `comparison_columns` because up until now, we've assumed that each value in the comparison vector corresponds to a single column, and each column is identified by the `col_name` key in the `comparison_columns` part of the settings dictionary.

What I've done is allowed two possible specs for an entry in `comparison_columns`.  

Either `col_name` must be completed as before:

```
{
"col_name": "first_name"
}
```

or the user must explicitly specify a custom column:

```
  {
        "custom_name": "custom_name",
        "custom_columns_used": ["first_name", "surname],
        "case_expression": """
CASE WHEN
first_name_l = first_name_r AND surname_l = surname_r THEN 2
first_name_l = surname_r AND surname_l = first_name_r THEN 1
ELSE 0 
END
""",
        "num_levels": 2
        }
```

The later syntax isn't very intuitive, but this is advanced functionality and it would be expected that the user would modify example settings rather than write this from scratch