### PR TITLE
Sql edit isnull clause

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -4,6 +4,9 @@ from .format_sql import format_sql
 
 logger = logging.getLogger(__name__)
 
+def create_null_clauses(rule: str):
+    return " OR ".join(f"{p.strip()} IS NULL"
+            for p in rule.split("="))
 
 def _sql_gen_and_not_previous_rules(previous_rules: list):
     if previous_rules:
@@ -11,8 +14,11 @@ def _sql_gen_and_not_previous_rules(previous_rules: list):
         # you filter out any records with nulls in the previous rules
         # meaning these comparisons get lost
         or_clauses = [f"ifnull(({r}), false)" for r in previous_rules]
+        or_clauses = [f"{r} OR {create_null_clauses(r)}" for
+                                        r in previous_rules]
         previous_rules = " OR ".join(or_clauses)
-        return f"AND NOT ({previous_rules})"
+
+        return f"AND NOT {previous_rules}"
     else:
         return ""
 

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -31,7 +31,7 @@ def _sql_gen_where_condition(link_type, unique_id_cols):
     id_expr_r = _sql_gen_composite_unique_id(unique_id_cols, "r")
 
     if link_type == "two_dataset_link_only":
-        where_condition = " where true "
+        where_condition = " where 1=1 "
     elif link_type in ["link_and_dedupe", "dedupe_only"]:
         where_condition = f"where {id_expr_l} < {id_expr_r}"
     elif link_type == "link_only":
@@ -76,7 +76,7 @@ def block_using_rules(linker):
     # you create a cartesian product, rather than having separate code
     # that generates a cross join for the case of no blocking rules
     if not blocking_rules:
-        blocking_rules = ["true"]
+        blocking_rules = ["1=1"]
 
     for matchkey_number, rule in enumerate(blocking_rules):
         not_previous_rules_statement = _sql_gen_and_not_previous_rules(previous_rules)

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -397,7 +397,12 @@ class ComparisonLevel:
                 (CASE WHEN {tf_adjustment_exists}
                 THEN
                 POW(
-                    {u_prob_exact_match}D / GREATEST({coalesce_l_r},{coalesce_r_l}),
+                    {u_prob_exact_match}D /
+                (CASE
+                    WHEN {coalesce_l_r} >= {coalesce_r_l}
+                    THEN {coalesce_l_r}
+                    ELSE {coalesce_r_l}
+                END),
                     {self.tf_adjustment_weight}D
                 )
                 ELSE 1D


### PR DESCRIPTION
And another PR that generalises some of our SQL code.

This one changes the ISNULL clause that apparently isn't present in T-SQL. If this fails in another language, we can just move to using a case when statement instead and that should do the trick.

This change does make the SQL code a little bit more painful to read.

Change made:
`WHERE ISNULL((col1=col2), FALSE)` -> `WHERE IFNULL(col1=col2, FALSE) OR col IS NULL OR col2 IS NULL`

_We might want to make some refinements to this edit._