### PR TITLE
Persist state during iterations in case job fails

### DIFF
--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -27,7 +27,7 @@ except ImportError:
     SparkSession = None
     spark_exists = False
 
-
+from typing import Callable
 class Splink:
     @check_types
     def __init__(
@@ -37,6 +37,7 @@ class Splink:
         df_l: DataFrame = None,
         df_r: DataFrame = None,
         df: DataFrame = None,
+        save_state_fn: Callable = None
     ):
 
         self.spark = spark
@@ -51,6 +52,7 @@ class Splink:
         self.df_r = df_r
         self.df_l = df_l
         self.df = df
+        self.save_state_fn = save_state_fn
         self._check_args()
 
     def _check_args(self):
@@ -98,7 +100,7 @@ class Splink:
 
     def get_scored_comparisons(self, num_iterations=None):
 
-        if (num_iterations is None):
+        if num_iterations is None:
             num_iterations=self.settings["max_iterations"]
 
         df_comparison = self._get_df_comparison()
@@ -114,6 +116,7 @@ class Splink:
             self.spark,
             num_iterations=num_iterations,
             compute_ll=False,
+            save_state_fn=self.save_state_fn
         )
         df_gammas.unpersist()
         return df_e

--- a/splink/params.py
+++ b/splink/params.py
@@ -394,7 +394,13 @@ class Params:
         else:
             return adjustment_weight_chart_def
 
-    def all_charts_write_html_file(self, filename="splink_charts.html"):
+    def all_charts_write_html_file(self, filename="splink_charts.html", overwrite=False):
+
+        if os.path.isfile(filename):
+            if not overwrite:
+                raise ValueError(
+                    f"The path {filename} already exists. Please provide a different path."
+                )
 
         if altair_installed:
             c1 = self.probability_distribution_chart().to_json(indent=None)


### PR DESCRIPTION
Closes #87 

For big jobs, it is useful to be able to persist `splink`'s state after each iteration.  

This means that if the job successfully completes some iterations, but fails thereafter for whatever reason, the user can 'start where they left off' by loading in the persisted state, rather than having to start again from scratch.

In terms of implementation, we need to give the user a lot of flexibility because we do not know the environment in which they are executing their code.  Is it AWS Glue, local spark, a custom cluster, another cloud provider?  Since we don't know this I propose including a hook that lets them run an arbitrary function of their choosing after each iteration.

The idea is that it works like this

Custom user function (can be anything, takes the arguments `params, settings`).  
```
def persist_params_settings(params, settings):
    it_num = params.iteration
    p_path = f"saved_params_iteration_{it_num}.json"
    params.save_params_to_json_file(p_path, overwrite=True)
    
    c_path = f"saved_charts_iteration_{it_num}.html"
    params.all_charts_write_html_file(c_path, overwrite=True)
```

Then they pass it to `splink` like:

linker = Splink(settings, spark, df=df, save_state_fn=persist_params_settings)

If `save_state_fn` is None, then nothing happens.