### PR TITLE
Sql edit isnull clause

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -4,6 +4,9 @@ from .format_sql import format_sql
 
 logger = logging.getLogger(__name__)
 
+def create_null_clauses(rule: str):
+    return " OR ".join(f"{p.strip()} IS NULL"
+            for p in rule.split("="))
 
 def _sql_gen_and_not_previous_rules(previous_rules: list):
     if previous_rules:
@@ -11,8 +14,11 @@ def _sql_gen_and_not_previous_rules(previous_rules: list):
         # you filter out any records with nulls in the previous rules
         # meaning these comparisons get lost
         or_clauses = [f"ifnull(({r}), false)" for r in previous_rules]
+        or_clauses = [f"{r} OR {create_null_clauses(r)}" for
+                                        r in previous_rules]
         previous_rules = " OR ".join(or_clauses)
-        return f"AND NOT ({previous_rules})"
+
+        return f"AND NOT {previous_rules}"
     else:
         return ""
 

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -4,9 +4,10 @@ from .format_sql import format_sql
 
 logger = logging.getLogger(__name__)
 
+
 def create_null_clauses(rule: str):
-    return " OR ".join(f"{p.strip()} IS NULL"
-            for p in rule.split("="))
+    return " OR ".join(f"{p.strip()} IS NULL" for p in rule.split("="))
+
 
 def _sql_gen_and_not_previous_rules(previous_rules: list):
     if previous_rules:
@@ -14,8 +15,7 @@ def _sql_gen_and_not_previous_rules(previous_rules: list):
         # you filter out any records with nulls in the previous rules
         # meaning these comparisons get lost
         or_clauses = [f"ifnull(({r}), false)" for r in previous_rules]
-        or_clauses = [f"{r} OR {create_null_clauses(r)}" for
-                                        r in previous_rules]
+        or_clauses = [f"{r} OR {create_null_clauses(r)}" for r in previous_rules]
         previous_rules = " OR ".join(or_clauses)
 
         return f"AND NOT {previous_rules}"


### PR DESCRIPTION
Another one for you.

This changes:
`ifnull((col1=col2), false)` -> `0 = case when (col1=col2) then 1 else 0...`.

Nulls are taken into account when using CASE WHEN (some code is provided in a separate message if you'd like to check).

This one also had some weird benchmarking results (I checked to see if adding in CASE WHEN statements makes a difference to speed).
* `CASE WHEN` example
![Screenshot 2022-03-09 at 23 37 05](https://user-images.githubusercontent.com/45356472/157559140-faa1d94c-d53a-4ed5-b644-7e0a8ca5f807.png)

* Original
![Screenshot 2022-03-09 at 23 45 39](https://user-images.githubusercontent.com/45356472/157559177-3519e87a-322a-4a69-8e18-2a9115a3ba25.png)

On the smaller datasets it's slower when using CASE WHEN, while on the larger df it's actually quicker... Not sure how that one has happened, but fine.