### PR TITLE
DO NOT MERGE - New TF adjustment

### DIFF
--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -15,7 +15,7 @@ from splink.blocking import block_using_rules
 from splink.gammas import add_gammas
 from splink.iterate import iterate
 from splink.expectation_step import run_expectation_step
-from splink.term_frequencies import make_adjustment_for_term_frequencies
+from splink.term_frequencies import make_adjustment_for_term_frequencies, add_term_frequencies
 from splink.vertically_concat import (
     vertically_concatenate_datasets,
 )
@@ -92,7 +92,9 @@ class Splink:
             DataFrame: A spark dataframe including a match probability column
         """
 
-        df_comparison = block_using_rules(self.settings_dict, self.df, self.spark)
+        df_with_tf = add_term_frequencies(self.df, self.settings_dict, self.spark)
+
+        df_comparison = block_using_rules(self.settings_dict, df_with_tf, self.spark)
 
         df_gammas = add_gammas(df_comparison, self.settings_dict, self.spark)
 

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -113,11 +113,11 @@ class Splink:
 
         df_e = self.break_lineage_scored_comparisons(df_e, self.spark)
 
-        df_e_adj = self.make_term_frequency_adjustments(df_e)
+        #df_e_adj = self.make_term_frequency_adjustments(df_e)
 
-        df_e.unpersist()
+        #df_e.unpersist()
 
-        return df_e_adj
+        return df_e
 
     def make_term_frequency_adjustments(self, df_e: DataFrame):
         """Take the outputs of 'get_scored_comparisons' and make term frequency adjustments on designated columns in the settings dictionary

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -59,6 +59,8 @@ def _get_columns_to_retain_blocking(settings_dict, df):
         cc = ComparisonColumn(col)
         for col_name in cc.columns_used:
             columns_to_retain.add(col_name)
+        if cc["term_frequency_adjustments"]:
+            columns_to_retain.add(f"tf_{cc.name}")
 
     for c in settings_dict["additional_columns_to_retain"]:
         columns_to_retain.add(c)

--- a/splink/default_settings.py
+++ b/splink/default_settings.py
@@ -138,6 +138,19 @@ def _complete_probabilities(col_settings: dict, mu_probabilities: str):
         col_settings[mu_probabilities] = probs
 
 
+def _complete_tf_adjustment_weights(col_settings: dict):
+
+    if "tf_adjustment_weights" in col_settings:
+        if not all(0.0 <= w <= 1.0 for w in col_settings["tf_adjustment_weights"]):
+            raise ValueError(
+                f"All values of 'tf_adjustment_weights' must be between 0 and 1"
+            )
+    else:
+        weights = [0.0] * col_settings["num_levels"]
+        weights[-1] = 1.0  
+        col_settings["tf_adjustment_weights"] = weights
+
+
 def complete_settings_dict(settings_dict: dict, spark: SparkSession):
     """Auto-populate any missing settings from the settings dictionary using the 'sensible defaults' that
     are specified in the json schema (./splink/files/settings_jsonschema.json)
@@ -203,6 +216,7 @@ def complete_settings_dict(settings_dict: dict, spark: SparkSession):
         _complete_case_expression(col_settings, spark)
         _complete_probabilities(col_settings, "m_probabilities")
         _complete_probabilities(col_settings, "u_probabilities")
+        _complete_tf_adjustment_weights(col_settings)
 
     return settings_dict
 

--- a/splink/files/settings_jsonschema.json
+++ b/splink/files/settings_jsonschema.json
@@ -281,7 +281,13 @@
             "type": "boolean",
             "default": false,
             "title": "Whether ex post term frequency adjustments should be made to match scores for this column",
-            "description": "For some columns such as first name, the value of first name is important due to the distribution of values being non-uniform.  For instance, a match on 'linacre' contains more information than a match on 'smith. If this is set to true, a term frequency adjustment is made to account for these difference.  For details of how this works, see [here](https://static.cambridge.org/content/id/urn:cambridge.org:id:article:S0003055418000783/resource/name/S0003055418000783sup001.pdf) page 7"
+            "description": "For some columns such as first name, the value of first name is important due to the distribution of values being non-uniform.  For instance, a match on 'linacre' contains more information than a match on 'smith'. If this is set to true, a term frequency adjustment is made to account for these difference."
+          },
+          "tf_adjustment_weights": {
+            "$id": "#/properties/comparison_columns/items/properties/tf_adjusment_weights",
+            "type": "array",
+            "title": "An array of weights to apply to term frequency adjustments for each level gamma level. ",
+            "description": "The first weight given corresponds to level 0 (least similar) and the last corresponds to level n (most similar). By default, the full term frequency adjustment (weight=1) is made to the top level only, and no term frequency is applied to other levels (weight=0)."
           },
           "gamma_index": {
             "$id": "#/properties/comparison_columns/items/properties/gamma_index",

--- a/splink/gammas.py
+++ b/splink/gammas.py
@@ -60,6 +60,7 @@ def _get_select_expression_gammas(settings: dict, retain_source_dataset_col: boo
                 select_columns = _add_left_right(select_columns, col_name)
         if col["term_frequency_adjustments"]:
             select_columns = _add_left_right(select_columns, cc.name)
+            select_columns = _add_left_right(select_columns, f"tf_{cc.name}")
         select_columns.add(col["case_expression"])
 
     for c in settings["additional_columns_to_retain"]:

--- a/splink/maximisation_step.py
+++ b/splink/maximisation_step.py
@@ -49,7 +49,7 @@ def _sql_gen_intermediate_pi_aggregate(model, table_name="df_e"):
     gamma_cols_expr = ", ".join([cc.gamma_name for cc in ccs])
 
     sql = f"""
