### PR TITLE
Allow user provided tf tables.

### DIFF
--- a/benchmarking/test_performance.py
+++ b/benchmarking/test_performance.py
@@ -245,7 +245,7 @@ def sqlite_performance(con, target_rows=1e6):
         sqlite_connection=con,
     )
 
-    linker.train_u_using_random_sampling(target_rows=1e6)
+    linker.train_u_using_random_sampling(target_rows=target_rows)
 
     blocking_rule = "l.first_name = r.first_name and l.surname = r.surname"
     linker.train_m_using_expectation_maximisation(blocking_rule)
@@ -259,13 +259,15 @@ def sqlite_performance(con, target_rows=1e6):
 def test_2_rounds_1k_sqlite(benchmark):
     import sqlite3
 
-    con = sqlite3.connect(":memory:")
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df.to_sql("input_df_tablename", con)
+    def setup():
+        con = sqlite3.connect(":memory:")
+        df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+        df.to_sql("input_df_tablename", con)
+        return (con,), {"target_rows": 1e6}
 
     benchmark.pedantic(
         sqlite_performance,
-        kwargs={"con": con, "target_rows": 1e6},
+        setup=setup,
         rounds=2,
         iterations=1,
         warmup_rounds=0,
@@ -275,13 +277,15 @@ def test_2_rounds_1k_sqlite(benchmark):
 def test_10_rounds_20k_sqlite(benchmark):
     import sqlite3
 
-    con = sqlite3.connect(":memory:")
-    df = pd.read_csv("./benchmarking/fake_20000_from_splink_demos.csv")
-    df.to_sql("input_df_tablename", con)
+    def setup():
+        con = sqlite3.connect(":memory:")
+        df = pd.read_csv("./benchmarking/fake_20000_from_splink_demos.csv")
+        df.to_sql("input_df_tablename", con)
+        return (con,), {"target_rows": 3e6}
 
     benchmark.pedantic(
         sqlite_performance,
-        kwargs={"con": con, "target_rows": 3e6},
+        setup=setup,
         rounds=10,
         iterations=1,
         warmup_rounds=0,

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -45,10 +45,10 @@ class DuckDBInMemoryLinker(Linker):
 
         for templated_name, df in tf_tables.items():
             # Make a table with this name
+            templated_name = "__splink__df_" + templated_name
             con.register(templated_name, df)
-            tf_tables[templated_name] = templated_name
 
-        super().__init__(settings_dict, input_tables, tf_tables)
+        super().__init__(settings_dict, input_tables)
 
     def _df_as_obj(self, templated_name, physical_name):
         return DuckDBInMemoryLinkerDataFrame(templated_name, physical_name, self)
@@ -71,3 +71,11 @@ class DuckDBInMemoryLinker(Linker):
             return ""
         percent = proportion * 100
         return f"USING SAMPLE {percent}% (bernoulli)"
+
+    def table_exists_in_database(self, table_name):
+        sql = f"PRAGMA table_info('{table_name}');"
+        try:
+            self.con.execute(sql)
+        except RuntimeError:
+            return False
+        return True

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -121,7 +121,7 @@ class Linker:
 
         hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
         # Ensure hash is valid sql table name
-        hash = "a_" + hash
+        hash = "__splink__" + hash
 
         if self.table_exists_in_database(hash):
             return self._df_as_obj(output_tablename_templated, hash)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -127,7 +127,6 @@ class Linker:
             return self._df_as_obj(output_tablename_templated, hash)
 
         print(f"Executing sql with hashed value {hash}")
-        print(sql)
 
         if materialise_as_hash:
             dataframe = self.execute_sql(sql, output_tablename_templated, hash)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -9,7 +9,11 @@ from .em_training import EMTrainingSession
 from .misc import bayes_factor_to_prob, escape_columns, prob_to_bayes_factor
 from .predict import predict
 from .settings import Settings
-from .term_frequencies import term_frequencies
+from .term_frequencies import (
+    term_frequencies,
+    sql_gen_term_frequencies,
+    colname_to_tf_tablename,
+)
 
 from .m_training import estimate_m_values_from_label_column
 from .u_training import estimate_u_values
@@ -64,27 +68,32 @@ class Linker:
 
         self.settings_obj = Settings(settings_dict)
 
-        # self.named_cache = {name: DataFrame(name, value)}
-        self.named_cache = {}
-
-        # self.hashed_cache = {hash: DataFrame(name, value)}
-        self.hashed_cache = {}
-
         self.pipeline = SQLPipeline()
 
         self.input_dfs = self._get_input_dataframe_dict(input_tables)
-        self.input_tf_tables = self._get_input_tf_dict(tf_tables)
+
         self._validate_input_dfs()
         self.em_training_sessions = []
 
+    def _initialise_df_concat_with_tf(self, materialise=True):
+        if self.table_exists_in_database("__splink__df_concat_with_tf"):
+            return
         sql = vertically_concatente(self.input_dfs)
         self.enqueue_sql(sql, "__splink__df_concat")
 
-        sqls = term_frequencies(self.settings_obj, self.input_tf_tables)
+        sqls = term_frequencies(self)
         for sql in sqls:
             self.enqueue_sql(sql["sql"], sql["output_table_name"])
 
-        self.execute_sql_pipeline(materialise_as_hash=False)
+        if materialise:
+            self.execute_sql_pipeline(materialise_as_hash=False)
+
+    def compute_tf_table(self, column_name):
+        sql = vertically_concatente(self.input_dfs)
+        self.enqueue_sql(sql, "__splink__df_concat")
+        sql = sql_gen_term_frequencies(column_name)
+        self.enqueue_sql(sql, colname_to_tf_tablename(column_name))
+        return self.execute_sql_pipeline(materialise_as_hash=False)
 
     def enqueue_sql(self, sql, output_table_name):
         self.pipeline.enqueue_sql(sql, output_table_name)
@@ -105,27 +114,27 @@ class Linker:
 
         self.pipeline.reset()
 
-        if output_tablename_templated in self.named_cache:
-            print(f"Returning named cache {output_tablename_templated}")
-            return self.named_cache[output_tablename_templated]
+        if self.table_exists_in_database(output_tablename_templated):
+            return self._df_as_obj(
+                output_tablename_templated, output_tablename_templated
+            )
 
         hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
         # Ensure hash is valid sql table name
         hash = "a_" + hash
-        if hash in self.hashed_cache:
-            print(f"Returning hashed cache {hash}")
-            return self.hashed_cache[hash]
+
+        if self.table_exists_in_database(hash):
+            return self._df_as_obj(output_tablename_templated, hash)
 
         print(f"Executing sql with hashed value {hash}")
+        print(sql)
 
         if materialise_as_hash:
             dataframe = self.execute_sql(sql, output_tablename_templated, hash)
-            self.hashed_cache[hash] = dataframe
         else:
             dataframe = self.execute_sql(
                 sql, output_tablename_templated, output_tablename_templated
             )
-            self.named_cache[output_tablename_templated] = dataframe
 
         return dataframe
 
@@ -152,6 +161,11 @@ class Linker:
     def execute_sql(self, sql, templated_name, physical_name, transpile=True):
         raise NotImplementedError(f"execute_sql not implemented for {type(self)}")
 
+    def table_exists_in_database(self, table_name):
+        raise NotImplementedError(
+            f"table_exists_in_database not implemented for {type(self)}"
+        )
+
     def _validate_input_dfs(self):
         for df in self.input_dfs.values():
             df.validate()
@@ -165,12 +179,12 @@ class Linker:
             return df_dict
 
     def train_u_using_random_sampling(self, target_rows):
-
+        self._initialise_df_concat_with_tf(materialise=True)
         estimate_u_values(self, target_rows)
         self.populate_m_u_from_trained_values()
 
     def train_m_from_label_column(self, label_colname):
-
+        self._initialise_df_concat_with_tf(materialise=True)
         estimate_m_values_from_label_column(self, self.input_dfs, label_colname)
         self.populate_m_u_from_trained_values()
 
@@ -183,7 +197,7 @@ class Linker:
         fix_u_probabilities=True,
         fix_m_probabilities=False,
     ):
-
+        self._initialise_df_concat_with_tf(materialise=True)
         em_training_session = EMTrainingSession(
             self,
             blocking_rule,
@@ -274,15 +288,11 @@ class Linker:
             comparison_levels_to_reverse_blocking_rule=comparison_levels_to_reverse_blocking_rule,
         )
 
-    def _comparison_vectors(self):
-        sql = block_using_rules(self.settings_obj)
-        self.enqueue_sql(sql, "__splink__df_blocked")
-
-        sql = compute_comparison_vector_values(self.settings_obj)
-        self.enqueue_sql(sql, "__splink__df_comparison_vectors")
-        return self.execute_sql_pipeline([])
-
     def predict(self):
+
+        # If the user only calls predict, it runs as a single pipeline with no
+        # materialisation of anything
+        self._initialise_df_concat_with_tf(materialise=False)
 
         sql = block_using_rules(self.settings_obj)
         self.enqueue_sql(sql, "__splink__df_blocked")

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -64,9 +64,7 @@ class SparkLinker(Linker):
         spark_df = self.spark.sql(sql)
 
         # Break lineage
-        # spark_df.write.mode("overwrite").parquet(f"./tmp_spark/{physical_name}")
-        # spark_df = self.spark.read.parquet(f"./tmp_spark/{physical_name}")
-        # Only persist if templated_name = pyhsical_name
+
         if templated_name == physical_name:
             print(f"persisted {templated_name}")
             spark_df.persist()

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -86,3 +86,10 @@ class SparkLinker(Linker):
             return ""
         percent = proportion * 100
         return f" TABLESAMPLE ({percent} PERCENT) "
+
+    def table_exists_in_database(self, table_name):
+        tables = self.spark.catalog.listTables()
+        for t in tables:
+            if t.name == table_name:
+                return True
+        return False

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -103,3 +103,14 @@ class SQLiteLinker(Linker):
         sample_size = int(sample_size)
 
         return f"where unique_id IN (SELECT unique_id FROM __splink__df_concat_with_tf ORDER BY RANDOM() LIMIT {sample_size})"
+
+    def table_exists_in_database(self, table_name):
+        sql = f"PRAGMA table_info('{table_name}');"
+
+        rec = self.con.execute(sql).fetchone()
+        if not rec:
+            print(f"table {table_name} does not exist")
+            return False
+        else:
+            print(f"table {table_name} exists")
+            return True

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -77,12 +77,6 @@ class SQLiteLinker(Linker):
 
     def execute_sql(self, sql, templated_name, physical_name, transpile=True):
 
-        drop_sql = f"""
-        drop table if exists {physical_name};
-        """
-
-        self.con.execute(drop_sql)
-
         if transpile:
             sql = sqlglot.transpile(sql, read="spark", write="sqlite")[0]
 

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -60,7 +60,7 @@ def join_tf_to_input_df(settings_obj):
     return sql
 
 
-def term_frequencies(settings_obj, user_provided_tf_dict):
+def term_frequencies(linker):
     """Compute the term frequencies of the required columns and add to the dataframe.
 
     Returns:
@@ -68,6 +68,7 @@ def term_frequencies(settings_obj, user_provided_tf_dict):
         of the corresponding values
     """
 
+    settings_obj = linker.settings_obj
     tf_cols = settings_obj._term_frequency_columns
 
     if not tf_cols:
@@ -75,7 +76,9 @@ def term_frequencies(settings_obj, user_provided_tf_dict):
 
     sqls = []
     for tf_col in tf_cols:
-        if colname_to_tf_tablename(tf_col) not in user_provided_tf_dict:
+        tf_table_name = colname_to_tf_tablename(tf_col)
+
+        if not linker.table_exists_in_database(tf_table_name):
             sql = sql_gen_term_frequencies(tf_col)
             sql = {
                 "sql": sql,


### PR DESCRIPTION
This PR makes several changes:

- **Enables the user to provide a database with precomputed tables**, such as term frequency tables, or even (say) `__splink__df_concat_with_tf`, which may be useful for real-time (low latency) linkage.

- *Make the database the cache*:  Removes** the explicit `named_cache` and `hashed_cache` in favour of asking the database whether the table exists using a new `table_exists_in_database` that must be implemented for each Linker class.  

- Moves the initialisation of `__splink__df_concat_with_tf` away from `__init__`.  It's undesirable to perform these computations on `__init__` because:
  - it's a potentially long running computation
  - It forces `__splink__df_concat_with_tf` to be materialised.  This is not necessarily wanted - e.g. if the user _only_ wants to call `predict` without training the model (e.g. in the case of real-time linkage), then a single `predict()` pipline that performs all computations 'in one' will be fastest.
  - These calculations are now performed when the user calls any of the training methods i.e. at the point we know we definitely want to materialise 
 

- **Allow user to pre-compute tf tables**. Allow the user to compute a tf adjustment table that's compatible with splink, and persist to the db.  This means if the user is rapidly iterating their code, training will be faster because they can skip the computation of tf tables.

 