### PR TITLE
convert GREATEST to a more general CASE WHEN format

### DIFF
--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -397,7 +397,12 @@ class ComparisonLevel:
                 (CASE WHEN {tf_adjustment_exists}
                 THEN
                 POW(
-                    {u_prob_exact_match}D / GREATEST({coalesce_l_r},{coalesce_r_l}),
+                    {u_prob_exact_match}D /
+                (CASE
+                    WHEN {coalesce_l_r} >= {coalesce_r_l}
+                    THEN {coalesce_l_r}
+                    ELSE {coalesce_r_l}
+                END),
                     {self.tf_adjustment_weight}D
                 )
                 ELSE 1D


### PR DESCRIPTION
Quick edit to make the SQL code that's generated more general (applicable to more SQL dialects).

All we're doing is moving from:
GREATEST -> CASE WHEN (val1, val2) ...