### PR TITLE
Remove pandas dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink"
-version = "0.2.9"
+version = "0.2.10"
 description = "Implementation in Apache Spark of the EM algorithm to estimate parameters of Fellegi-Sunter's canonical model of record linkage."
 authors = ["Robin Linacre <robinlinacre@hotmail.com>", "Sam Lindsay", "Theodore Manassis"]
 license = "MIT"


### PR DESCRIPTION
When i was doing a final review i realised we're using pandas for some of the calculations.  I've been trying to keep `splink`'s dependencies as lightweight as possible, and so have avoided the use of pandas elsewhere.

Luckily I could copy and paste your calculations and run them row by row using a list of dicts, so it was easy to get rid of it.

I also ran black on the code - I'm not sure why there is a difference between my results and your here.

[Here](https://github.com/moj-analytical-services/splink/pull/142/commits/7d036d915c10bc255502ad7620940f63b44d6e29) is the commit which switched out the pandas dependency (i.e. that's where the code has functionally changed).

The other diffs are down to black.

If you're happy with this, we will merge this into `histdiag` and then merge `histdiag` into master.