### PR TITLE
Convert core SQL to ansi SQL (no dialect needed in sqlglot)

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -99,13 +99,17 @@ class AthenaDataFrame(SplinkDataFrame):
 class AthenaLinker(Linker):
     def __init__(
         self,
-        settings_dict: dict,
         boto3_session: boto3.session.Session,
         output_database: str,
         output_bucket: str,
+        settings_dict: dict = None,
         folder_in_bucket_for_outputs="",
         input_tables={},
     ):
+
+        if settings_dict is not None and "sql_dialect" not in settings_dict:
+            settings_dict["sql_dialect"] = "presto"
+
         self.boto3_session = boto3_session
         self.boto_utils = boto_utils(
             boto3_session, output_bucket, folder_in_bucket_for_outputs

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -124,7 +124,7 @@ class AthenaLinker(Linker):
         self.drop_table_from_database_if_exists(physical_name)
 
         if transpile:
-            sql = sqlglot.transpile(sql, read="spark", write="presto")[0]
+            sql = sqlglot.transpile(sql, read=None, write="presto")[0]
 
         logger.debug(
             execute_sql_logging_message_info(

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -289,13 +289,20 @@ class ComparisonLevel:
         col = self._level_dict.get("tf_adjustment_column")
         return col is not None
 
+    @property
+    def sql_read_dialect(self):
+        read_dialect = None
+        if self.settings_obj is not None:
+            read_dialect = self.settings_obj._sql_dialect
+        return read_dialect
+
     def _validate_sql(self):
         sql = self.sql_condition
         if self.is_else_level:
             return True
 
         try:
-            sqlglot.parse_one(sql, read=None)
+            sqlglot.parse_one(sql, read=self.sql_read_dialect)
         except sqlglot.ParseError as e:
             raise ValueError(f"Error parsing sql_statement:\n{sql}") from e
 
@@ -308,7 +315,9 @@ class ComparisonLevel:
         if self.is_else_level:
             return []
 
-        cols = get_columns_used_from_sql(self.sql_condition)
+        cols = get_columns_used_from_sql(
+            self.sql_condition, dialect=self.sql_read_dialect
+        )
         # Parsed order seems to be roughly in reverse order of apearance
         cols = cols[::-1]
 

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 def _is_exact_match(sql):
-    syntax_tree = sqlglot.parse_one(sql, read="spark")
+    syntax_tree = sqlglot.parse_one(sql, read=None)
 
     expected_types = {0: EQ, 1: Column, 2: Identifier}
     for tup in syntax_tree.walk():
@@ -38,7 +38,7 @@ def _is_exact_match(sql):
 
 def _exact_match_colname(sql):
     cols = []
-    syntax_tree = sqlglot.parse_one(sql.lower(), read="spark")
+    syntax_tree = sqlglot.parse_one(sql.lower(), read=None)
     for tup in syntax_tree.walk():
         subtree = tup[0]
         depth = getattr(subtree, "depth", None)
@@ -295,7 +295,7 @@ class ComparisonLevel:
             return True
 
         try:
-            sqlglot.parse_one(sql, read="spark")
+            sqlglot.parse_one(sql, read=None)
         except sqlglot.ParseError as e:
             raise ValueError(f"Error parsing sql_statement:\n{sql}") from e
 
@@ -413,7 +413,7 @@ class ComparisonLevel:
         sql = f"""
         WHEN
         {self.comparison.gamma_column_name} = {self.comparison_vector_value}
-        THEN {self.bayes_factor}D
+        THEN cast({self.bayes_factor} as double)
         """
         return dedent(sql)
 
@@ -426,13 +426,13 @@ class ComparisonLevel:
 
         # A tf adjustment of 1D is a multiplier of 1.0, i.e. no adjustment
         if self.comparison_vector_value == -1:
-            sql = f"WHEN  {gamma_colname_value_is_this_level} then 1D"
+            sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
         elif not self.has_tf_adjustments:
-            sql = f"WHEN  {gamma_colname_value_is_this_level} then 1D"
+            sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
         elif self.tf_adjustment_weight == 0:
-            sql = f"WHEN  {gamma_colname_value_is_this_level} then 1D"
+            sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
         elif self.is_else_level:
-            sql = f"WHEN  {gamma_colname_value_is_this_level} then 1D"
+            sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
         else:
             tf_adj_col = self.tf_adjustment_input_column
 
@@ -467,11 +467,11 @@ class ComparisonLevel:
                 divisor_sql = f"""
                 (CASE
                     WHEN {coalesce_l_r} >= {coalesce_r_l}
-                    AND {coalesce_l_r} > {self.tf_minimum_u_value}D
+                    AND {coalesce_l_r} > cast({self.tf_minimum_u_value} as double)
                         THEN {coalesce_l_r}
-                    WHEN {coalesce_r_l}  > {self.tf_minimum_u_value}D
+                    WHEN {coalesce_r_l}  > cast({self.tf_minimum_u_value} as double)
                         THEN {coalesce_r_l}
-                    ELSE {self.tf_minimum_u_value}D
+                    ELSE cast({self.tf_minimum_u_value} as double)
                 END)
                 """
 
@@ -480,10 +480,10 @@ class ComparisonLevel:
                 (CASE WHEN {tf_adjustment_exists}
                 THEN
                 POW(
-                    {u_prob_exact_match}D /{divisor_sql},
-                    {self.tf_adjustment_weight}D
+                    cast({u_prob_exact_match} as double) /{divisor_sql},
+                    cast({self.tf_adjustment_weight} as double)
                 )
-                ELSE 1D
+                ELSE cast(1 as double)
                 END)
             """
         return dedent(sql).strip()

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -62,6 +62,9 @@ class DuckDBLinker(Linker):
         input_table_aliases: Union[str, list] = None,
     ):
 
+        if settings_dict is not None and "sql_dialect" not in settings_dict:
+            settings_dict["sql_dialect"] = "duckdb"
+
         if connection == ":memory:":
             con = duckdb.connect(database=connection)
         else:
@@ -124,8 +127,8 @@ class DuckDBLinker(Linker):
         # execute sql is only reached if the user has explicitly turned off the cache
         self.delete_table_from_database(physical_name)
 
-        # if transpile:
-        #     sql = sqlglot.transpile(sql, read=None, write="duckdb", pretty=True)[0]
+        if transpile:
+            sql = sqlglot.transpile(sql, read=None, write="duckdb", pretty=True)[0]
 
         logger.debug(
             execute_sql_logging_message_info(

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -124,8 +124,8 @@ class DuckDBLinker(Linker):
         # execute sql is only reached if the user has explicitly turned off the cache
         self.delete_table_from_database(physical_name)
 
-        if transpile:
-            sql = sqlglot.transpile(sql, read="spark", write="duckdb", pretty=True)[0]
+        # if transpile:
+        #     sql = sqlglot.transpile(sql, read=None, write="duckdb", pretty=True)[0]
 
         logger.debug(
             execute_sql_logging_message_info(

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -61,7 +61,9 @@ class EMTrainingSession:
         # use this instead
         if not comparisons_to_deactivate:
             comparisons_to_deactivate = []
-            br_cols = get_columns_used_from_sql(blocking_rule_for_training)
+            br_cols = get_columns_used_from_sql(
+                blocking_rule_for_training, self.settings_obj._sql_dialect
+            )
             for cc in self.settings_obj.comparisons:
                 cc_cols = cc.input_columns_used_by_case_statement
                 cc_cols = [c.input_name for c in cc_cols]

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -19,7 +19,7 @@ def compute_new_parameters(settings_obj: Settings):
            sum(1 - match_probability)/(select sum(1 - match_probability)
             from __splink__df_predict where {gamma_column} != -1) as u_probability,
 
-           "{comparison_name}" as comparison_name
+           '{comparison_name}' as comparison_name
     from __splink__df_predict
     where {gamma_column} != -1
     group by {gamma_column}
@@ -37,7 +37,7 @@ def compute_new_parameters(settings_obj: Settings):
     select 0 as comparison_vector_value,
            avg(match_probability) as m_probability,
            avg(1-match_probability) as u_probability,
-           "_proportion_of_matches" as comparison_name
+           '_proportion_of_matches' as comparison_name
     from __splink__df_predict
     """
     union_sqls.append(sql)

--- a/splink/files/settings_jsonschema.json
+++ b/splink/files/settings_jsonschema.json
@@ -213,6 +213,12 @@
       "title": "The prefix to use for the columns that will be created to store the comparison vector values",
       "default": "gamma_",
       "examples": ["gamma_", "__gamma__"]
+    },
+    "sql_dialect": {
+      "type": "string",
+      "title": "The SQL dialect in which sql_conditions are written.  Must be a valid sqlglot dialect",
+      "default": null,
+      "examples": ["spark", "duckdb", "presto"]
     }
   }
 }

