### PR TITLE
Update API to allow user to break lineage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink"
-version = "0.1.7"
+version = "0.2.0"
 description = "[Beta]: Implementation in Apache Spark of the EM algorithm to estimate parameters of Fellegi-Sunter's canonical model of record linkage."
 authors = ["Robin Linacre <robinlinacre@hotmail.com>", "Sam Lindsay", "Theodore Manassis"]
 license = "MIT"

--- a/splink/break_lineage.py
+++ b/splink/break_lineage.py
@@ -1,0 +1,34 @@
+# https://stackoverflow.com/questions/52556798/spark-iterative-recursive-algorithms-breaking-spark-lineage
+# From https://github.com/high-performance-spark/high-performance-spark-examples/blob/f02142bebf528437702ec8fa689c9c0263e96fe7/high_performance_pyspark/SQLLineage.py#L20
+from pyspark.sql.dataframe import DataFrame
+def cutLineage(df):
+    """
+    Cut the lineage of a DataFrame - used for iterative algorithms
+    
+    .. Note: This uses internal members and may break between versions
+    >>> df = rdd.toDF()
+    >>> cutDf = cutLineage(df)
+    >>> cutDf.count()
+    3
+    """
+    jRDD = df._jdf.toJavaRDD()
+    jSchema = df._jdf.schema()
+    jRDD.cache()
+    sqlCtx = df.sql_ctx
+    try:
+        javaSqlCtx = sqlCtx._jsqlContext
+    except:
+        javaSqlCtx = sqlCtx._ssql_ctx
+    newJavaDF = javaSqlCtx.createDataFrame(jRDD, jSchema)
+    newDF = DataFrame(newJavaDF, sqlCtx)
+    return newDF
+
+def default_break_lineage_blocked_comparisons(df_gammas, spark):
+    df_gammas = cutLineage(df_gammas)
+    df_gammas.persist()
+    return df_gammas
+
+def default_break_lineage_scored_comparisons(df_e, spark):
+    df_e = cutLineage(df_e)
+    df_e.persist()
+    return df_e


### PR DESCRIPTION
This closes #81 

See also this for a bit of background to this PR and an example/tutorial of how to use:
https://github.com/moj-analytical-services/splink_demos/blob/master/large_jobs_and_breaking_lineage.ipynb

I'm not totally happy with this in that it's a bit complex to use.  But on the other hand it's now much simpler than it used to be, and the user no longer has to remember to run the term frequency adjustments.  (e.g. Rachel didn't do this, because she very reasonably thought it would happen automatically - it does now)