### PR TITLE
Fix intuition report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink"
-version = "0.3.0"
+version = "0.3.1"
 description = "Implementation in Apache Spark of the EM algorithm to estimate parameters of Fellegi-Sunter's canonical model of record linkage."
 authors = ["Robin Linacre <robinlinacre@hotmail.com>", "Sam Lindsay", "Theodore Manassis"]
 license = "MIT"

--- a/splink/intuition.py
+++ b/splink/intuition.py
@@ -68,8 +68,13 @@ def intuition_report(row_dict:dict, params:Params):
         d["gamma_col_name"] = gk
         d["gamma_value"] = row_dict[gk]
 
-        d["prob_m"] = float(row_dict[f"prob_{gk}_match"])
-        d["prob_nm"] = float(row_dict[f"prob_{gk}_non_match"])
+        if row_dict[gk] != -1:
+            d["prob_m"] = float(pi[gk]["prob_dist_match"][f"level_{row_dict[gk]}"]["probability"])
+            d["prob_nm"] = float(pi[gk]["prob_dist_non_match"][f"level_{row_dict[gk]}"]["probability"])
+        else:
+            d["prob_m"] = 1.0
+            d["prob_nm"] = 1.0
+
 
         d["bf"] = d["prob_m"]/d["prob_nm"]
 


### PR DESCRIPTION
It looks like the intuition report depends on `prob_{gk}_match` / `prob_{gk}_non_match` being in `df_e`. This is only the case if you have explicitly set `retain_intermediate_calculation_columns` in the settings. 

Not as neat, but the same information can be pulled from `params` rather than `df_e`.

You may or may not want to include the intermediate cols but:
- not including them shouldn't prevent the creation of intuition reports
- you shouldn't _have to_ include them just to be able to create intuition reports