--- a/splink/format_sql.py
+++ b/splink/format_sql.py
@@ -3,6 +3,6 @@ import sqlglot
 
 def format_sql(sql):
 
-    parsed_list = sqlglot.parse(sql, read="spark")
+    parsed_list = sqlglot.parse(sql, read=None)
     return_sql = [p.sql(dialect="spark", pretty=True) for p in parsed_list]
     return "\n".join(return_sql)

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -15,7 +15,7 @@ class InputColumn:
         # If settings_obj is None, then default values will be used
         # from the jsonschame
         self.settings_obj = settings_obj
-        self.has_tf_adjustments = tf_adjustments
+        self._has_tf_adjustments = tf_adjustments
 
         if name.endswith("_l"):
             self.input_name = name[:-2]
@@ -80,6 +80,9 @@ class InputColumn:
 
     @property
     def has_tf_adjustment(self):
+        if self._has_tf_adjustments is not None:
+            return self._has_tf_adjustments
+
         if self.settings_obj:
             if self.input_name in self.settings_obj._term_frequency_columns:
                 return True

--- a/splink/m_from_labels.py
+++ b/splink/m_from_labels.py
@@ -23,7 +23,7 @@ def estimate_m_from_pairwise_labels(linker, table_name):
     linker.enqueue_sql(sql, "__splink__df_comparison_vectors")
 
     sql = """
-    select *, 1.0D as match_probability
+    select *, cast(1.0 as double) as match_probability
     from __splink__df_comparison_vectors
     """
     linker.enqueue_sql(sql, "__splink__df_predict")

