### PR TITLE
Add new adjustment history charts

### DIFF
--- a/splink/chart_definitions.py
+++ b/splink/chart_definitions.py
@@ -28,7 +28,7 @@ pi_iteration_chart_def = {
                     "field": "probability",
                 },
             },
-            "height": 100,
+            "height": 150,
             "resolve": {"scale": {"y": "independent"}},
             "title": "Non Match",
             "transform": [{"filter": "(datum.match === 0)"}],
@@ -56,7 +56,7 @@ pi_iteration_chart_def = {
                     "field": "probability",
                 },
             },
-            "height": 100,
+            "height": 150,
             "resolve": {"scale": {"y": "independent"}},
             "title": "Match",
             "transform": [{"filter": "(datum.match === 1)"}],
@@ -126,7 +126,11 @@ probability_distribution_chart = {
         {
             "mark": "bar",
             "encoding": {
-                "color": {"type": "nominal", "field": "match"},
+                "color": {
+                    "type": "nominal",
+                    "field": "match",
+                    "scale": {"domain": [0, 1], "range": ["red", "green"]}
+                },
                 "row": {
                     "type": "nominal",
                     "field": "column",
@@ -152,7 +156,11 @@ probability_distribution_chart = {
         {
             "mark": "bar",
             "encoding": {
-                "color": {"type": "nominal", "field": "match"},
+                "color": {
+                    "type": "nominal",
+                    "field": "match",
+                    "scale": {"domain": [0, 1], "range": ["red", "green"]}
+                },
                 "row": {
                     "type": "nominal",
                     "field": "column",
@@ -181,6 +189,39 @@ probability_distribution_chart = {
     "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
 }
 
+gamma_distribution_chart_def = {
+    "config": {
+        "view": {"width": 400, "height": 300},  # pragma: no cover
+        "mark": {"tooltip": None},
+        "title": {"anchor": "middle"},
+    },
+            "mark": "bar",
+            "encoding": {
+                "row": {
+                    "type": "nominal",
+                    "field": "column",
+                    "sort": {"field": "column"},
+                },
+                "tooltip": [
+                    {"type": "nominal", "field": "column"},
+                    {"type": "quantitative", "field": "level_proportion", "format": ".4f"},
+                    {"type": "ordinal", "field": "level"},
+                ],
+                "x": {"type": "quantitative", "field": "level_proportion"},
+                "y": {
+                    "type": "nominal",
+                    "axis": {"title": "𝛾 value"},
+                    "field": "level",
+                },
+            },
+            "resolve": {"scale": {"y": "independent"}},
+            "width": 150,
+            "height": 50,
+    "data": {"values": None},
+    "title": "Distribution of (non-null) 𝛾 values",
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+}
+
 adjustment_weight_chart_def = {
     "config": {
         "view": {"width": 400, "height": 300},
@@ -198,9 +239,9 @@ adjustment_weight_chart_def = {
                 "range": ["red", "orange", "green", "orange", "red"],
             },
         },
-        "row": {"type": "nominal", "field": "col_name", "sort": {"field": "gamma"}},
+        "row": {"type": "nominal", "field": "column", "sort": {"field": "column"}},
         "tooltip": [
-            {"type": "nominal", "field": "col_name"},
+            {"type": "nominal", "field": "column"},
             {"type": "quantitative", "field": "normalised_adjustment"},
         ],
         "x": {
@@ -239,7 +280,7 @@ adjustment_factor_chart_def = {
             "field": "normalised",
             "scale": {"domain": [-0.5, 0.5]},
         },
-        "y": {"type": "nominal", "field": "col_name", "sort": {"field": "gamma"}},
+        "y": {"type": "nominal", "field": "column", "sort": {"field": "gamma"}},
     },
     "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
 }
@@ -255,13 +296,13 @@ multi_chart_template = """
 </head>
 <body>
 
-<div id="vis1"></div><div id="vis2"></div>
+<div id="vis1"></div><div id="vis2"></div><div id="vis3"></div>
 <br/>
-<div id="vis3"></div><div id="vis5"></div>
-<br/>
-<div id="vis4"></div>
+<div id="vis4"></div><div id="vis5"></div>
 <br/>
 <div id="vis6"></div>
+<br/>
+<div id="vis7"></div>
 
 
 
@@ -272,6 +313,7 @@ multi_chart_template = """
   vegaEmbed('#vis4', {spec4}).catch(console.error);
   vegaEmbed('#vis5', {spec5}).catch(console.error);
   vegaEmbed('#vis6', {spec6}).catch(console.error);
+  vegaEmbed('#vis7', {spec7}).catch(console.error);
 </script>
 </body>
 </html>
@@ -289,7 +331,7 @@ adjustment_history_chart_def = {
                      'scheme': 'redyellowgreen'}
              },
              'tooltip': [
-                 {'type': 'nominal', 'field': 'col_name'},
+                 {'type': 'nominal', 'field': 'column'},
                  {'type': 'ordinal', 'field': 'level'},
                  {'type': 'quantitative', 'field': 'm'},
                  {'type': 'quantitative', 'field': 'u'},
@@ -309,13 +351,15 @@ adjustment_history_chart_def = {
             {"filter": "(datum.final === true)"}
         ],
         'width': 100,
+        'height': 150,
         'selection': {
-            'selector190': {'type': 'single', 'on': 'mouseover', 'fields': ['level', 'col_name']}
+            'selector190': {'type': 'single', 'on': 'mouseover', 'fields': ['level', 'column']}
         }
     },
         {
             'layer': [{
                 'mark': 'line',
+                'height': 150,
                 'encoding': {
                     'color': {
                         'type': 'nominal',
@@ -338,7 +382,7 @@ adjustment_history_chart_def = {
                         'value': 5
                     },
                     'tooltip': [
-                        {'type': 'nominal', 'field': 'col_name'},
+                        {'type': 'nominal', 'field': 'column'},
                         {'type': 'quantitative', 'field': 'iteration'},
                         {'type': 'ordinal', 'field': 'level'},
                         {'type': 'quantitative', 'field': 'm'},

--- a/splink/chart_definitions.py
+++ b/splink/chart_definitions.py
@@ -369,7 +369,7 @@ adjustment_history_chart_def = {
                     },
                     'opacity': {
                         'condition': {
-                            'value': 0.5,
+                            'value': 0.8,
                             'selection': {'not': 'selector190'}
                         },
                         'value': 1 

--- a/splink/chart_definitions.py
+++ b/splink/chart_definitions.py
@@ -260,7 +260,8 @@ multi_chart_template = """
 <div id="vis3"></div><div id="vis5"></div>
 <br/>
 <div id="vis4"></div>
-
+<br/>
+<div id="vis6"></div>
 
 
 
@@ -270,8 +271,136 @@ multi_chart_template = """
   vegaEmbed('#vis3', {spec3}).catch(console.error);
   vegaEmbed('#vis4', {spec4}).catch(console.error);
   vegaEmbed('#vis5', {spec5}).catch(console.error);
+  vegaEmbed('#vis6', {spec6}).catch(console.error);
 </script>
 </body>
 </html>
 """  # pragma: no cover
 
+adjustment_history_chart_def = {
+    'hconcat': [{
+        'mark': 'bar',
+         'encoding': {
+             'color': {
+                 'type': 'nominal',
+                 'field': 'level',
+                 'legend': {},
+                 'scale': {
+                     'scheme': 'redyellowgreen'}
+             },
+             'tooltip': [
+                 {'type': 'nominal', 'field': 'col_name'},
+                 {'type': 'nominal', 'field': 'level'},
+                 {'type': 'quantitative', 'field': 'm'},
+                 {'type': 'quantitative', 'field': 'u'},
+                 {'type': 'quantitative', 'field': 'normalised_adjustment'}],
+             'x': {
+                 'type': 'ordinal', 
+                 'field': 'level'
+             },
+             'y': {
+                 'type': 'quantitative',
+                 'axis': {'title': 'Influence on match probability'},
+                 'field': 'normalised_adjustment',
+                 'scale': {'domain': [-0.5, 0.5]}
+             }
+         },
+        'width': 100,
+        'selection': {
+            'selector190': {'type': 'single', 'on': 'mouseover', 'fields': ['level', 'col_name']}
+        },
+        'transform': [
+            {'calculate': 'datum.iteration + 0.8/datum.num_levels*(parseInt(substring(datum.level, 6))-(datum.num_levels-1)/2)', 
+             'as': 'iteration_jitter'},
+            {'filter': 'datum.final === true'}
+        ]
+    },
+        {
+            'layer': [{
+                'mark': 'bar',
+                'encoding': {
+                    'color': {
+                        'type': 'nominal',
+                        'field': 'level',
+                        'legend': {},
+                        'scale': {'scheme': 'redyellowgreen'}
+                    },
+                    'opacity': {
+                        'condition': {
+                            'value': 0.5,
+                            'selection': {'not': 'selector190'}
+                        },
+                        'value': 1 
+                    },
+                    'size': {
+                        'condition': {
+                            'value': 4, 
+                            'selection': {'not': 'selector190'}
+                        },
+                        'value': 6
+                    },
+                    'tooltip': [
+                        {'type': 'nominal', 'field': 'col_name'},
+                        {'type': 'quantitative', 'field': 'iteration'},
+                        {'type': 'nominal', 'field': 'level'},
+                        {'type': 'quantitative', 'field': 'm'},
+                        {'type': 'quantitative', 'field': 'u'},
+                        {'type': 'quantitative', 'field': 'normalised_adjustment'}
+                    ],
+                    'x': {
+                        'type': 'quantitative',     
+                        'axis': {'title': 'Iteration'},
+                        'field': 'iteration_jitter'
+                    },
+                    'y': {
+                        'type': 'quantitative',
+                        'axis': {'title': 'Influence on match probability'},
+                        'field': 'normalised_adjustment',
+                        'scale': {'domain': [-0.5, 0.5]}
+                    }
+                },
+                'transform': [
+                    {'calculate': 'datum.iteration + 0.8/datum.num_levels*(parseInt(substring(datum.level, 6))-(datum.num_levels-1)/2)',
+                     'as': 'iteration_jitter'}
+                ]
+            },
+                {
+                    'mark': 'line',
+                    'encoding': {
+                        'color': {'value': '#000000'},
+                        'detail': {'type': 'nominal', 'field': 'level'},
+                        'opacity': {
+                            'condition': {
+                                'value': 0,'selection': {'not': 'selector190'}
+                            },
+                            'value': 1
+                        },
+                        'tooltip': [
+                            {'type': 'nominal', 'field': 'col_name'},
+                            {'type': 'nominal', 'field': 'level'},
+                            {'type': 'quantitative', 'field': 'm'},
+                            {'type': 'quantitative', 'field': 'u'},
+                            {'type': 'quantitative', 'field': 'normalised_adjustment'}  
+                        ],
+                        'x': {
+                            'type': 'quantitative', 
+                            'field': 'iteration_jitter'  
+                        },
+                        'y': {
+                            'type': 'quantitative',
+                            'axis': {'title': 'Influence on match probability'},
+                            'field': 'normalised_adjustment', 
+                            'scale': {'domain': [-0.5, 0.5]}
+                        }
+                    },
+                    'transform': [
+                        {'calculate': 'datum.iteration + 0.8/datum.num_levels*(parseInt(substring(datum.level, 6))-(datum.num_levels-1)/2)',
+                         'as': 'iteration_jitter'}
+                    ]
+                }
+            ]
+        }
+    ],
+    'title': {'text': None, 'orient': 'top', 'dx': 200},
+    'data': {'values': None}
+}

--- a/splink/chart_definitions.py
+++ b/splink/chart_definitions.py
@@ -324,11 +324,10 @@ adjustment_history_chart_def = {
         'mark': 'bar',
          'encoding': {
              'color': {
-                 'type': 'ordinal',
+                 'type': 'quantitative',
                  'field': 'level',
                  'legend': {},
-                 'scale': {
-                     'scheme': 'redyellowgreen'}
+                 'scale': {'range': ['red', 'orange', 'green']}
              },
              'tooltip': [
                  {'type': 'nominal', 'field': 'column'},
@@ -362,10 +361,10 @@ adjustment_history_chart_def = {
                 'height': 150,
                 'encoding': {
                     'color': {
-                        'type': 'nominal',
+                        'type': 'quantitative',
                         'field': 'level',
-                        'legend': {},
-                        'scale': {'scheme': 'redyellowgreen'}
+                        'legend': {'type': 'symbol', 'tickCount':2},
+                        'scale': {'range': ['red', 'orange', 'green']}
                     },
                     'opacity': {
                         'condition': {

--- a/splink/chart_definitions.py
+++ b/splink/chart_definitions.py
@@ -282,7 +282,7 @@ adjustment_history_chart_def = {
         'mark': 'bar',
          'encoding': {
              'color': {
-                 'type': 'nominal',
+                 'type': 'ordinal',
                  'field': 'level',
                  'legend': {},
                  'scale': {
@@ -290,7 +290,7 @@ adjustment_history_chart_def = {
              },
              'tooltip': [
                  {'type': 'nominal', 'field': 'col_name'},
-                 {'type': 'nominal', 'field': 'level'},
+                 {'type': 'ordinal', 'field': 'level'},
                  {'type': 'quantitative', 'field': 'm'},
                  {'type': 'quantitative', 'field': 'u'},
                  {'type': 'quantitative', 'field': 'normalised_adjustment'}],
@@ -305,19 +305,17 @@ adjustment_history_chart_def = {
                  'scale': {'domain': [-0.5, 0.5]}
              }
          },
+        "transform": [
+            {"filter": "(datum.final === true)"}
+        ],
         'width': 100,
         'selection': {
             'selector190': {'type': 'single', 'on': 'mouseover', 'fields': ['level', 'col_name']}
-        },
-        'transform': [
-            {'calculate': 'datum.iteration + 0.8/datum.num_levels*(parseInt(substring(datum.level, 6))-(datum.num_levels-1)/2)', 
-             'as': 'iteration_jitter'},
-            {'filter': 'datum.final === true'}
-        ]
+        }
     },
         {
             'layer': [{
-                'mark': 'bar',
+                'mark': 'line',
                 'encoding': {
                     'color': {
                         'type': 'nominal',
@@ -334,23 +332,23 @@ adjustment_history_chart_def = {
                     },
                     'size': {
                         'condition': {
-                            'value': 4, 
+                            'value': 3, 
                             'selection': {'not': 'selector190'}
                         },
-                        'value': 6
+                        'value': 5
                     },
                     'tooltip': [
                         {'type': 'nominal', 'field': 'col_name'},
                         {'type': 'quantitative', 'field': 'iteration'},
-                        {'type': 'nominal', 'field': 'level'},
+                        {'type': 'ordinal', 'field': 'level'},
                         {'type': 'quantitative', 'field': 'm'},
                         {'type': 'quantitative', 'field': 'u'},
                         {'type': 'quantitative', 'field': 'normalised_adjustment'}
                     ],
                     'x': {
-                        'type': 'quantitative',     
+                        'type': 'ordinal',     
                         'axis': {'title': 'Iteration'},
-                        'field': 'iteration_jitter'
+                        'field': 'iteration'
                     },
                     'y': {
                         'type': 'quantitative',
@@ -358,46 +356,8 @@ adjustment_history_chart_def = {
                         'field': 'normalised_adjustment',
                         'scale': {'domain': [-0.5, 0.5]}
                     }
-                },
-                'transform': [
-                    {'calculate': 'datum.iteration + 0.8/datum.num_levels*(parseInt(substring(datum.level, 6))-(datum.num_levels-1)/2)',
-                     'as': 'iteration_jitter'}
-                ]
-            },
-                {
-                    'mark': 'line',
-                    'encoding': {
-                        'color': {'value': '#000000'},
-                        'detail': {'type': 'nominal', 'field': 'level'},
-                        'opacity': {
-                            'condition': {
-                                'value': 0,'selection': {'not': 'selector190'}
-                            },
-                            'value': 1
-                        },
-                        'tooltip': [
-                            {'type': 'nominal', 'field': 'col_name'},
-                            {'type': 'nominal', 'field': 'level'},
-                            {'type': 'quantitative', 'field': 'm'},
-                            {'type': 'quantitative', 'field': 'u'},
-                            {'type': 'quantitative', 'field': 'normalised_adjustment'}  
-                        ],
-                        'x': {
-                            'type': 'quantitative', 
-                            'field': 'iteration_jitter'  
-                        },
-                        'y': {
-                            'type': 'quantitative',
-                            'axis': {'title': 'Influence on match probability'},
-                            'field': 'normalised_adjustment', 
-                            'scale': {'domain': [-0.5, 0.5]}
-                        }
-                    },
-                    'transform': [
-                        {'calculate': 'datum.iteration + 0.8/datum.num_levels*(parseInt(substring(datum.level, 6))-(datum.num_levels-1)/2)',
-                         'as': 'iteration_jitter'}
-                    ]
                 }
+            }
             ]
         }
     ],

--- a/splink/params.py
+++ b/splink/params.py
@@ -178,7 +178,7 @@ class Params:
         data = []
         # Want to compare the u and m probabilities
         lam = self.params['λ']
-        pi = gk = self.params["π"]
+        pi = self.params["π"]
         gk = list(pi.keys())
 
         for g in gk:
@@ -208,12 +208,12 @@ class Params:
         """
         adj_data = []
 
-        pi = gk = self.params["π"]
+        pi = self.params["π"]
         gk = list(pi.keys())
 
         for it_num, param_value in enumerate(self.param_history):
             for g in gk:
-                pi = gk = self.param_history[it_num]["π"]
+                pi = self.param_history[it_num]["π"]
                 gk = list(pi.keys())
                 this_gamma = pi[g]
                 for l in range(this_gamma["num_levels"]):

--- a/splink/params.py
+++ b/splink/params.py
@@ -178,7 +178,7 @@ class Params:
         data = []
         # Want to compare the u and m probabilities
         lam = self.params['λ']
-        pi = self.params["π"]
+        pi = gk = self.params["π"]
         gk = list(pi.keys())
 
         for g in gk:
@@ -208,12 +208,12 @@ class Params:
         """
         adj_data = []
 
-        pi = self.params["π"]
+        pi = gk = self.params["π"]
         gk = list(pi.keys())
 
         for it_num, param_value in enumerate(self.param_history):
             for g in gk:
-                pi = self.param_history[it_num]["π"]
+                pi = gk = self.param_history[it_num]["π"]
                 gk = list(pi.keys())
                 this_gamma = pi[g]
                 for l in range(this_gamma["num_levels"]):
@@ -506,6 +506,7 @@ class Params:
             # Assign iteration history to values of chart_def
             chart_def["data"]["values"] = [d for d in data if d['column']==col_name]
             chart_def["title"]["text"] = col_name
+            chart_def["hconcat"][1]["layer"][0]["encoding"]["color"]["legend"]["tickCount"] = col_dict["num_levels"]-1
             chart_defs.append(chart_def)
         
         combined_charts = {

--- a/splink/params.py
+++ b/splink/params.py
@@ -512,6 +512,7 @@ class Params:
             "config": {
                 "view": {"width": 400, "height": 120},
             },
+            "title": {"text":"Influence factors iteration history", "anchor": "middle"},
             "vconcat": chart_defs,
             "resolve": {"scale":{"color": "independent"}},
             '$schema': 'https://vega.github.io/schema/vega-lite/v4.8.1.json'

--- a/splink/params.py
+++ b/splink/params.py
@@ -14,6 +14,7 @@ from .chart_definitions import (
     lambda_iteration_chart_def,
     pi_iteration_chart_def,
     probability_distribution_chart,
+    gamma_distribution_chart_def,
     ll_iteration_chart_def,
     adjustment_weight_chart_def,
     adjustment_history_chart_def,
@@ -176,6 +177,7 @@ class Params:
         """
         data = []
         # Want to compare the u and m probabilities
+        lam = self.params['λ']
         pi = gk = self.params["π"]
         gk = list(pi.keys())
 
@@ -184,10 +186,11 @@ class Params:
             for l in range(this_gamma["num_levels"]):
                 row = {}
                 level = f"level_{l}"
-                row["level"] = level
-                row["col_name"] = this_gamma["column_name"]
+                row["level"] = l
+                row["column"] = this_gamma["column_name"]
                 row["m"] = this_gamma["prob_dist_match"][level]["probability"]
                 row["u"] = this_gamma["prob_dist_non_match"][level]["probability"]
+                row["level_proportion"] = row["m"]*lam + row["u"]*(1-lam)
                 try:
                     row["adjustment"] = row["m"] / (row["m"] + row["u"])
                     row["normalised_adjustment"] = row["adjustment"] - 0.5
@@ -217,9 +220,9 @@ class Params:
                     row = {}
                     row["iteration"] = it_num
                     level = f"level_{l}"
-                    row["level"] = level
+                    row["level"] = l
                     row["num_levels"] = this_gamma["num_levels"]
-                    row["col_name"] = this_gamma["column_name"]
+                    row["column"] = this_gamma["column_name"]
                     row["m"] = this_gamma["prob_dist_match"][level]["probability"]
                     row["u"] = this_gamma["prob_dist_non_match"][level]["probability"]
                     try:
@@ -450,6 +453,20 @@ class Params:
             return alt.Chart.from_dict(probability_distribution_chart)
         else:
             return probability_distribution_chart
+        
+    def gamma_distribution_chart(self):  # pragma: no cover
+        """
+        If altair is installed, returns the chart
+        Otherwise will return the chart spec as a dictionary
+        """
+        data = self._convert_params_dict_to_normalised_adjustment_data()
+
+        gamma_distribution_chart_def["data"]["values"] = data
+
+        if altair_installed:
+            return alt.Chart.from_dict(gamma_distribution_chart_def)
+        else:
+            return gamma_distribution_chart_def
 
     def adjustment_factor_chart(self):  # pragma: no cover
         """
@@ -487,7 +504,7 @@ class Params:
            
             chart_def = copy.deepcopy(adjustment_history_chart_def)
             # Assign iteration history to values of chart_def
-            chart_def["data"]["values"] = [d for d in data if d['col_name']==col_name]
+            chart_def["data"]["values"] = [d for d in data if d['column']==col_name]
             chart_def["title"]["text"] = col_name
             chart_defs.append(chart_def)
         
@@ -526,6 +543,7 @@ class Params:
                 c5 = ""
 
             c6 = self.adjustment_factor_history_charts().to_json(indent=None)
+            c7 = self.gamma_distribution_chart().to_json(indent=None)
             
             with open(filename, "w") as f:
                 f.write(
@@ -534,11 +552,12 @@ class Params:
                         vegalite_version=alt.VEGALITE_VERSION,
                         vegaembed_version=alt.VEGAEMBED_VERSION,
                         spec1=c1,
-                        spec2=c2,
-                        spec3=c3,
-                        spec4=c4,
+                        spec2=c7,
+                        spec3=c2,
+                        spec4=c3,
                         spec5=c5,
-                        spec6=c6
+                        spec6=c4,
+                        spec7=c6
                     )
                 )
         else:
@@ -553,6 +572,7 @@ class Params:
                 c5 = ""
             
             c6 = json.dumps(self.adjustment_factor_history_charts())
+            c7 = json.dumps(self.gamma_distribution_chart())
             
             with open(filename, "w") as f:
                 f.write(
@@ -561,11 +581,12 @@ class Params:
                         vegalite_version="3.3.0",
                         vegaembed_version="4",
                         spec1=c1,
-                        spec2=c2,
-                        spec3=c3,
-                        spec4=c4,
+                        spec2=c7,
+                        spec3=c2,
+                        spec4=c3,
                         spec5=c5,
-                        spec6=c6,
+                        spec6=c4,
+                        spec7=c6
                     )
                 )
 


### PR DESCRIPTION
For the time being just adds a new chart to the existing menu of charts provided and sticks them at the bottom of the `all_charts_write_html_file()` output

Still to address:
- Arrangement of charts in all charts output
- New chart for distribution of gamma levels for each col (to complete link between m/u probabilities and influence factor)
- Replace adjustment/influence factor with Bayes factor, K in charts and documentation (worthy of a separate PR)