### PR TITLE
Update the graphframe test to include virtualenv conf element

### DIFF
--- a/splink/cluster.py
+++ b/splink/cluster.py
@@ -75,6 +75,7 @@ def _check_graphframes_installation(spark):
         "spark.app.initial.file.urls",
         "spark.files",
         "spark.app.initial.jar.urls",
+        "spark.pyspark.virtualenv.packages",
     ]
 
     graphframe_jar_registered = False


### PR DESCRIPTION
This test seems somewhat ill conceived given the range of hosted spark environments out there - this patch is a fix for aws emr under virtualenv but I suspect its a sticking plaster. 