--- a/splink/m_training.py
+++ b/splink/m_training.py
@@ -35,7 +35,7 @@ def estimate_m_values_from_label_column(linker, df_dict, label_colname):
     training_linker.enqueue_sql(sql, "__splink__df_comparison_vectors")
 
     sql = """
-    select *, 1.0D as match_probability
+    select *, cast(1.0 as double) as match_probability
     from __splink__df_comparison_vectors
     """
     training_linker.enqueue_sql(sql, "__splink__df_predict")

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -10,7 +10,11 @@ def escape_columns(cols):
 
 
 def escape_column(col):
-    return f"`{col}`"
+    return f'"{col}"'
+
+
+def literal_column(col):
+    return f"'{col}'"
 
 
 def prob_to_bayes_factor(prob):

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -13,10 +13,6 @@ def escape_column(col):
     return f'"{col}"'
 
 
-def literal_column(col):
-    return f"'{col}'"
-
-
 def prob_to_bayes_factor(prob):
     return prob / (1 - prob)
 

--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -2,7 +2,7 @@ import sqlglot
 from sqlglot.expressions import Column, Bracket, Lambda
 
 
-def get_columns_used_from_sql(sql, dialect="spark", retain_table_prefix=False):
+def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
     column_names = set()
     syntax_tree = sqlglot.parse_one(sql, read=dialect)
     path = {}

--- a/splink/pipeline.py
+++ b/splink/pipeline.py
@@ -16,7 +16,7 @@ class SQLTask:
 
     @property
     def _uses_tables(self):
-        tree = sqlglot.parse_one(self.sql, read="spark")
+        tree = sqlglot.parse_one(self.sql, read=None)
 
         table_names = set()
         for subtree, parent, key in tree.walk():

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -40,7 +40,7 @@ def predict_from_comparison_vectors_sql(
     bayes_factor = prob_to_bayes_factor(proportion_of_matches)
 
     bayes_factor_expr = " * ".join(mult)
-    bayes_factor_expr = f"{bayes_factor}D * {bayes_factor_expr}"
+    bayes_factor_expr = f"cast({bayes_factor} as double) * {bayes_factor_expr}"
 
     # In case user provided both, take the minimum of the two thresholds
     if threshold_match_probability or threshold_match_weight:

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -19,6 +19,8 @@ class Settings:
         self._settings_dict = settings_dict
 
         ccs = self._settings_dict["comparisons"]
+        s_else_d = self.from_settings_dict_else_default
+        self._sql_dialect = s_else_d("sql_dialect")
 
         self.comparisons = []
         for cc in ccs:
@@ -28,7 +30,6 @@ class Settings:
                 cc.settings_obj = self
                 self.comparisons.append(Comparison)
 
-        s_else_d = self.from_settings_dict_else_default
         self._link_type = s_else_d("link_type")
         self._proportion_of_matches = s_else_d("proportion_of_matches")
         self._em_convergence = s_else_d("em_convergence")

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -65,6 +65,9 @@ class SparkLinker(Linker):
         spark=None,
     ):
 
