### PR TITLE
change benchmark names

### DIFF
--- a/benchmarking/benchmark_connected_components.py
+++ b/benchmarking/benchmark_connected_components.py
@@ -13,7 +13,7 @@ from tests.cc_testing_utils import (
 seed = 5
 
 
-def test_500_edge_performance(benchmark):
+def test_500_node_performance(benchmark):
     g = generate_random_graph(graph_size=500, seed=seed)
     linker = register_cc_df(g)
 
@@ -26,7 +26,7 @@ def test_500_edge_performance(benchmark):
     )
 
 
-def test_10000_edge_performance(benchmark):
+def test_10000_node_performance(benchmark):
     g = generate_random_graph(graph_size=10000, seed=seed)
     linker = register_cc_df(g)
 
@@ -39,7 +39,7 @@ def test_10000_edge_performance(benchmark):
     )
 
 
-def test_100000_edge_performance(benchmark):
+def test_100000_node_performance(benchmark):
     g = generate_random_graph(graph_size=100000, seed=seed)
     linker = register_cc_df(g)
 


### PR DESCRIPTION
Quick fix to the names of our benchmarks...

![Screenshot 2022-05-01 at 21 38 05](https://user-images.githubusercontent.com/45356472/166163702-62465868-c2a5-4d85-acc5-ddc48cad51c9.png)
