### PR TITLE
Cc performance improvements

### DIFF
--- a/benchmarking/connected_components_random_graphs.py
+++ b/benchmarking/connected_components_random_graphs.py
@@ -4,7 +4,7 @@ from tests.cc_testing_utils import (
     run_cc_implementation,
     register_cc_df,
     generate_random_graph,
-    )
+)
 
 ###############################################################################
 # Performance Testing
@@ -12,6 +12,7 @@ from tests.cc_testing_utils import (
 
 # set a seed for consistent benchmarking
 seed = 5
+
 
 def test_500_edge_performance(benchmark):
     g = generate_random_graph(graph_size=500, seed=seed)

--- a/benchmarking/connected_components_random_graphs.py
+++ b/benchmarking/connected_components_random_graphs.py
@@ -1,0 +1,52 @@
+# python3 -m pytest performance/connected_components_random_graphs.py
+import pytest
+from tests.cc_testing_utils import (
+    run_cc_implementation,
+    register_cc_df,
+    generate_random_graph,
+    )
+
+###############################################################################
+# Performance Testing
+###############################################################################
+
+# set a seed for consistent benchmarking
+seed = 5
+
+def test_500_edge_performance(benchmark):
+    g = generate_random_graph(graph_size=500, seed=seed)
+    linker = register_cc_df(g)
+
+    benchmark.pedantic(
+        run_cc_implementation,
+        args=(linker,),
+        rounds=10,
+        iterations=10,
+        warmup_rounds=0,
+    )
+
+
+def test_10000_edge_performance(benchmark):
+    g = generate_random_graph(graph_size=10000, seed=seed)
+    linker = register_cc_df(g)
+
+    benchmark.pedantic(
+        run_cc_implementation,
+        args=(linker,),
+        rounds=10,
+        iterations=10,
+        warmup_rounds=0,
+    )
+
+
+def test_100000_edge_performance(benchmark):
+    g = generate_random_graph(graph_size=100000, seed=seed)
+    linker = register_cc_df(g)
+
+    benchmark.pedantic(
+        run_cc_implementation,
+        args=(linker,),
+        rounds=10,
+        iterations=2,
+        warmup_rounds=0,
+    )

--- a/splink/connected_components.py
+++ b/splink/connected_components.py
@@ -37,7 +37,8 @@ class ConnectedComponents:
         # Note that, since the edges always have the lower id on the left hand side
         # we only need to join on unique_id_r, and pick unique_id_l
 
-        # That is to say, we only bother to find neighbours that are smaller than the node
+        # That is to say, we only bother to find neighbours that are
+        # smaller than the node
 
         # i.e if we want to get the neighbours of node D, we don't need to get both
         # D->C and D->E, we only need to bother getting D->C, because we know in advance
@@ -60,8 +61,8 @@ class ConnectedComponents:
         # EITHER SMALLER OR GREATER, and get THEIR representative
 
         # For example, supposing we have an edge C -> D.  It may be the case that the
-        # representative of D is A.  So we want to retreieve C->D even though D is greater
-        # than C, because D's representative may be less than C.
+        # representative of D is A.  So we want to retreieve C->D even though D
+        # is greater than C, because D's representative may be less than C.
 
         # >> Get all the neighbours of C,
 

--- a/splink/connected_components.py
+++ b/splink/connected_components.py
@@ -101,6 +101,7 @@ class ConnectedComponents:
 
             left join {self.edges} as e_r
                 on n.node_id = e_r.unique_id_r
+
         """
 
         # create our neighbours table
@@ -123,7 +124,9 @@ class ConnectedComponents:
                     select
                         neighbours.node_id,
                         min(neighbour) as representative
+
                     from neighbours
+
                     group by node_id
                     order by node_id
                 """
@@ -150,13 +153,19 @@ class ConnectedComponents:
             else:
 
                 sql = f"""
+
                 select
                     neighbours.node_id,
                     min(representatives.representative) as representative
+
                 from neighbours
+
                 left join {representatives_table} as representatives
+
                 on neighbours.neighbour = representatives.node_id
-                    group by neighbours.node_id
+
+                group by neighbours.node_id
+
                 """
 
                 self.linker.enqueue_sql(sql, representatives_name)
@@ -172,18 +181,27 @@ class ConnectedComponents:
 
             # If True, terminate the loop.
             sql = f"""
+
             with root_nodes as (
+
                 select
                     node_id,
                     representative,
                     node_id=representative as root_node
+
                 from {representatives_name}
             )
-                select count(root_nodes.root_node) as count
-                from root_nodes
-                right join {representatives_name} as representatives
-                on root_nodes.node_id = representatives.representative
-                where root_nodes.root_node = true
+
+            select count(root_nodes.root_node) as count
+
+            from root_nodes
+
+            right join {representatives_name} as representatives
+
+            on root_nodes.node_id = representatives.representative
+
+            where root_nodes.root_node = true
+
             """
             dataframe = self.linker.sql_to_dataframe(
                 sql, "__splink__df_root_rows", materialise_as_hash=False

--- a/tests/cc_testing_utils.py
+++ b/tests/cc_testing_utils.py
@@ -1,0 +1,54 @@
+import networkx as nx
+from networkx.algorithms import connected_components as cc_nx
+import pandas as pd
+import random
+
+from splink.duckdb.duckdb_linker import DuckDBLinker, DuckDBLinkerDataFrame
+
+
+def generate_random_graph(graph_size, seed=None):
+    if not seed:
+        seed = random.randint(5, 1000000)
+
+    print(f"Seed set to {seed}")
+    graph = nx.fast_gnp_random_graph(graph_size, 0.001, seed=seed, directed=False)
+    return graph
+
+
+def register_cc_df(G):
+
+    from tests.basic_settings import get_settings_dict
+    settings_dict = get_settings_dict()
+
+    df = nx.to_pandas_edgelist(G)
+    df.columns = ["unique_id_l", "unique_id_r"]
+    df = pd.concat([
+        pd.DataFrame({
+            "unique_id_l": G.nodes,
+            "unique_id_r": G.nodes}
+        ),
+        df
+    ])
+
+    # boot up our linker
+    table_name = "__splink__df_predict_graph"
+    # this registers our table under __splink__df__{table_name}
+    # but our cc function actively looks for "__splink__df_predict"
+    linker = DuckDBLinker(settings_dict, input_tables={table_name: df})
+
+    # re-register under our required name to run the CC function
+    linker.con.register(table_name, df)
+
+    # add our prediction df to our list of created tables
+    predict_df = DuckDBLinkerDataFrame(table_name, table_name, linker)
+    linker.names_of_tables_created_by_splink = [predict_df]
+
+    return linker
+
+
+def run_cc_implementation(linker):
+
+    # finally, run our connected components linker
+    linker.run_connected_components()
+
+    return linker

--- a/tests/cc_testing_utils.py
+++ b/tests/cc_testing_utils.py
@@ -18,17 +18,12 @@ def generate_random_graph(graph_size, seed=None):
 def register_cc_df(G):
 
     from tests.basic_settings import get_settings_dict
+
     settings_dict = get_settings_dict()
 
     df = nx.to_pandas_edgelist(G)
     df.columns = ["unique_id_l", "unique_id_r"]
-    df = pd.concat([
-        pd.DataFrame({
-            "unique_id_l": G.nodes,
-            "unique_id_r": G.nodes}
-        ),
-        df
-    ])
+    df = pd.concat([pd.DataFrame({"unique_id_l": G.nodes, "unique_id_r": G.nodes}), df])
 
     # boot up our linker
     table_name = "__splink__df_predict_graph"


### PR DESCRIPTION
Performance improvements for our connected components implementation.

The tweaks are as follows:
* Remove the need to create our _**nodes**_ table, which documents all unique nodes in our _edgelist_. This has been added into a CTE statement that creates our neighbours table directly.
* Adjust how we create the _**neighbours**_ table, which was causing considerable slowdown on the original deduping step. While this change dramatically cuts down on creation time for our neighbours table, it does occasionally result in additional rows being added to the table, which in turn are used in a `left join` step. However, even on very large dfs this increase is negligble and only occurs where the initial edge has a circular reference (A->A). As a result, the maximum number of additional rows is just the number of nodes in our nodes df and the actual increase is usually not noticeable. -- I'll reinvestigate whether there's a cleaner way of producing this output without additional circular references at another point.
* Change where and how we create our **representatives** table. This can now be added to our pipeline to reduce the number of output tables we generate when we add batching (which will be one of the next big PRs).
<hr>

## Benchmarks

**The original implementation had the following results from the benchmarks added in this PR:**
<img width="1491" alt="Screenshot 2022-04-29 at 10 33 30" src="https://user-images.githubusercontent.com/45356472/165919988-2dd8b764-cdce-4615-95d0-3bdfe867011c.png">

**The adjustments added in this PR give the following results:**
<img width="1481" alt="Screenshot 2022-04-29 at 10 37 03" src="https://user-images.githubusercontent.com/45356472/165920525-f1a0cf43-40bf-41e0-bc78-46ef447e74c4.png">