+        if settings_dict is not None and "sql_dialect" not in settings_dict:
+            settings_dict["sql_dialect"] = "spark"
+
         self.break_lineage_method = break_lineage_method
         self.persist_level = persist_level
 

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -1,4 +1,5 @@
 import logging
+import sqlglot
 from typing import Union
 import re
 from pyspark.sql import Row
@@ -138,6 +139,9 @@ class SparkLinker(Linker):
         return spark_df
 
     def execute_sql(self, sql, templated_name, physical_name, transpile=True):
+
+        if transpile:
+            sql = sqlglot.transpile(sql, read=None, write="spark", pretty=True)[0]
 
         spark_df = self.spark.sql(sql)
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -19,7 +19,7 @@ def _remove_table_prefix(node):
 
 
 def move_l_r_table_prefix_to_column_suffix(blocking_rule):
-    expression_tree = sqlglot.parse_one(blocking_rule, read="spark")
+    expression_tree = sqlglot.parse_one(blocking_rule, read=None)
     transformed_tree = expression_tree.transform(_add_l_or_r_to_identifier)
     transformed_tree = transformed_tree.transform(_remove_table_prefix)
     return transformed_tree.sql()

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -87,6 +87,10 @@ class SQLiteLinker(Linker):
         set_up_basic_logging=True,
         input_table_aliases: Union[str, list] = None,
     ):
+
+        if settings_dict is not None and "sql_dialect" not in settings_dict:
+            settings_dict["sql_dialect"] = "sqlite"
+
         self.con = connection
         self.con.row_factory = dict_factory
         self.con.create_function("log2", 1, log2)

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -106,7 +106,7 @@ class SQLiteLinker(Linker):
     def execute_sql(self, sql, templated_name, physical_name, transpile=True):
 
         if transpile:
-            sql = sqlglot.transpile(sql, read="spark", write="sqlite")[0]
+            sql = sqlglot.transpile(sql, read=None, write="sqlite")[0]
 
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
         logger.log(5, log_sql(sql))

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -47,8 +47,8 @@ def join_tf_to_input_df(settings_obj):
         tf_col = escape_column(f"tf_{col}")
         select_cols.append(f"{tbl}.{tf_col}")
 
+    select_cols.insert(0, "__splink__df_concat.*")
     select_cols = ", ".join(select_cols)
-    select_cols = "__splink__df_concat.*, " + select_cols
 
     templ = "left join {tbl} on __splink__df_concat.{col} = {tbl}.{col}"
 

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from .misc import escape_column, literal_column
+from .misc import escape_column
 from .input_column import InputColumn
 
 logger = logging.getLogger(__name__)

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -3,7 +3,8 @@
 
 import logging
 
-from .misc import escape_column
+from .misc import escape_column, literal_column
+from .input_column import InputColumn
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +18,16 @@ def term_frequencies_for_single_column_sql(
     column_name, table_name="__splink__df_concat"
 ):
 
-    tf_col_name = escape_column(f"tf_{column_name}")
+    # TODO: Not escaped so if col name has a space, will fail in Spark
+
+    col = InputColumn(column_name, tf_adjustments=True)
+
     col_name = escape_column(column_name)
 
     sql = f"""
     select
     {col_name}, cast(count(*) as double) / (select
-        count({col_name}) as total from {table_name}) as {tf_col_name}
+        count({col_name}) as total from {table_name}) as {col.tf_name(escape=False)}
     from {table_name}
     where {col_name} is not null
     group by {col_name}

--- a/splink/u_training.py
+++ b/splink/u_training.py
@@ -87,7 +87,7 @@ def estimate_u_values(linker, target_rows):
     training_linker.enqueue_sql(sql, "__splink__df_comparison_vectors")
 
     sql = """
