### PR TITLE
Athena linker input tables as lists

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -188,27 +188,11 @@ class AthenaLinker(Linker):
             input_table_or_tables, input_table_aliases
         )
 
-        # 'homogenised' means all entries are strings representing tables
-        homogenised_tables = []
-        homogenised_aliases = []
-
-        for i, (table, alias) in enumerate(zip(input_tables, input_aliases)):
-
-            if type(alias).__name__ == "DataFrame":
-                alias = f"__splink__input_table_{i}"
-
-            if type(table).__name__ == "DataFrame":
-                con.register(alias, table)
-                table = alias
-
-            homogenised_tables.append(table)
-            homogenised_aliases.append(alias)
-
         super().__init__(
-            homogenised_tables,
+            input_table_or_tables,
             settings_dict,
             set_up_basic_logging,
-            input_table_aliases=homogenised_aliases,
+            input_table_aliases=input_table_aliases,
         )
 
         self.output_schema = output_database

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -115,18 +115,21 @@ class AthenaLinker(Linker):
         See linker.py for more information on the main linker class.
 
         Attributes:
-            input_table_or_tables: A list, str or pandas dataframe object that contains your
-                data or the name of your data to link and/or dedupe.
-            boto3_session (boto3.session.Session): A working boto3 session, which should contain
-                user credentials and region information.
-            output_database (str): The name of the database you wish to export the results
-                of the link job to. This should be created prior to performing your link.
-            output_bucket (str): The name of the bucket and the filepath you wish to store your
-                outputs in on aws. The bucket should be created prior to performing your link.
+            input_table_or_tables: A list, str or pandas dataframe object that contains
+                your data or the name of your data to link and/or dedupe.
+            boto3_session (boto3.session.Session): A working boto3 session, which
+                should contain user credentials and region information.
+            output_database (str): The name of the database you wish to export the
+                results of the link job to. This should be created prior to performing
+                your link.
+            output_bucket (str): The name of the bucket and the filepath you wish to
+                store your outputs in on aws. The bucket should be created prior to
+                performing your link.
             settings_dict (dict): A splink settings dictionary.
             input_table_aliases: Aliases/custom names for your input tables, if
-                a pandas df or a list of dfs are used as inputs. None by default, which saves
-                your tables under a custom name: '__splink__input_table_{n}'; where n is the list index.
+                a pandas df or a list of dfs are used as inputs. None by default, which
+                saves your tables under a custom name: '__splink__input_table_{n}';
+                where n is the list index.
             set_up_basic_logging (bool): Set up basic logging for splink. This logs ...
                 True by default.
 
@@ -137,8 +140,7 @@ class AthenaLinker(Linker):
             >>>
             >>> from splink.athena.athena_linker import AthenaLinker
             >>> import boto3
-            >>> # Create a session - please see the boto3 documentation for more info:
-            >>> # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+            >>> # Create a session - please see the boto3 documentation for more info
             >>> my_session = boto3.Session(region_name="eu-west-1")
             >>>
             >>> linker = AthenaLinker(
@@ -181,12 +183,6 @@ class AthenaLinker(Linker):
             output_bucket,
         )
         self.ctas_query_info = {}
-
-        input_tables = self._coerce_to_list(input_table_or_tables)
-
-        input_aliases = self._ensure_aliases_populated_and_is_list(
-            input_table_or_tables, input_table_aliases
-        )
 
         super().__init__(
             input_table_or_tables,

--- a/splink/athena/athena_utils.py
+++ b/splink/athena/athena_utils.py
@@ -8,7 +8,6 @@ class boto_utils:
         self,
         boto3_session: boto3.session.Session,
         output_bucket: str,
-        folder_in_bucket_for_outputs: str,
     ):
 
         if not type(boto3_session) == boto3.session.Session:
@@ -16,7 +15,6 @@ class boto_utils:
 
         self.boto3_session = boto3_session
         self.bucket = output_bucket
-        self.folder_in_bucket_for_outputs = folder_in_bucket_for_outputs
         self.session_id = uuid4().hex[:10]
 
         # specify some additional prefixes
@@ -28,7 +26,6 @@ class boto_utils:
         out_path = os.path.join(
             "s3://",
             self.bucket,
-            self.folder_in_bucket_for_outputs,
             self.s3_output_name_prefix,
             self.session_id,
         )

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -826,7 +826,29 @@ class Linker:
 
         return predictions
 
-    def cluster_predictions(self, match_probability_threshold=0.9):
+    def cluster_predictions(self, threshold_match_probability=0.99):
+
+        """This method clusters your linked or deduped records
+        into single groups, for easier visualisation and analysis.
+
+        It uses the output generated in linker.predict(), or - if this doesn't exist
+        in your database - automatically runs the predict method.
+
+        A match probability threshold can be manually set by the user to
+        filter for specific pairwise match comparisons.
+
+        Args:
+            threshold_match_probability (float):
+                Filter the results of linker.predict() to include only
+                pairwise comparisons with a match_probability above this
+                threshold. This dataframe is then fed into the clustering
+                algorithm.
+
+        Returns:
+            SplinkDataFrame: A SplinkDataFrame dataframe containing a list of
+            all IDs, clustered into groups based on the desired match threshold.
+
+        """
 
         # Using our caching system, either grab the edges table
         # or run the predict() step to generate it.
@@ -835,7 +857,7 @@ class Linker:
         # the code will error.
         edges_table = _cc_create_unique_id_cols(
             self,
-            match_probability_threshold,
+            threshold_match_probability,
         )
 
         cc = solve_connected_components(self, edges_table)


### PR DESCRIPTION
Updates `AthenaLinker` to use the new methodology laid out in the [following PR](https://github.com/moj-analytical-services/splink/pull/416).

Also includes some improved docstrings for athena linker and clustering code.

@RobinL do you want any tests for athena added to the `tests` folder, just with unique names so they don't get triggered by `pytest`? I can also create some random gists for our personal use.