-    select {gamma_cols_expr}, sum(match_probability) as expected_num_matches, sum(1- match_probability) as expected_num_non_matches, count(*) as num_rows
+    select {gamma_cols_expr}, sum(tf_adjusted_match_prob) as expected_num_matches, sum(1- tf_adjusted_match_prob) as expected_num_non_matches, count(*) as num_rows
     from {table_name}
     group by {gamma_cols_expr}
     """

--- a/splink/maximisation_step.py
+++ b/splink/maximisation_step.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def _sql_gen_new_lambda(table_name="df_intermediate"):
 
     sql = f"""
-    select cast(sum(expected_num_matches)/sum(num_rows) as float) as new_lambda
+    select cast(sum(expected_num_matches)/sum(num_rows) as double) as new_lambda
     from {table_name}
     """
 
@@ -65,8 +65,8 @@ def _sql_gen_pi_df(model, table_name="df_intermediate"):
         sql = f"""
         select
         {gamma_column_name} as gamma_value,
-        cast(sum(expected_num_matches)/(select sum(expected_num_matches) from {table_name} where {gamma_column_name} != -1) as float) as new_probability_match,
-        cast(sum(expected_num_non_matches)/(select sum(expected_num_non_matches) from {table_name} where {gamma_column_name} != -1) as float) as new_probability_non_match,
+        cast(sum(expected_num_matches)/(select sum(expected_num_matches) from {table_name} where {gamma_column_name} != -1) as double) as new_probability_match,
+        cast(sum(expected_num_non_matches)/(select sum(expected_num_non_matches) from {table_name} where {gamma_column_name} != -1) as double) as new_probability_non_match,
         '{col_name}' as column_name
         from {table_name}
         where {gamma_column_name} != -1

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -70,6 +70,12 @@ class ComparisonColumn:
         elif "col_name" in cd:
             return [cd["col_name"]]
 
+    @property
+    def term_frequency_adjustments(self):
+        cd = self.column_dict
+        return  cd["term_frequency_adjustments"]
+
+
     def get_m_u_bayes_at_gamma_index(self, gamma_index):
 
         # if -1 this indicates a null field


### PR DESCRIPTION
## Changes so far

- Add term frequencies to `df` 
  - e.g. `tf_surname` is the count of surname / count of all non-null surnames
- Add `tf_adjustment_weights` to settings 
  - weight between 0 (no TF adjustment) and 1 (full TF adjustment) for each gamma level
  - intermediate weights can be applied to fuzzy match levels where TF adjustment is partially relevant (e.g. `lindsay` vs `lindsey`) -> `tf_adjustment_weights = [0.0, 0.7, 1.0]`
  - default: 0 except for max gamma level (e.g. `[0.0, 0.0, 1.0]`)
- Convert match probability calculation to Bayes factors (rather than m and u)
- New TF component to the Bayes factor
  - TF adjustment effectively replaces `u` with term frequency (i.e. surname-specific BF = `m / tf_surname`)
  - Expressed as an additional Bayes factor (i.e. surname-specific BF = `bf_gamma_surname * bf_tf_adj_surname`)
  - `bf_tf_adj_surname = u / tf_surname` (raised to the power of `tf_adjustment_weight`)
  - Where matches are fuzzy, uses the larger of the two term frequencies (assumes the less frequent one is an error)
- EM algorithm uses TF adjusted match probability with each iteration


## TO DO / TEST / CONSIDER:
- Does it give the right answer??? (test on real data and QA clusters?)
- TF adjustments on custom comparison columns (do not allow 🚫)
- Does the new method work without first estimating u probabilities and fixing them? (Do the parameters still iterate properly to the same solution?)
- How this feeds into later diagnostic elements
- Visualising TF adjustments
- Other stuff I haven't thought of yet...