### PR TITLE
implement as_pandas_dataframe using awswrangler funcs

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -65,8 +65,8 @@ class AthenaDataFrame(SplinkDataFrame):
                 "terminated. Please retry the link/dedupe job and report the issue "
                 "if this error persists."
             )
-
-    def as_record_dict(self, limit=None):
+    
+    def as_pandas_dataframe(self, limit=None):
         sql = f"""
         select *
         from {self.physical_name}
@@ -79,7 +79,12 @@ class AthenaDataFrame(SplinkDataFrame):
             database=self.athena_linker.output_schema,
             s3_output=self.athena_linker.boto_utils.s3_output,
             keep_files=False,
+            ctas_approach=True,
         )
+        return out_df
+    
+    def as_record_dict(self, limit=None):
+        out_df = self.as_pandas_dataframe(limit)
         return out_df.to_dict(orient="records")
 
     def get_schema_info(self, input_table):

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -65,7 +65,7 @@ class AthenaDataFrame(SplinkDataFrame):
                 "terminated. Please retry the link/dedupe job and report the issue "
                 "if this error persists."
             )
-    
+
     def as_pandas_dataframe(self, limit=None):
         sql = f"""
         select *
@@ -82,7 +82,7 @@ class AthenaDataFrame(SplinkDataFrame):
             ctas_approach=True,
         )
         return out_df
-    
+
     def as_record_dict(self, limit=None):
         out_df = self.as_pandas_dataframe(limit)
         return out_df.to_dict(orient="records")


### PR DESCRIPTION
Implements `as_pandas_dataframe` for the aws wrangler, instead of reading in the dataframe, converting it to a dictionary and then converting it back to a pandas df for users.