### PR TITLE
add duckdb connection validator

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -41,7 +41,7 @@ def validate_duckdb_connection(connection):
         return
 
     logger.info(
-        f"The registered connection -- {connection} -- is ambiguous. "
+        f"The registered connection -- {connection} -- has an uncommon file type. "
         "We recommend that you add a clear suffix of '.db' or '.duckdb' "
         "to the connection string, when generating an on-disk database."
     )

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -15,6 +15,38 @@ from ..logging_messages import execute_sql_logging_message_info, log_sql
 logger = logging.getLogger(__name__)
 
 
+def validate_duckdb_connection(connection):
+
+    """Check if the duckdb connection requested by the user is valid.
+
+    Raises:
+        Exception: If the connection is invalid or a warning if
+        the naming convention is ambiguous (not adhering to the
+        duckdb convention).
+    """
+
+    if not isinstance(connection, str):
+        raise Exception(
+            "Connection must be a string in the form: :memory:, :temporary: "
+            "or the name of a new or existing duckdb database."
+        )
+
+    connection = connection.lower()
+
+    if connection in [":memory:", ":temporary:"]:
+        return
+
+    suffixes = (".duckdb", ".db")
+    if connection.endswith(suffixes):
+        return
+
+    logger.info(
+        f"The registered connection -- {connection} -- is ambiguous. "
+        "We recommend that you add a clear suffix of '.db' or '.duckdb' "
+        "to the connection string, when generating a custom database."
+    )
+
+
 class DuckDBLinkerDataFrame(SplinkDataFrame):
     def __init__(self, templated_name, physical_name, duckdb_linker):
         super().__init__(templated_name, physical_name)
@@ -64,6 +96,8 @@ class DuckDBLinker(Linker):
 
         if settings_dict is not None and "sql_dialect" not in settings_dict:
             settings_dict["sql_dialect"] = "duckdb"
+
+        validate_duckdb_connection(connection)
 
         if connection == ":memory:":
             con = duckdb.connect(database=connection)

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -43,7 +43,7 @@ def validate_duckdb_connection(connection):
     logger.info(
         f"The registered connection -- {connection} -- is ambiguous. "
         "We recommend that you add a clear suffix of '.db' or '.duckdb' "
-        "to the connection string, when generating a custom database."
+        "to the connection string, when generating an on-disk database."
     )
 
 


### PR DESCRIPTION
Quick one for you. This simply evaluates the `connection` string entered by the user and either returns an error if it invalid, or returns a debugger warning if they enter an ambiguous name, such as `test`.

**This does not:** - enforce a syntax for connection names or error on potential misspellings
For example, `:memory` would become an on-disk db with our current code.

For some quick examples:
```
# Setup
from splink.duckdb.duckdb_linker import DuckDBLinker
import pandas as pd

df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
```

##### These all pass without issue
```
DuckDBLinker(df, connection = ":memory:")
DuckDBLinker(df, connection = ":temporary:")
DuckDBLinker(df, connection = "test.duckdb")
```

##### These both error...
```
DuckDBLinker(df, connection = 1)
DuckDBLinker(df, connection = None)
```

##### This sends a debugger message warning that it's ambiguous
```
DuckDBLinker(df, connection = "test")
```