### PR TITLE
(WIP) Input tables as list

### DIFF
--- a/benchmarking/test_performance.py
+++ b/benchmarking/test_performance.py
@@ -158,7 +158,7 @@ settings_dict = {
 
 def duckdb_performance(df, target_rows=1e6):
 
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     linker.train_u_using_random_sampling(target_rows=target_rows)
 
@@ -196,9 +196,7 @@ def test_10_rounds_20k_duckdb(benchmark):
 
 def duckdb_on_disk_performance(df, target_rows=1e6):
 
-    linker = DuckDBLinker(
-        settings_dict, input_tables={"fake_data_1": df}, connection=":temporary:"
-    )
+    linker = DuckDBLinker(df, settings_dict, connection=":temporary:")
 
     linker.train_u_using_random_sampling(target_rows=target_rows)
 
@@ -236,7 +234,7 @@ def test_10_rounds_20k_duckdb_on_disk_performance(benchmark):
 
 def spark_performance(df, target_rows=1e6):
 
-    linker = SparkLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = SparkLinker(df, settings_dict)
 
     linker.train_u_using_random_sampling(target_rows=target_rows)
 
@@ -285,9 +283,7 @@ def sqlite_performance(con, target_rows=1e6):
 
     print("**** running sqlite benchmark ***")
     linker = SQLiteLinker(
-        settings_dict,
-        connection=con,
-        input_tables={"mydf": "input_df_tablename"},
+        "input_df_tablename", settings_dict, connection=con, input_table_aliases="mydf"
     )
 
     linker.train_u_using_random_sampling(target_rows=target_rows)

--- a/benchmarking/test_synthetic_data.py
+++ b/benchmarking/test_synthetic_data.py
@@ -170,7 +170,7 @@ settings_dict = {
 
 
 def duckdb_performance(df, target_rows):
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     linker.train_u_using_random_sampling(target_rows=target_rows)
 
@@ -228,9 +228,8 @@ def test_3_rounds_1m_duckdb(benchmark):
 def spark_performance(df, target_rows=1e6):
 
     linker = SparkLinker(
+        df,
         settings_dict,
-        input_tables={"fake_data_1": df},
-        # break_lineage_method="checkpoint",
     )
 
     linker.train_u_using_random_sampling(target_rows=target_rows)

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -1,12 +1,14 @@
-import sqlglot
-from splink.linker import Linker, SplinkDataFrame
 import logging
-from splink.logging_messages import execute_sql_logging_message_info, log_sql
 
-# import utils for communicating with athena
 import awswrangler as wr
 import boto3
-from splink.athena.athena_utils import boto_utils
+import sqlglot
+
+from ..linker import Linker
+from ..splink_dataframe import SplinkDataFrame
+from ..logging_messages import execute_sql_logging_message_info, log_sql
+from ..athena.athena_utils import boto_utils
+
 
 logger = logging.getLogger(__name__)
 

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -1,7 +1,8 @@
 import logging
 import re
 from pyspark.sql import Row
-from ..linker import Linker, SplinkDataFrame
+from ..linker import Linker
+from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union
 import re
 from pyspark.sql import Row
 from ..linker import Linker
@@ -39,9 +40,11 @@ class SparkDataframe(SplinkDataFrame):
         # But there's no real need to clean these up, so we'll just do nothing
         pass
 
-    def as_pandas_dataframe(self):
+    def as_pandas_dataframe(self, limit=None):
 
         sql = f"select * from {self.physical_name}"
+        if limit:
+            sql += f" limit {limit}"
 
         return self.spark_linker.spark.sql(sql).toPandas()
 
@@ -49,30 +52,61 @@ class SparkDataframe(SplinkDataFrame):
         return self.spark_linker.spark.table(self.physical_name)
 
 
-# These classes want to be as minimal as possible
-# dealing with only the backend-specific logic
 class SparkLinker(Linker):
     def __init__(
         self,
+        input_table_or_tables,
         settings_dict=None,
-        input_tables={},
         break_lineage_method="persist",
         persist_level=None,
         set_up_basic_logging=True,
+        input_table_aliases: Union[str, list] = None,
+        spark=None,
     ):
-        df = next(iter(input_tables.values()))
 
-        self.spark = df.sql_ctx.sparkSession
         self.break_lineage_method = break_lineage_method
         self.persist_level = persist_level
 
-        for templated_name, df in input_tables.items():
-            db_tablename = f"__splink__{templated_name}"
+        input_tables = self._ensure_is_list(input_table_or_tables)
 
-            df.createOrReplaceTempView(db_tablename)
-            input_tables[templated_name] = db_tablename
+        input_aliases = self._ensure_aliases_populated_and_is_list(
+            input_table_or_tables, input_table_aliases
+        )
 
-        super().__init__(settings_dict, input_tables, set_up_basic_logging)
+        self.spark = spark
+        if spark is None:
+            for t in input_tables:
+                if type(t).__name__ == "DataFrame":
+                    self.spark = t.sql_ctx.sparkSession
+                    break
+        if self.spark is None:
+            raise ValueError(
+                "If input_table_or_tables are strings rather than "
+                "Spark dataframes, you must pass in the spark session using the spark="
+                " argument when you initialise thel inker"
+            )
+
+        homogenised_tables = []
+        homogenised_aliases = []
+
+        for i, (table, alias) in enumerate(zip(input_tables, input_aliases)):
+
+            if type(alias).__name__ == "DataFrame":
+                alias = f"__splink__input_table_{i}"
+
+            if type(table).__name__ == "DataFrame":
+                table.createOrReplaceTempView(alias)
+                table = alias
+
+            homogenised_tables.append(table)
+            homogenised_aliases.append(alias)
+
+        super().__init__(
+            homogenised_tables,
+            settings_dict,
+            set_up_basic_logging,
+            input_table_aliases=homogenised_aliases,
+        )
 
     def _df_as_obj(self, templated_name, physical_name):
         return SparkDataframe(templated_name, physical_name, self)

--- a/splink/splink_dataframe.py
+++ b/splink/splink_dataframe.py
@@ -1,0 +1,64 @@
+import logging
+
+from .misc import escape_columns
+
+
+logger = logging.getLogger(__name__)
+
+
+class SplinkDataFrame:
+    """Abstraction over dataframe to handle basic operations
+    like retrieving columns, which need different implementations
+    depending on whether it's a spark dataframe, sqlite table etc.
+    """
+
+    def __init__(self, templated_name, physical_name):
+        self.templated_name = templated_name
+        self.physical_name = physical_name
+
+    @property
+    def columns(self):
+        pass
+
+    @property
+    def columns_escaped(self):
+        cols = self.columns
+        return escape_columns(cols)
+
+    def validate():
+        pass
+
+    def random_sample_sql(percent):
+        pass
+
+    @property
+    def physical_and_template_names_equal(self):
+        return self.templated_name == self.physical_name
+
+    def _check_drop_table_created_by_splink(self, force_non_splink_table=False):
+
+        if not self.physical_name.startswith("__splink__"):
+            if not force_non_splink_table:
+                raise ValueError(
+                    f"You've asked to drop table {self.physical_name} from your "
+                    "database which is not a table created by Splink.  If you really "
+                    "want to drop this table, you can do so by setting "
+                    "force_non_splink_table=True"
+                )
+        logger.debug(
+            f"Dropping table with templated name {self.templated_name} and "
+            f"physical name {self.physical_name}"
+        )
+
+    def drop_table_from_database(self, force_non_splink_table=False):
+        raise NotImplementedError(
+            "Drop table from database not implemented for this linker"
+        )
+
+    def as_record_dict(self, limit=None):
+        pass
+
+    def as_pandas_dataframe(self, limit=None):
+        import pandas as pd
+
+        return pd.DataFrame(self.as_record_dict(limit=limit))

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -6,9 +6,8 @@ from rapidfuzz.distance.Levenshtein import distance
 
 
 from ..logging_messages import execute_sql_logging_message_info, log_sql
-
-
-from ..linker import Linker, SplinkDataFrame
+from ..linker import Linker
+from ..splink_dataframe import SplinkDataFrame
 
 logger = logging.getLogger(__name__)
 

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -1,5 +1,5 @@
 import sqlglot
-
+from typing import Union
 import logging
 from math import pow, log2
 from rapidfuzz.distance.Levenshtein import distance
@@ -81,10 +81,11 @@ class SQLiteDataFrame(SplinkDataFrame):
 class SQLiteLinker(Linker):
     def __init__(
         self,
+        input_table_or_tables,
         settings_dict=None,
-        input_tables={},
         connection=":memory:",
         set_up_basic_logging=True,
+        input_table_aliases: Union[str, list] = None,
     ):
         self.con = connection
         self.con.row_factory = dict_factory
@@ -92,7 +93,12 @@ class SQLiteLinker(Linker):
         self.con.create_function("pow", 2, pow)
         self.con.create_function("levenshtein", 2, distance)
 
-        super().__init__(settings_dict, input_tables, set_up_basic_logging)
+        super().__init__(
+            input_table_or_tables,
+            settings_dict,
+            set_up_basic_logging,
+            input_table_aliases=input_table_aliases,
+        )
 
     def _df_as_obj(self, templated_name, physical_name):
         return SQLiteDataFrame(templated_name, physical_name, self)

--- a/splink/vertically_concatenate.py
+++ b/splink/vertically_concatenate.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 def vertically_concatente_sql(linker):
 
     # Use column order from first table in dict
-    df_obj = next(iter(linker.input_dfs.values()))
+    df_obj = next(iter(linker.input_tables_dict.values()))
     columns = df_obj.columns_escaped
 
     select_columns_sql = ", ".join(columns)
@@ -22,7 +22,7 @@ def vertically_concatente_sql(linker):
 
     if source_dataset_col_req:
         sqls_to_union = []
-        for df_obj in linker.input_dfs.values():
+        for df_obj in linker.input_tables_dict.values():
             sql = f"""
             select '{df_obj.templated_name}' as source_dataset, {select_columns_sql}
             from {df_obj.physical_name}

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -47,7 +47,7 @@ def test_scored_labels():
         ],
     }
 
-    linker = DuckDBLinker(settings, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings)
 
     linker._initialise_df_concat_with_tf()
     linker.con.register("labels", df_labels)
@@ -121,7 +121,7 @@ def test_truth_space_table():
         ],
     }
 
-    linker = DuckDBLinker(settings, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings)
 
     labels_with_predictions = [
         {
@@ -200,9 +200,7 @@ def test_roc_chart_dedupe_only():
         axis=1,
     )
     settings_dict = get_settings_dict()
-    linker = DuckDBLinker(
-        settings_dict, input_tables={"fake_data_1": df}, connection=":memory:"
-    )
+    linker = DuckDBLinker(df, settings_dict, connection=":memory:")
 
     linker._initialise_df_concat_with_tf()
 
@@ -234,7 +232,7 @@ def test_roc_chart_link_and_dedupe():
     settings_dict = get_settings_dict()
     settings_dict["link_type"] = "link_and_dedupe"
     linker = DuckDBLinker(
-        settings_dict, input_tables={"fake_data_1": df}, connection=":memory:"
+        df, settings_dict, connection=":memory:", input_table_aliases="fake_data_1"
     )
 
     linker._initialise_df_concat_with_tf()

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -14,7 +14,7 @@ def test_splink_2_predict():
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     expected_record = pd.read_csv("tests/datasets/splink2_479_vs_481.csv")
 
@@ -33,7 +33,7 @@ def test_splink_2_predict():
 # @pytest.mark.skip(reason="Uses Spark so slow and heavyweight")
 def test_splink_2_predict_spark(df_spark):
     settings_dict = get_settings_dict()
-    linker = SparkLinker(settings_dict, input_tables={"fake_data_1": df_spark})
+    linker = SparkLinker(df_spark, settings_dict)
 
     df_e = linker.predict().as_pandas_dataframe()
     print(len(df_e))
@@ -57,9 +57,9 @@ def test_splink_2_predict_sqlite():
     df.to_sql("fake_data_1", con, if_exists="replace")
     settings_dict = get_settings_dict()
     linker = SQLiteLinker(
+        "fake_data_1",
         settings_dict,
         connection=con,
-        input_tables={"fake_data_1": "fake_data_1"},
     )
 
     df_e = linker.predict().as_pandas_dataframe()
@@ -81,7 +81,7 @@ def test_splink_2_em_fixed_u():
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     # Check lambda history is the same
     expected_prop_history = pd.read_csv(
@@ -126,7 +126,7 @@ def test_splink_2_em_no_fix():
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     # Check lambda history is the same
     expected_prop_history = pd.read_csv(
@@ -181,7 +181,7 @@ def test_lambda():
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     ma = linker.predict().as_pandas_dataframe()
     print(len(ma))

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -11,8 +11,8 @@ def test_full_example_duckdb(tmp_path):
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
     linker = DuckDBLinker(
+        df,
         settings_dict,
-        input_tables={"fake_data_1": df},
         connection=os.path.join(tmp_path, "duckdb.db"),
         output_schema="splink_in_duckdb",
     )

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -8,7 +8,7 @@ from basic_settings import get_settings_dict
 
 def test_full_example_spark(df_spark, tmp_path):
     settings_dict = get_settings_dict()
-    linker = SparkLinker(settings_dict, input_tables={"fake_data_1": df_spark})
+    linker = SparkLinker(df_spark, settings_dict)
 
     linker.profile_columns(
         ["first_name", "surname", "first_name || surname", "concat(city, first_name)"]

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -15,9 +15,10 @@ def test_full_example_sqlite(tmp_path):
     df.to_sql("input_df_tablename", con)
     settings_dict = get_settings_dict()
     linker = SQLiteLinker(
+        "input_df_tablename",
         settings_dict,
-        input_tables={"fake_data_1": "input_df_tablename"},
         connection=con,
+        input_table_aliases="fake_data_1",
     )
 
     linker.profile_columns(["first_name", "surname", "first_name || surname"])

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -1,3 +1,4 @@
+from duckdb import alias
 import pandas as pd
 import pytest
 from splink.comparison_library import exact_match
@@ -46,18 +47,28 @@ def dfs():
     )
 
     return {
-        "dedupe_only__pass": {"df": dedupe_only},
-        "link_only__two": {"df_d": sds_d_only.copy(), "df_b": sds_b_only.copy()},
-        "link_only__three": {
-            "df_d": sds_d_only.copy(),
-            "df_b": sds_b_only.copy(),
-            "df_c": sds_c_only.copy(),
+        "dedupe_only__pass": {"input_tables": dedupe_only, "input_table_aliases": "df"},
+        "link_only__two": {
+            "input_tables": [sds_d_only, sds_b_only],
+            "input_table_aliases": [
+                "df_d",
+                "df_b",
+            ],
         },
-        "link_and_dedupe__two": {"df_d": sds_d_only.copy(), "df_b": sds_b_only.copy()},
+        "link_only__three": {
+            "input_tables": [sds_d_only, sds_b_only, sds_c_only],
+            "input_table_aliases": ["df_d", "df_b", "df_c"],
+        },
+        "link_and_dedupe__two": {
+            "input_tables": [sds_d_only, sds_b_only],
+            "input_table_aliases": [
+                "df_d",
+                "df_b",
+            ],
+        },
         "link_and_dedupe__three": {
-            "df_d": sds_d_only.copy(),
-            "df_b": sds_b_only.copy(),
-            "df_c": sds_c_only.copy(),
+            "input_tables": [sds_d_only, sds_b_only, sds_c_only],
+            "input_table_aliases": ["df_d", "df_b", "df_c"],
         },
     }
 
@@ -67,7 +78,8 @@ def test_link_type(input_name, input_tables):
     # Basic check that no errors are generated for any of the link types
     link_type, test_name = input_name.split("__")
 
-    input_tables = dfs()[input_name]
+    input_tables = dfs()[input_name]["input_tables"]
+    aliases = dfs()[input_name]["input_table_aliases"]
     settings = {
         "proportion_of_matches": 0.01,
         "unique_id_column_name": "id",
@@ -88,7 +100,9 @@ def test_link_type(input_name, input_tables):
 
     from splink.duckdb.duckdb_linker import DuckDBLinker
 
-    linker = DuckDBLinker(settings, input_tables=input_tables, connection=":memory:")
+    linker = DuckDBLinker(
+        input_tables, settings, connection=":memory:", input_table_aliases=aliases
+    )
 
     linker.train_u_using_random_sampling(target_rows=1e6)
 

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -1,4 +1,3 @@
-from duckdb import alias
 import pandas as pd
 import pytest
 from splink.comparison_library import exact_match

--- a/tests/test_m_train.py
+++ b/tests/test_m_train.py
@@ -21,7 +21,7 @@ def test_m_train():
     }
 
     # Train from label column
-    linker = DuckDBLinker(settings, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings)
 
     linker.train_m_from_label_column("cluster")
     cc_name = linker.settings_obj.comparisons[0]
@@ -53,7 +53,7 @@ def test_m_train():
             val["unique_id_l"] = uid_r
             val["unique_id_r"] = uid_l
 
-    linker_pairwise = DuckDBLinker(settings, input_tables={"fake_data_1": df})
+    linker_pairwise = DuckDBLinker(df, settings)
 
     linker_pairwise.con.register("labels", df_labels)
     linker_pairwise.train_m_from_pairwise_labels("labels")

--- a/tests/test_profile_data.py
+++ b/tests/test_profile_data.py
@@ -11,9 +11,7 @@ from basic_settings import get_settings_dict
 def test_profile_using_duckdb():
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
-    linker = DuckDBLinker(
-        settings_dict, input_tables={"fake_data_1": df}, connection=":memory:"
-    )
+    linker = DuckDBLinker(df, settings_dict, connection=":memory:")
 
     linker.profile_columns(
         ["first_name", "surname", "first_name || surname", "concat(city, first_name)"],
@@ -25,7 +23,7 @@ def test_profile_using_duckdb():
 def test_profile_using_duckdb_no_settings():
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
-    linker = DuckDBLinker(input_tables={"fake_data_1": df}, connection=":memory:")
+    linker = DuckDBLinker(df, connection=":memory:")
 
     linker.profile_columns(
         ["first_name", "surname", "first_name || surname", "concat(city, first_name)"],
@@ -42,9 +40,9 @@ def test_profile_using_sqlite():
     df.to_sql("fake_data_1", con, if_exists="replace")
     settings_dict = get_settings_dict()
     linker = SQLiteLinker(
+        "fake_data_1",
         settings_dict,
         connection=con,
-        input_tables={"fake_data_1": "fake_data_1"},
     )
 
     linker.profile_columns(["first_name", "surname", "first_name || surname"])
@@ -53,7 +51,7 @@ def test_profile_using_sqlite():
 # @pytest.mark.skip(reason="Uses Spark so slow and heavyweight")
 def test_profile_using_spark(df_spark):
     settings_dict = get_settings_dict()
-    linker = SparkLinker(settings_dict, input_tables={"fake_data_1": df_spark})
+    linker = SparkLinker(df_spark, settings_dict)
 
     linker.profile_columns(
         ["first_name", "surname", "first_name || surname", "concat(city, first_name)"]

--- a/tests/test_term_frequencies.py
+++ b/tests/test_term_frequencies.py
@@ -79,9 +79,7 @@ def test_tf_basic():
         "retain_intermediate_calculation_columns": True,
     }
 
-    linker = DuckDBLinker(
-        settings, input_tables={"fake_data_1": data}, connection=":memory:"
-    )
+    linker = DuckDBLinker(data, settings, connection=":memory:")
     df_predict = linker.predict()
     results = filter_results(df_predict)
 
@@ -117,9 +115,7 @@ def test_tf_clamp():
         "retain_intermediate_calculation_columns": True,
     }
 
-    linker = DuckDBLinker(
-        settings, input_tables={"fake_data_1": data}, connection=":memory:"
-    )
+    linker = DuckDBLinker(data, settings, connection=":memory:")
     df_predict = linker.predict()
     results = filter_results(df_predict)
 
@@ -155,9 +151,7 @@ def test_weight():
         "retain_intermediate_calculation_columns": True,
     }
 
-    linker = DuckDBLinker(
-        settings, input_tables={"fake_data_1": data}, connection=":memory:"
-    )
+    linker = DuckDBLinker(data, settings, connection=":memory:")
     df_predict = linker.predict()
     results = filter_results(df_predict)
 
@@ -206,9 +200,7 @@ def test_weightand_clamp():
         "retain_intermediate_calculation_columns": True,
     }
 
-    linker = DuckDBLinker(
-        settings, input_tables={"fake_data_1": data}, connection=":memory:"
-    )
+    linker = DuckDBLinker(data, settings, connection=":memory:")
     df_predict = linker.predict()
     results = filter_results(df_predict)
 

--- a/tests/test_train_vs_predict.py
+++ b/tests/test_train_vs_predict.py
@@ -22,7 +22,7 @@ def test_train_vs_predict():
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
     settings_dict["blocking_rules_to_generate_predictions"] = ["l.surname = r.surname"]
-    linker = DuckDBLinker(settings_dict, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings_dict)
 
     training_session = linker.train_m_and_u_using_expectation_maximisation(
         "l.surname = r.surname"

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -21,7 +21,7 @@ def test_u_train():
         "blocking_rules_to_generate_predictions": ["l.name = r.name"],
     }
 
-    linker = DuckDBLinker(settings, input_tables={"fake_data_1": df})
+    linker = DuckDBLinker(df, settings)
     linker.debug_mode = True
     linker.train_u_using_random_sampling(target_rows=1e6)
     cc_name = linker.settings_obj.comparisons[0]


### PR DESCRIPTION

Have been struggling a bit with the API for passing tables into Splink 



The challenges are:
Since Splink 3 is agnostic to the backend, a ‘table’ may be a pandas dataframe, a spark dataframe, or a string that refers to a table that exists in a database.
The user may wish to provide a single input table (dedupe_only), or a list of tables (link_and_dedupe, link_only)
For the outputs of Splink, each input table must be associated with a human-readable name, such as df, a pandas dataframe being named prison_persons_list or whatever


In terms of solutions, the version you seen in the demos looks like this:


i.e. input tables are provided as  a dictionary
This is kindof intuitive in the case you’re passing in a pandas dataframe.  In the screenshot fake_1000 is the name (alias) the user wants to give to the pandas df called df (edited) 


However, suppose a table called fake_1000 exists in the database, you have to do:
linker = DuckDBLinker(input_tables = {"fake_1000": "fake_1000"})
Which is much less intuitive (what’s the alias and what’s the table name?) (edited) 


It’s also excessively verbose.  In the case of a single input table (dedupe_only) there is actually no need for the alias


In many cases the aliases aren’t really that important and we can just call the input datafraes input_table_1, input_table_2 etc under the hood

Proposed solution
The proposed solution is that the user provides:
The input tables as either a list OR a single dataframe/string
OPTIONALLY provides aliases
```
# Dedupe only, df is a spark Dataframe
linker = SparkLinker(df_1, settings)

# Explicit (i.e. not autogenerated) alias
linker = SparkLinker(df_1, settings, input_table_aliases="my_alias")

# Dedupe only, "my_table" is a table already registered in the spark catalog
linker = SparkLinker("my_table", settings)
linker = SparkLinker("my_table", settings, input_table_aliases="my_alias")

# Link and dedupe, df_1 and df_2 are spark Dataframes
linker = SparkLinker([df_1, df_2], settings)
linker = SparkLinker([df_1, df_2], settings, input_table_aliases=["_1", "_2"])

# Mix and match
linker = SparkLinker([df_1, "my_table"], settings)
```

This feels most intuitive - i.e. what the user would try to do if they didn’t read the docs:
most users just pass in a single dataframe, or list of dataframes without needing to think about it
But you can optionally alias  them if you need to