-    select *, 0.0D as match_probability
+    select *, cast(0.0 as double) as match_probability
     from __splink__df_comparison_vectors
     """
     training_linker.enqueue_sql(sql, "__splink__df_predict")

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -10,12 +10,28 @@ def test_full_example_duckdb(tmp_path):
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
+
+    # Overwrite the surname comparison to include duck-db specific syntax
+    surname_match_level = {
+        "sql_condition": "jaccard(surname_l, surname_r)",
+        # "sql_condition": "surname_l similar to surname_r",
+        "label_for_charts": "Exact match",
+        "m_probability": 0.9,
+        "u_probability": 0.1,
+    }
+
+    settings_dict["comparisons"][1]["comparison_levels"][1] = surname_match_level
+
     linker = DuckDBLinker(
         df,
         settings_dict,
         connection=os.path.join(tmp_path, "duckdb.db"),
         output_schema="splink_in_duckdb",
     )
+
+    # linker.analyse_blocking_rule(
+    #     "l.first_name = r.first_name and l.surname = r.surname"
+    # )
 
     linker.profile_columns(
         ["first_name", "surname", "first_name || surname", "concat(city, first_name)"]

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -8,6 +8,18 @@ from basic_settings import get_settings_dict
 
 def test_full_example_spark(df_spark, tmp_path):
     settings_dict = get_settings_dict()
+
+    # Overwrite the surname comparison to include duck-db specific syntax
+    surname_match_level = {
+        "sql_condition": "`surname_l` = `surname_r`",
+        # "sql_condition": "surname_l similar to surname_r",
+        "label_for_charts": "Exact match",
+        "m_probability": 0.9,
+        "u_probability": 0.1,
+    }
+
+    settings_dict["comparisons"][1]["comparison_levels"][1] = surname_match_level
+
     linker = SparkLinker(df_spark, settings_dict)
 
     linker.profile_columns(


### PR DESCRIPTION

Robin
Problem:
At present, all the main SQL algorithms (blocking, EM etc.) are written in the pyspark dialect of SQL.
When we compute the comparison vectors, any custom sql expression  provided by the users are interpolated into the SQL that computes the comparison vectors.
This means that if you are using a non-PySpark linker (e.g. DuckDB), you have to provide your custom sql using the PySpark dialect, which is counterintuitive.
The ‘obvious’ solution would be for the user to provide DuckDB custom SQL expressions.
But there are a few issues with this:
We can’t interpolate duckdb SQL into a PySpark template and expect transpilation to work, because the SQL statement won’t parse
Our canned SQL statements in comparison_library are currently PySpark, a bit unclear how this would work with multiple flavours
A setting object written for one linker (e.g. the duckdb linker) does not necessarily automatically work in other linkers.  The user would have to translate their custom sql expressions by hand
(edited)

Robin
I don’t have a perfect solution for this at the moment.
But wanted to note down the issues while I’m thinking about it.
I think ideal solution would be that user provides custom SQL corresponding to their linker (so duckdb dialect sql if they’re using the duckdb linker etc).
And that splink throws a warning if you provide SQL in the wrong dialect (edited) 

Sam
Could the settings include a native dialect field so comparisons can be auto-generated or custom ones translated to whatever linker is used?

Theo
another point of view....
having one (pyspark) as the standard is not as counterintuitive as you might think.
having end users (and not expert end-users ) worry about dialects from the start might be more confusing. Agree that there is no easy solution.
Again it falls down to trying to have sensible defaults  (whatever ones we choose in the end)

Sam
Yeah so I was imagining settings["sql_dialect"] = "spark" by default and all the current expressions being used. Then if users want to write their own custom expressions they specify which dialect and then splink translates any of our home grown Pyspark expressions into that dialect as part of complete_settings_dict

Sam
Then to get around the issue of using a DuckDB model with the spark linker, the linkers can translate the settings from their specified native dialect to the required dialect (edited) 
:+1:
1


Sam
Unless I'm overestimating what we can reliably do with sqlglot...

Tom
Sam’s suggestion seems the simplest :point_up_2:
You could take the user’s SQL statements, transpile them to pyspark in the initialisation steps and then the pipeline will work as is (at least in theory).
The native dialect can also be inherited from the specific linker selected by the user, if no sql_dialect is added into the settings dictionary.
:point_up:
2
:+1:
2

