### PR TITLE
create table directly with sql in duckdb

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -57,9 +57,12 @@ class DuckDBInMemoryLinker(Linker):
         if transpile:
             sql = sqlglot.transpile(sql, read="spark", write="duckdb", pretty=True)[0]
 
-        output = self.con.query(sql).to_df()
-
-        self.con.register(physical_name, output)
+        sql = f"""
+        CREATE TABLE IF NOT EXISTS {physical_name}
+        AS
+        ({sql})
+        """
+        output = self.con.execute(sql).fetch_df()
 
         return DuckDBInMemoryLinkerDataFrame(templated_name, physical_name, self)
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -296,6 +296,3 @@ class Linker:
 
         predictions = self.execute_sql_pipeline([])
         return predictions
-
-    def execute_sql(self):
-        pass


### PR DESCRIPTION
Nice quick one for you. Makes more sense for you to benchmark and add your results to the existing charts.

I'm getting 2.3 seconds for this version vs 3 seconds for the older version.