### PR TITLE
Comparisons can be specified as objects in settings

### DIFF
--- a/benchmarking/test_performance.py
+++ b/benchmarking/test_performance.py
@@ -13,7 +13,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 
 first_name_cc = {
-    "column_name": "first_name",
+    "output_column_name": "first_name",
     "comparison_levels": [
         {
             "sql_condition": "first_name_l IS NULL OR first_name_r IS NULL",
@@ -44,7 +44,7 @@ first_name_cc = {
 }
 
 surname_cc = {
-    "column_name": "surname",
+    "output_column_name": "surname",
     "comparison_levels": [
         {
             "sql_condition": "surname_l IS NULL OR surname_r IS NULL",
@@ -67,7 +67,7 @@ surname_cc = {
 }
 
 dob_cc = {
-    "column_name": "dob",
+    "output_column_name": "dob",
     "comparison_levels": [
         {
             "sql_condition": "dob_l IS NULL OR dob_r IS NULL",
@@ -90,7 +90,7 @@ dob_cc = {
 }
 
 email_cc = {
-    "column_name": "email",
+    "output_column_name": "email",
     "comparison_levels": [
         {
             "sql_condition": "email_l IS NULL OR email_r IS NULL",
@@ -113,7 +113,7 @@ email_cc = {
 }
 
 city_cc = {
-    "column_name": "city",
+    "output_column_name": "city",
     "comparison_levels": [
         {
             "sql_condition": "city_l IS NULL OR city_r IS NULL",

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -35,7 +35,7 @@ class Comparison:
         counter = num_levels - 1
 
         for level in self.comparison_levels:
-            if level.is_null_level:
+            if level._is_null_level:
                 level.comparison_vector_value = -1
                 level.max_level = False
             else:
@@ -52,11 +52,11 @@ class Comparison:
 
     @property
     def _num_levels(self):
-        return len([cl for cl in self.comparison_levels if not cl.is_null_level])
+        return len([cl for cl in self.comparison_levels if not cl._is_null_level])
 
     @property
     def _comparison_levels_excluding_null(self):
-        return [cl for cl in self.comparison_levels if not cl.is_null_level]
+        return [cl for cl in self.comparison_levels if not cl._is_null_level]
 
     @property
     def _gamma_prefix(self):
@@ -339,7 +339,9 @@ class Comparison:
 
         return records
 
-    def _get_comparison_level_by_comparison_vector_value(self, value):
+    def _get_comparison_level_by_comparison_vector_value(
+        self, value
+    ) -> ComparisonLevel:
         for cl in self.comparison_levels:
 
             if cl.comparison_vector_value == value:

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -254,7 +254,7 @@ class Comparison:
     @property
     def as_dict(self):
         return {
-            "column_name": self._output_column_name,
+            "output_column_name": self._output_column_name,
             "comparison_levels": [cl.as_dict for cl in self.comparison_levels],
         }
 

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -31,7 +31,7 @@ class Comparison:
         self._settings_obj: "Settings" = settings_obj
 
         # Assign comparison vector values starting at highest level, count down to 0
-        num_levels = self.num_levels
+        num_levels = self._num_levels
         counter = num_levels - 1
 
         for level in self.comparison_levels:
@@ -51,54 +51,54 @@ class Comparison:
         return cc
 
     @property
-    def num_levels(self):
+    def _num_levels(self):
         return len([cl for cl in self.comparison_levels if not cl.is_null_level])
 
     @property
-    def comparison_levels_excluding_null(self):
+    def _comparison_levels_excluding_null(self):
         return [cl for cl in self.comparison_levels if not cl.is_null_level]
 
     @property
-    def gamma_prefix(self):
+    def _gamma_prefix(self):
         return self._settings_obj._gamma_prefix
 
     @property
-    def retain_intermediate_calculation_columns(self):
+    def _retain_intermediate_calculation_columns(self):
         return self._settings_obj._retain_intermediate_calculation_columns
 
     @property
-    def bf_column_name(self):
-        return f"{self._settings_obj._bf_prefix}{self.output_column_name}".replace(
+    def _bf_column_name(self):
+        return f"{self._settings_obj._bf_prefix}{self._output_column_name}".replace(
             " ", "_"
         )
 
     @property
-    def bf_tf_adj_column_name(self):
+    def _bf_tf_adj_column_name(self):
         bf = self._settings_obj._bf_prefix
         tf = self._settings_obj._tf_prefix
-        cc_name = self.output_column_name
+        cc_name = self._output_column_name
         return f"{bf}{tf}adj_{cc_name}".replace(" ", "_")
 
     @property
-    def has_tf_adjustments(self):
-        return any([cl.has_tf_adjustments for cl in self.comparison_levels])
+    def _has_tf_adjustments(self):
+        return any([cl._has_tf_adjustments for cl in self.comparison_levels])
 
     @property
-    def case_statement(self):
+    def _case_statement(self):
 
         sqls = [
-            cl.when_then_comparison_vector_value_sql for cl in self.comparison_levels
+            cl._when_then_comparison_vector_value_sql for cl in self.comparison_levels
         ]
         sql = " ".join(sqls)
-        sql = f"CASE {sql} END as {self.gamma_column_name}"
+        sql = f"CASE {sql} END as {self._gamma_column_name}"
 
         return sql
 
     @property
-    def input_columns_used_by_case_statement(self):
+    def _input_columns_used_by_case_statement(self):
         cols = []
         for cl in self.comparison_levels:
-            cols.extend(cl.input_columns_used_by_sql_condition)
+            cols.extend(cl._input_columns_used_by_sql_condition)
 
         # dedupe_preserving_order on input column
         already_observed = []
@@ -111,11 +111,11 @@ class Comparison:
         return deduped_cols
 
     @property
-    def output_column_name(self):
+    def _output_column_name(self):
         if "output_column_name" in self._comparison_dict:
             return self._comparison_dict["output_column_name"]
         else:
-            cols = self.input_columns_used_by_case_statement
+            cols = self._input_columns_used_by_case_statement
             cols = [c.input_name for c in cols]
             if len(cols) == 1:
                 return cols[0]
@@ -123,58 +123,58 @@ class Comparison:
                 return f"custom_{'_'.join(cols)}"
 
     @property
-    def comparison_description(self):
+    def _comparison_description(self):
         if "comparison_description" in self._comparison_dict:
             return self._comparison_dict["comparison_description"]
         else:
-            return self.output_column_name
+            return self._output_column_name
 
     @property
-    def gamma_column_name(self):
-        return f"{self.gamma_prefix}{self.output_column_name}".replace(" ", "_")
+    def _gamma_column_name(self):
+        return f"{self._gamma_prefix}{self._output_column_name}".replace(" ", "_")
 
     @property
-    def tf_adjustment_input_col_names(self):
+    def _tf_adjustment_input_col_names(self):
         cols = [cl._tf_adjustment_input_column_name for cl in self.comparison_levels]
         cols = [c for c in cols if c]
 
         return cols
 
     @property
-    def columns_to_select_for_blocking(self):
+    def _columns_to_select_for_blocking(self):
         cols = []
         for cl in self.comparison_levels:
-            cols.extend(cl.columns_to_select_for_blocking)
+            cols.extend(cl._columns_to_select_for_blocking)
 
         return dedupe_preserving_order(cols)
 
     @property
-    def columns_to_select_for_comparison_vector_values(self):
+    def _columns_to_select_for_comparison_vector_values(self):
 
         input_cols = []
         for cl in self.comparison_levels:
-            input_cols.extend(cl.input_columns_used_by_sql_condition)
+            input_cols.extend(cl._input_columns_used_by_sql_condition)
 
         output_cols = []
         for col in input_cols:
             if self._settings_obj._retain_matching_columns:
                 output_cols.extend(col.names_l_r())
 
-        output_cols.append(self.case_statement)
+        output_cols.append(self._case_statement)
 
         for col in input_cols:
 
-            if self.has_tf_adjustments:
+            if self._has_tf_adjustments:
                 output_cols.extend(col.tf_name_l_r())
 
         return dedupe_preserving_order(output_cols)
 
     @property
-    def columns_to_select_for_bayes_factor_parts(self):
+    def _columns_to_select_for_bayes_factor_parts(self):
 
         input_cols = []
         for cl in self.comparison_levels:
-            input_cols.extend(cl.input_columns_used_by_sql_condition)
+            input_cols.extend(cl._input_columns_used_by_sql_condition)
 
         output_cols = []
         for col in input_cols:
@@ -182,38 +182,38 @@ class Comparison:
 
                 output_cols.extend(col.names_l_r())
 
-        output_cols.append(self.gamma_column_name)
+        output_cols.append(self._gamma_column_name)
 
         for col in input_cols:
 
-            if self.has_tf_adjustments:
+            if self._has_tf_adjustments:
                 if self._settings_obj._retain_intermediate_calculation_columns:
 
                     output_cols.extend(col.tf_name_l_r())
 
         # Bayes factor case when statement
-        sqls = [cl.bayes_factor_sql for cl in self.comparison_levels]
+        sqls = [cl._bayes_factor_sql for cl in self.comparison_levels]
         sql = " ".join(sqls)
-        sql = f"CASE {sql} END as {self.bf_column_name} "
+        sql = f"CASE {sql} END as {self._bf_column_name} "
         output_cols.append(sql)
 
         # tf adjustment case when statement
 
-        if self.has_tf_adjustments:
-            sqls = [cl.tf_adjustment_sql for cl in self.comparison_levels]
+        if self._has_tf_adjustments:
+            sqls = [cl._tf_adjustment_sql for cl in self.comparison_levels]
             sql = " ".join(sqls)
-            sql = f"CASE {sql} END as {self.bf_tf_adj_column_name} "
+            sql = f"CASE {sql} END as {self._bf_tf_adj_column_name} "
             output_cols.append(sql)
-        output_cols.append(self.gamma_column_name)
+        output_cols.append(self._gamma_column_name)
 
         return dedupe_preserving_order(output_cols)
 
     @property
-    def columns_to_select_for_predict(self):
+    def _columns_to_select_for_predict(self):
 
         input_cols = []
         for cl in self.comparison_levels:
-            input_cols.extend(cl.input_columns_used_by_sql_condition)
+            input_cols.extend(cl._input_columns_used_by_sql_condition)
 
         output_cols = []
         for col in input_cols:
@@ -224,28 +224,28 @@ class Comparison:
             self._settings_obj._training_mode
             or self._settings_obj._retain_matching_columns
         ):
-            output_cols.append(self.gamma_column_name)
+            output_cols.append(self._gamma_column_name)
 
         for col in input_cols:
             if self._settings_obj._retain_intermediate_calculation_columns:
-                if self.has_tf_adjustments:
+                if self._has_tf_adjustments:
 
                     output_cols.extend(col.tf_name_l_r())
 
-                output_cols.extend(self.match_weight_columns_to_multiply)
+                output_cols.extend(self._match_weight_columns_to_multiply)
 
         return dedupe_preserving_order(output_cols)
 
     @property
-    def match_weight_columns_to_multiply(self):
+    def _match_weight_columns_to_multiply(self):
         cols = []
-        cols.append(self.bf_column_name)
-        if self.has_tf_adjustments:
-            cols.append(self.bf_tf_adj_column_name)
+        cols.append(self._bf_column_name)
+        if self._has_tf_adjustments:
+            cols.append(self._bf_tf_adj_column_name)
         return cols
 
     @property
-    def term_frequency_columns(self):
+    def _term_frequency_columns(self):
         cols = set()
         for cl in self.comparison_levels:
             cols.add(cl.tf_adjustment_input_col_name)
@@ -254,92 +254,92 @@ class Comparison:
     @property
     def as_dict(self):
         return {
-            "column_name": self.output_column_name,
+            "column_name": self._output_column_name,
             "comparison_levels": [cl.as_dict for cl in self.comparison_levels],
         }
 
     @property
     def as_completed_dict(self):
         return {
-            "column_name": self.output_column_name,
+            "column_name": self._output_column_name,
             "comparison_levels": [
                 cl.as_completed_dict for cl in self.comparison_levels
             ],
             "input_columns_used_by_case_statement": [
-                c.input_name for c in self.input_columns_used_by_case_statement
+                c.input_name for c in self._input_columns_used_by_case_statement
             ],
         }
 
     @property
-    def has_estimated_m_values(self):
+    def _has_estimated_m_values(self):
         return all(cl._has_estimated_m_values for cl in self.comparison_levels)
 
     @property
-    def has_estimated_u_values(self):
+    def _has_estimated_u_values(self):
         return all(cl._has_estimated_u_values for cl in self.comparison_levels)
 
     @property
-    def all_m_are_trained(self):
-        return all(cl.m_is_trained for cl in self.comparison_levels)
+    def _all_m_are_trained(self):
+        return all(cl._m_is_trained for cl in self.comparison_levels)
 
     @property
-    def all_u_are_trained(self):
-        return all(cl.u_is_trained for cl in self.comparison_levels)
+    def _all_u_are_trained(self):
+        return all(cl._u_is_trained for cl in self.comparison_levels)
 
     @property
-    def some_m_are_trained(self):
-        return any(cl.m_is_trained for cl in self.comparison_levels_excluding_null)
+    def _some_m_are_trained(self):
+        return any(cl._m_is_trained for cl in self._comparison_levels_excluding_null)
 
     @property
-    def some_u_are_trained(self):
-        return any(cl.u_is_trained for cl in self.comparison_levels_excluding_null)
+    def _some_u_are_trained(self):
+        return any(cl._u_is_trained for cl in self._comparison_levels_excluding_null)
 
     @property
-    def is_trained_message(self):
+    def _is_trained_message(self):
         messages = []
-        if self.all_m_are_trained and self.all_u_are_trained:
+        if self._all_m_are_trained and self._all_u_are_trained:
             return None
 
-        if not self.some_u_are_trained:
+        if not self._some_u_are_trained:
             messages.append("no u values are trained")
-        elif self.some_u_are_trained and not self.all_u_are_trained:
+        elif self._some_u_are_trained and not self._all_u_are_trained:
             messages.append("some u values are not trained")
 
-        if not self.some_m_are_trained:
+        if not self._some_m_are_trained:
             messages.append("no m values are trained")
-        elif self.some_m_are_trained and not self.all_m_are_trained:
+        elif self._some_m_are_trained and not self._all_m_are_trained:
             messages.append("some m values are not trained")
 
         message = ", ".join(messages)
-        message = f"    - {self.output_column_name} ({message})."
+        message = f"    - {self._output_column_name} ({message})."
         return message
 
     @property
-    def is_trained(self):
-        return self.all_m_are_trained and self.all_u_are_trained
+    def _is_trained(self):
+        return self._all_m_are_trained and self._all_u_are_trained
 
     @property
-    def as_detailed_records(self):
+    def _as_detailed_records(self):
         records = []
         for cl in self.comparison_levels:
             record = {}
-            record["comparison_name"] = self.output_column_name
-            record = {**record, **cl.as_detailed_record}
+            record["comparison_name"] = self._output_column_name
+            record = {**record, **cl._as_detailed_record}
             records.append(record)
         return records
 
     @property
-    def parameter_estimates_as_records(self):
+    def _parameter_estimates_as_records(self):
         records = []
         for cl in self.comparison_levels:
-            new_records = cl.parameter_estimates_as_records
+            new_records = cl._parameter_estimates_as_records
             for r in new_records:
-                r["comparison_name"] = self.output_column_name
+                r["comparison_name"] = self._output_column_name
             records.extend(new_records)
 
         return records
 
-    def get_comparison_level_by_comparison_vector_value(self, value):
+    def _get_comparison_level_by_comparison_vector_value(self, value):
         for cl in self.comparison_levels:
 
             if cl.comparison_vector_value == value:
@@ -348,24 +348,24 @@ class Comparison:
 
     def __repr__(self):
         return (
-            f"<Comparison {self.comparison_description} with "
-            f"{self.num_levels} levels at {hex(id(self))}>"
+            f"<Comparison {self._comparison_description} with "
+            f"{self._num_levels} levels at {hex(id(self))}>"
         )
 
     @property
-    def not_trained_messages(self):
+    def _not_trained_messages(self):
 
         msgs = []
 
-        cname = self.output_column_name
+        cname = self._output_column_name
 
         header = f"Comparison: '{cname}':\n"
 
         msg_template = "{header}    {m_or_u} values not fully trained"
 
-        if not self.all_m_are_trained:
+        if not self._all_m_are_trained:
             msgs.append(msg_template.format(header=header, m_or_u="m"))
-        if not self.all_u_are_trained:
+        if not self._all_u_are_trained:
             msgs.append(msg_template.format(header=header, m_or_u="u"))
 
         return msgs

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -56,6 +56,15 @@ def _exact_match_colname(sql):
 
 
 class ComparisonLevel:
+    """Defines a way in which the similarity between one or more columns of a pairwise
+    comparisons is assessed.
+
+    For example, the Comparison for first_name comparison may have an exact match level,
+    a levenstein similarity level and an 'all other comparisons' level
+
+    A Comparison will have several ComparisonLevels. A Splink model will have several
+    Comparisons (e.g. name, dob, postcode, etc.)"""
+
     def __init__(
         self,
         level_dict,
@@ -527,10 +536,10 @@ class ComparisonLevel:
         if self._level_dict.get("label_for_charts"):
             output["label_for_charts"] = self._label_for_charts
 
-        if self.m_probability:
+        if self.m_probability and self._m_is_trained:
             output["m_probability"] = self.m_probability
 
-        if self.u_probability:
+        if self.u_probability and self._u_is_trained:
             output["u_probability"] = self.u_probability
 
         if self._has_tf_adjustments:

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -89,7 +89,7 @@ class ComparisonLevel:
         # is part of  a Comparison
         self.comparison_vector_value = None
 
-        self.validate()
+        self._validate()
 
     def level_dict_val_else_default(self, key):
         val = self._level_dict.get(key)
@@ -129,7 +129,7 @@ class ComparisonLevel:
         if self._m_probability == "level not observed in training dataset":
             return 1e-6
         if self._m_probability is None and self._has_comparison:
-            vals = normalise(interpolate(0.05, 0.95, self.comparison.num_levels))
+            vals = normalise(interpolate(0.05, 0.95, self.comparison._num_levels))
             return vals[self.comparison_vector_value]
         return self._m_probability
 
@@ -138,8 +138,8 @@ class ComparisonLevel:
         if self.is_null_level:
             raise AttributeError("Cannot set m_probability when is_null_level is true")
         if value == "level not observed in training dataset":
-            cc_n = self.comparison.output_column_name
-            cl_n = self.label_for_charts
+            cc_n = self.comparison._output_column_name
+            cl_n = self._label_for_charts
             logger.warning(
                 "\nWARNING:\n"
                 f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
@@ -155,7 +155,7 @@ class ComparisonLevel:
         if self._u_probability == "level not observed in training dataset":
             return 1e-6
         if self._u_probability is None:
-            vals = normalise(interpolate(0.95, 0.05, self.comparison.num_levels))
+            vals = normalise(interpolate(0.95, 0.05, self.comparison._num_levels))
             return vals[self.comparison_vector_value]
         return self._u_probability
 
@@ -164,8 +164,8 @@ class ComparisonLevel:
         if self.is_null_level:
             raise AttributeError("Cannot set u_probability when is_null_level is true")
         if value == "level not observed in training dataset":
-            cc_n = self.comparison.output_column_name
-            cl_n = self.label_for_charts
+            cc_n = self.comparison._output_column_name
+            cl_n = self._label_for_charts
             logger.warning(
                 "\nWARNING:\n"
                 f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
@@ -179,7 +179,7 @@ class ComparisonLevel:
             return (
                 "Amongst matching record comparisons, "
                 f"{self.m_probability:.2%} of records are in the "
-                f"{self.label_for_charts.lower()} comparison level"
+                f"{self._label_for_charts.lower()} comparison level"
             )
 
     @property
@@ -188,7 +188,7 @@ class ComparisonLevel:
             return (
                 "Amongst non-matching record comparisons, "
                 f"{self.u_probability:.2%} of records are in the "
-                f"{self.label_for_charts.lower()} comparison level"
+                f"{self._label_for_charts.lower()} comparison level"
             )
 
     def _add_trained_u_probability(self, val, desc="no description given"):
@@ -224,7 +224,7 @@ class ComparisonLevel:
         return self._has_estimated_m_values and self._has_estimated_u_values
 
     @property
-    def trained_m_median(self):
+    def _trained_m_median(self):
         vals = [r["probability"] for r in self.trained_m_probabilities]
         vals = [v for v in vals if isinstance(v, (int, float))]
         if len(vals) == 0:
@@ -232,7 +232,7 @@ class ComparisonLevel:
         return median(vals)
 
     @property
-    def trained_u_median(self):
+    def _trained_u_median(self):
         vals = [r["probability"] for r in self.trained_u_probabilities]
         vals = [v for v in vals if isinstance(v, (int, float))]
         if len(vals) == 0:
@@ -240,7 +240,7 @@ class ComparisonLevel:
         return median(vals)
 
     @property
-    def m_is_trained(self):
+    def _m_is_trained(self):
         if self.is_null_level:
             return True
         if self._m_probability == "level not observed in data":
@@ -250,7 +250,7 @@ class ComparisonLevel:
         return True
 
     @property
-    def u_is_trained(self):
+    def _u_is_trained(self):
         if self.is_null_level:
             return True
         if self._u_probability == "level not observed in data":
@@ -260,11 +260,11 @@ class ComparisonLevel:
         return True
 
     @property
-    def is_trained(self):
-        return self.m_is_trained and self.u_is_trained
+    def _is_trained(self):
+        return self._m_is_trained and self._u_is_trained
 
     @property
-    def bayes_factor(self):
+    def _bayes_factor(self):
         if self.is_null_level:
             return 1.0
         if self.m_probability is None or self.u_probability is None:
@@ -273,42 +273,42 @@ class ComparisonLevel:
             return self.m_probability / self.u_probability
 
     @property
-    def log2_bayes_factor(self):
+    def _log2_bayes_factor(self):
         if self.is_null_level:
             return 0.0
         else:
-            return math.log2(self.bayes_factor)
+            return math.log2(self._bayes_factor)
 
     @property
-    def bayes_factor_description(self):
+    def _bayes_factor_description(self):
         text = (
-            f"If comparison level is `{self.label_for_charts.lower()}` "
+            f"If comparison level is `{self._label_for_charts.lower()}` "
             "then comparison is"
         )
-        if self.bayes_factor >= 1.0:
-            return f"{text} {self.bayes_factor:,.2f} times more likely to be a match"
+        if self._bayes_factor >= 1.0:
+            return f"{text} {self._bayes_factor:,.2f} times more likely to be a match"
         else:
-            mult = 1 / self.bayes_factor
+            mult = 1 / self._bayes_factor
             return f"{text}  {mult:,.2f} times less likely to be a match"
 
     @property
-    def label_for_charts(self):
+    def _label_for_charts(self):
         return self._level_dict.get(
             "label_for_charts", str(self.comparison_vector_value)
         )
 
     @property
-    def is_else_level(self):
+    def _is_else_level(self):
         if self.sql_condition.strip().upper() == "ELSE":
             return True
 
     @property
-    def has_tf_adjustments(self):
+    def _has_tf_adjustments(self):
         col = self._level_dict.get("tf_adjustment_column")
         return col is not None
 
     @property
-    def sql_read_dialect(self):
+    def _sql_read_dialect(self):
         read_dialect = None
         if self._settings_obj is not None:
             read_dialect = self._settings_obj._sql_dialect
@@ -316,25 +316,25 @@ class ComparisonLevel:
 
     def _validate_sql(self):
         sql = self.sql_condition
-        if self.is_else_level:
+        if self._is_else_level:
             return True
 
         try:
-            sqlglot.parse_one(sql, read=self.sql_read_dialect)
+            sqlglot.parse_one(sql, read=self._sql_read_dialect)
         except sqlglot.ParseError as e:
             raise ValueError(f"Error parsing sql_statement:\n{sql}") from e
 
         return True
 
     @property
-    def input_columns_used_by_sql_condition(self):
+    def _input_columns_used_by_sql_condition(self):
         # returns e.g. InputColumn(first_name), InputColumn(surname)
 
-        if self.is_else_level:
+        if self._is_else_level:
             return []
 
         cols = get_columns_used_from_sql(
-            self.sql_condition, dialect=self.sql_read_dialect
+            self.sql_condition, dialect=self._sql_read_dialect
         )
         # Parsed order seems to be roughly in reverse order of apearance
         cols = cols[::-1]
@@ -362,10 +362,10 @@ class ComparisonLevel:
         return input_cols
 
     @property
-    def columns_to_select_for_blocking(self):
+    def _columns_to_select_for_blocking(self):
         # e.g. l.first_name as first_name_l, r.first_name as first_name_r
         output_cols = []
-        cols = self.input_columns_used_by_sql_condition
+        cols = self._input_columns_used_by_sql_condition
 
         for c in cols:
             output_cols.extend(c.l_r_names_as_l_r())
@@ -374,7 +374,7 @@ class ComparisonLevel:
         return dedupe_preserving_order(output_cols)
 
     @property
-    def when_then_comparison_vector_value_sql(self):
+    def _when_then_comparison_vector_value_sql(self):
         # e.g. when first_name_l = first_name_r then 1
         if not hasattr(self, "comparison_vector_value"):
             raise ValueError(
@@ -383,14 +383,14 @@ class ComparisonLevel:
                 "The comparison_vector_value is only defined in the "
                 "context of a list of ComparisonLevels within a ComparisonColumn."
             )
-        if self.is_else_level:
+        if self._is_else_level:
             return f"{self.sql_condition} {self.comparison_vector_value}"
         else:
             return f"WHEN {self.sql_condition} THEN {self.comparison_vector_value}"
 
     @property
-    def is_exact_match(self):
-        if self.is_else_level:
+    def _is_exact_match(self):
+        if self._is_else_level:
             return False
 
         sqls = re.split(r" and ", self.sql_condition, flags=re.IGNORECASE)
@@ -400,7 +400,7 @@ class ComparisonLevel:
         return True
 
     @property
-    def exact_match_colnames(self):
+    def _exact_match_colnames(self):
 
         sqls = re.split(r" and ", self.sql_condition, flags=re.IGNORECASE)
         for sql in sqls:
@@ -416,16 +416,16 @@ class ComparisonLevel:
         return cols
 
     @property
-    def u_probability_corresponding_to_exact_match(self):
+    def _u_probability_corresponding_to_exact_match(self):
         levels = self.comparison.comparison_levels
 
         # Find a level with a single exact match colname
         # which is equal to the tf adjustment input colname
 
         for level in levels:
-            if not level.is_exact_match:
+            if not level._is_exact_match:
                 continue
-            colnames = level.exact_match_colnames
+            colnames = level._exact_match_colnames
             if len(colnames) != 1:
                 continue
             if colnames[0] == self._tf_adjustment_input_column_name.lower():
@@ -438,17 +438,17 @@ class ComparisonLevel:
         )
 
     @property
-    def bayes_factor_sql(self):
+    def _bayes_factor_sql(self):
         sql = f"""
         WHEN
-        {self.comparison.gamma_column_name} = {self.comparison_vector_value}
-        THEN cast({self.bayes_factor} as double)
+        {self.comparison._gamma_column_name} = {self.comparison_vector_value}
+        THEN cast({self._bayes_factor} as double)
         """
         return dedent(sql)
 
     @property
-    def tf_adjustment_sql(self):
-        gamma_column_name = self.comparison.gamma_column_name
+    def _tf_adjustment_sql(self):
+        gamma_column_name = self.comparison._gamma_column_name
         gamma_colname_value_is_this_level = (
             f"{gamma_column_name} = {self.comparison_vector_value}"
         )
@@ -456,11 +456,11 @@ class ComparisonLevel:
         # A tf adjustment of 1D is a multiplier of 1.0, i.e. no adjustment
         if self.comparison_vector_value == -1:
             sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
-        elif not self.has_tf_adjustments:
+        elif not self._has_tf_adjustments:
             sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
         elif self.tf_adjustment_weight == 0:
             sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
-        elif self.is_else_level:
+        elif self._is_else_level:
             sql = f"WHEN  {gamma_colname_value_is_this_level} then cast(1 as double)"
         else:
             tf_adj_col = self._tf_adjustment_input_column
@@ -473,7 +473,7 @@ class ComparisonLevel:
             )
 
             tf_adjustment_exists = f"{coalesce_l_r} is not null"
-            u_prob_exact_match = self.u_probability_corresponding_to_exact_match
+            u_prob_exact_match = self._u_probability_corresponding_to_exact_match
 
             # Using coalesce protects against one of the tf adjustments being null
             # Which would happen if the user provided their own tf adjustment table
@@ -525,7 +525,7 @@ class ComparisonLevel:
         output["sql_condition"] = self.sql_condition
 
         if self._level_dict.get("label_for_charts"):
-            output["label_for_charts"] = self.label_for_charts
+            output["label_for_charts"] = self._label_for_charts
 
         if self.m_probability:
             output["m_probability"] = self.m_probability
@@ -533,7 +533,7 @@ class ComparisonLevel:
         if self.u_probability:
             output["u_probability"] = self.u_probability
 
-        if self.has_tf_adjustments:
+        if self._has_tf_adjustments:
             output["tf_adjustment_column"] = self._tf_adjustment_input_column.input_name
             if self.tf_adjustment_weight != 0:
                 output["tf_adjustment_weight"] = self.tf_adjustment_weight
@@ -549,11 +549,11 @@ class ComparisonLevel:
         return comp_dict
 
     @property
-    def as_detailed_record(self):
+    def _as_detailed_record(self):
         "A detailed representation of this level to describe it in charting outputs"
         output = {}
         output["sql_condition"] = self.sql_condition
-        output["label_for_charts"] = self.label_for_charts
+        output["label_for_charts"] = self._label_for_charts
 
         output["m_probability"] = self.m_probability
         output["u_probability"] = self.u_probability
@@ -561,28 +561,28 @@ class ComparisonLevel:
         output["m_probability_description"] = self._m_probability_description
         output["u_probability_description"] = self._u_probability_description
 
-        output["has_tf_adjustments"] = self.has_tf_adjustments
-        if self.has_tf_adjustments:
+        output["has_tf_adjustments"] = self._has_tf_adjustments
+        if self._has_tf_adjustments:
             output["tf_adjustment_column"] = self._tf_adjustment_input_column.input_name
         else:
             output["tf_adjustment_column"] = None
         output["tf_adjustment_weight"] = self.tf_adjustment_weight
 
         output["is_null_level"] = self.is_null_level
-        output["bayes_factor"] = self.bayes_factor
-        output["log2_bayes_factor"] = self.log2_bayes_factor
+        output["bayes_factor"] = self._bayes_factor
+        output["log2_bayes_factor"] = self._log2_bayes_factor
         output["comparison_vector_value"] = self.comparison_vector_value
-        output["max_comparison_vector_value"] = self.comparison.num_levels - 1
-        output["bayes_factor_description"] = self.bayes_factor_description
+        output["max_comparison_vector_value"] = self.comparison._num_levels - 1
+        output["bayes_factor_description"] = self._bayes_factor_description
 
         return output
 
     @property
-    def parameter_estimates_as_records(self):
+    def _parameter_estimates_as_records(self):
 
         output_records = []
 
-        cl_record = self.as_detailed_record
+        cl_record = self._as_detailed_record
         trained_values = self.trained_u_probabilities + self.trained_m_probabilities
         for trained_value in trained_values:
             record = {}
@@ -602,10 +602,10 @@ class ComparisonLevel:
 
         return output_records
 
-    def validate(self):
+    def _validate(self):
         self._validate_sql()
 
     def __repr__(self):
         sql = self.sql_condition
         sql = (sql[:75] + "...") if len(sql) > 75 else sql
-        return f"<ComparisonLevel {self.label_for_charts} with SQL: {sql}>"
+        return f"<ComparisonLevel {self._label_for_charts} with SQL: {sql}>"

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -75,11 +75,11 @@ class ComparisonLevel:
         self._level_dict = (
             level_dict  # Protected, because we don't want to modify the original dict
         )
-        self.comparison = comparison
+        self.comparison: "Comparison" = comparison
         self._settings_obj = settings_obj
 
         self.sql_condition = self._level_dict["sql_condition"]
-        self.is_null_level = self.level_dict_val_else_default("is_null_level")
+        self._is_null_level = self.level_dict_val_else_default("is_null_level")
         self.tf_adjustment_weight = self.level_dict_val_else_default(
             "tf_adjustment_weight"
         )
@@ -133,7 +133,7 @@ class ComparisonLevel:
 
     @property
     def m_probability(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return None
         if self._m_probability == "level not observed in training dataset":
             return 1e-6
@@ -144,7 +144,7 @@ class ComparisonLevel:
 
     @m_probability.setter
     def m_probability(self, value):
-        if self.is_null_level:
+        if self._is_null_level:
             raise AttributeError("Cannot set m_probability when is_null_level is true")
         if value == "level not observed in training dataset":
             cc_n = self.comparison._output_column_name
@@ -159,7 +159,7 @@ class ComparisonLevel:
 
     @property
     def u_probability(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return None
         if self._u_probability == "level not observed in training dataset":
             return 1e-6
@@ -170,7 +170,7 @@ class ComparisonLevel:
 
     @u_probability.setter
     def u_probability(self, value):
-        if self.is_null_level:
+        if self._is_null_level:
             raise AttributeError("Cannot set u_probability when is_null_level is true")
         if value == "level not observed in training dataset":
             cc_n = self.comparison._output_column_name
@@ -214,7 +214,7 @@ class ComparisonLevel:
 
     @property
     def _has_estimated_u_values(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return True
         vals = [r["probability"] for r in self.trained_u_probabilities]
         vals = [v for v in vals if isinstance(v, (int, float))]
@@ -222,7 +222,7 @@ class ComparisonLevel:
 
     @property
     def _has_estimated_m_values(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return True
         vals = [r["probability"] for r in self.trained_m_probabilities]
         vals = [v for v in vals if isinstance(v, (int, float))]
@@ -250,7 +250,7 @@ class ComparisonLevel:
 
     @property
     def _m_is_trained(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return True
         if self._m_probability == "level not observed in data":
             return False
@@ -260,7 +260,7 @@ class ComparisonLevel:
 
     @property
     def _u_is_trained(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return True
         if self._u_probability == "level not observed in data":
             return False
@@ -274,7 +274,7 @@ class ComparisonLevel:
 
     @property
     def _bayes_factor(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return 1.0
         if self.m_probability is None or self.u_probability is None:
             return None
@@ -283,7 +283,7 @@ class ComparisonLevel:
 
     @property
     def _log2_bayes_factor(self):
-        if self.is_null_level:
+        if self._is_null_level:
             return 0.0
         else:
             return math.log2(self._bayes_factor)
@@ -547,7 +547,7 @@ class ComparisonLevel:
             if self.tf_adjustment_weight != 0:
                 output["tf_adjustment_weight"] = self.tf_adjustment_weight
 
-        if self.is_null_level:
+        if self._is_null_level:
             output["is_null_level"] = True
         return output
 
@@ -577,7 +577,7 @@ class ComparisonLevel:
             output["tf_adjustment_column"] = None
         output["tf_adjustment_weight"] = self.tf_adjustment_weight
 
-        output["is_null_level"] = self.is_null_level
+        output["is_null_level"] = self._is_null_level
         output["bayes_factor"] = self._bayes_factor
         output["log2_bayes_factor"] = self._log2_bayes_factor
         output["comparison_vector_value"] = self.comparison_vector_value

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -1,49 +1,55 @@
 from .input_column import InputColumn
+from .comparison_level import ComparisonLevel
 
 
-def null_level(col_name):
+def null_level(col_name) -> ComparisonLevel:
     col = InputColumn(col_name)
-    return {
+    level_dict = {
         "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
         "label_for_charts": "Null",
         "is_null_level": True,
     }
+    return ComparisonLevel(level_dict)
 
 
-def exact_match_level(col_name, m_probability=None, term_frequency_adjustments=False):
+def exact_match_level(
+    col_name, m_probability=None, term_frequency_adjustments=False
+) -> ComparisonLevel:
     col = InputColumn(col_name)
-    d = {
+    level_dict = {
         "sql_condition": f"{col.name_l()} = {col.name_r()}",
         "label_for_charts": "Exact match",
     }
     if m_probability:
-        d["m_probability"] = m_probability
+        level_dict["m_probability"] = m_probability
     if term_frequency_adjustments:
-        d["tf_adjustment_column"] = col_name
+        level_dict["tf_adjustment_column"] = col_name
 
-    return d
+    return ComparisonLevel(level_dict)
 
 
-def levenshtein_level(col_name, distance_threshold, m_probability=None):
+def levenshtein_level(
+    col_name, distance_threshold, m_probability=None
+) -> ComparisonLevel:
     col = InputColumn(col_name)
     sql_cond = f"levenshtein({col.name_l()}, {col.name_r()}) <= {distance_threshold}"
-    d = {
+    level_dict = {
         "sql_condition": sql_cond,
         "label_for_charts": f"Levenstein <= {distance_threshold}",
     }
     if m_probability:
-        d["m_probability"] = m_probability
+        level_dict["m_probability"] = m_probability
 
-    return d
+    return ComparisonLevel(level_dict)
 
 
 def else_level(
     m_probability=None,
-):
-    d = {
+) -> ComparisonLevel:
+    level_dict = {
         "sql_condition": "ELSE",
         "label_for_charts": "All other comparisons",
     }
     if m_probability:
-        d["m_probability"] = m_probability
-    return d
+        level_dict["m_probability"] = m_probability
+    return ComparisonLevel(level_dict)

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -1,4 +1,7 @@
-from . import comparison_levels_library as cl
+from typing import Union
+from .comparison import Comparison
+from . import comparison_level_library as cl
+from .misc import ensure_iterable
 
 
 def exact_match(
@@ -6,8 +9,9 @@ def exact_match(
     term_frequency_adjustments=False,
     m_probability_exact_match=None,
     m_probability_else=None,
-):
-    return {
+) -> Comparison:
+    comparison_dict = {
+        "comparison_description": "Exact match vs. anything else",
         "comparison_levels": [
             cl.null_level(col_name),
             cl.exact_match_level(
@@ -16,31 +20,60 @@ def exact_match(
                 m_probability=m_probability_exact_match,
             ),
             cl.else_level(m_probability=m_probability_else),
-        ]
+        ],
     }
+    return Comparison(comparison_dict)
 
 
 def levenshtein(
-    col_name,
-    distance_threshold=2,
+    col_name: str,
+    distance_threshold_or_thresholds: Union[int, list] = 2,
+    exact_match_level=True,
     term_frequency_adjustments=False,
     m_probability_exact_match=None,
-    m_probability_leven=None,
+    m_probability_or_probabilities_lev: Union[float, list] = None,
     m_probability_else=None,
-):
-    return {
-        "comparison_levels": [
-            cl.null_level(col_name),
-            cl.exact_match_level(
-                col_name,
-                term_frequency_adjustments=term_frequency_adjustments,
-                m_probability=m_probability_exact_match,
-            ),
-            cl.levenshtein_level(
-                col_name,
-                distance_threshold=distance_threshold,
-                m_probability=m_probability_leven,
-            ),
-            cl.else_level(m_probability=m_probability_else),
-        ]
+) -> Comparison:
+
+    distance_thresholds = ensure_iterable(distance_threshold_or_thresholds)
+
+    if m_probability_or_probabilities_lev is None:
+        m_probability_or_probabilities_lev = [None] * len(distance_thresholds)
+    m_probabilities = ensure_iterable(m_probability_or_probabilities_lev)
+
+    comparison_levels = []
+    comparison_levels.append(cl.null_level(col_name))
+    if exact_match_level:
+        level = cl.exact_match_level(
+            col_name,
+            term_frequency_adjustments=term_frequency_adjustments,
+            m_probability=m_probability_exact_match,
+        )
+        comparison_levels.append(level)
+
+    for thres, m_prob in zip(distance_thresholds, m_probabilities):
+        level = cl.levenshtein_level(
+            col_name,
+            distance_threshold=thres,
+            m_probability=m_prob,
+        )
+        comparison_levels.append(level)
+
+    comparison_levels.append(
+        cl.else_level(m_probability=m_probability_else),
+    )
+
+    comparison_desc = ""
+    if exact_match_level:
+        comparison_desc += "Exact match vs. "
+
+    thres_desc = ", ".join([str(d) for d in distance_thresholds])
+    plural = "" if len(distance_thresholds) == 1 else "s"
+    comparison_desc += f"Levenstein at threshold{plural} {thres_desc} vs. "
+    comparison_desc += "anything else"
+
+    comparison_dict = {
+        "comparison_description": comparison_desc,
+        "comparison_levels": comparison_levels,
     }
+    return Comparison(comparison_dict)

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -1,7 +1,7 @@
 from typing import Union
 from .comparison import Comparison
 from . import comparison_level_library as cl
-from .misc import ensure_iterable
+from .misc import ensure_is_iterable
 
 
 def exact_match(
@@ -35,11 +35,11 @@ def levenshtein(
     m_probability_else=None,
 ) -> Comparison:
 
-    distance_thresholds = ensure_iterable(distance_threshold_or_thresholds)
+    distance_thresholds = ensure_is_iterable(distance_threshold_or_thresholds)
 
     if m_probability_or_probabilities_lev is None:
         m_probability_or_probabilities_lev = [None] * len(distance_thresholds)
-    m_probabilities = ensure_iterable(m_probability_or_probabilities_lev)
+    m_probabilities = ensure_is_iterable(m_probability_or_probabilities_lev)
 
     comparison_levels = []
     comparison_levels.append(cl.null_level(col_name))

--- a/splink/comparison_vector_distribution.py
+++ b/splink/comparison_vector_distribution.py
@@ -1,6 +1,13 @@
-def comparison_vector_distribution_sql(linker):
+from typing import TYPE_CHECKING
 
-    gamma_columns = [c.gamma_column_name for c in linker._settings_obj.comparisons]
+# https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
+if TYPE_CHECKING:
+    from .linker import Linker
+
+
+def comparison_vector_distribution_sql(linker: "Linker"):
+
+    gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
     groupby_cols = " , ".join(gamma_columns)
     gam_concat = " || ',' || ".join(gamma_columns)
 

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -12,6 +12,7 @@ import duckdb
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..logging_messages import execute_sql_logging_message_info, log_sql
+from ..misc import ensure_is_iterable
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +150,7 @@ class DuckDBLinker(Linker):
         # them with the database, using user-provided aliases
         # if provided or a created alias if not
 
-        input_tables = self._coerce_to_list(input_table_or_tables)
+        input_tables = ensure_is_iterable(input_table_or_tables)
 
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -12,7 +12,7 @@ import duckdb
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..logging_messages import execute_sql_logging_message_info, log_sql
-from ..misc import ensure_is_iterable
+from ..misc import ensure_is_list
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ class DuckDBLinker(Linker):
         # them with the database, using user-provided aliases
         # if provided or a created alias if not
 
-        input_tables = ensure_is_iterable(input_table_or_tables)
+        input_tables = ensure_is_list(input_table_or_tables)
 
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -287,8 +287,9 @@ class EMTrainingSession:
         else:
             cl = max_change_dict["current_comparison_level"]
             m_u = max_change_dict["max_change_type"]
-            cc_name = cl.comparison.comparison_name
-            cl_label = cl.label_for_charts
+            cc_name = cl.comparison._output_column_name
+
+            cl_label = cl._label_for_charts
             level_text = f"{cc_name}, level `{cl_label}`"
 
             message = (
@@ -316,7 +317,7 @@ class EMTrainingSession:
             this_cc = comparison[1]
             z_cls = zip(prev_cc.comparison_levels, this_cc.comparison_levels)
             for z_cl in z_cls:
-                if z_cl[0].is_null_level:
+                if z_cl[0]._is_null_level:
                     continue
                 prev_cl = z_cl[0]
                 this_cl = z_cl[1]

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -155,7 +155,7 @@ class EMTrainingSession:
 
         # Add m and u values to original settings
         for cc in self._settings_obj.comparisons:
-            orig_cc = self._original_settings_obj._get_comparison_by_name(
+            orig_cc = self._original_settings_obj._get_comparison_by_output_column_name(
                 cc._output_column_name
             )
             for cl in cc._comparison_levels_excluding_null:

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -83,7 +83,7 @@ class EMTrainingSession:
                 if set(br_cols).intersection(cc_cols):
                     comparisons_to_deactivate.append(cc)
         cc_names_to_deactivate = [
-            cc.comparison_name for cc in comparisons_to_deactivate
+            cc.output_column_name for cc in comparisons_to_deactivate
         ]
         self._comparisons_that_cannot_be_estimated: List[
             Comparison
@@ -92,7 +92,7 @@ class EMTrainingSession:
         filtered_ccs = [
             cc
             for cc in self._settings_obj.comparisons
-            if cc.comparison_name not in cc_names_to_deactivate
+            if cc.output_column_name not in cc_names_to_deactivate
         ]
 
         self._settings_obj.comparisons = filtered_ccs
@@ -105,12 +105,12 @@ class EMTrainingSession:
 
     def _training_log_message(self):
         not_estimated = [
-            cc.comparison_name for cc in self._comparisons_that_cannot_be_estimated
+            cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated
         ]
         not_estimated = "".join([f"\n    - {cc}" for cc in not_estimated])
 
         estimated = [
-            cc.comparison_name for cc in self._comparisons_that_can_be_estimated
+            cc.output_column_name for cc in self._comparisons_that_can_be_estimated
         ]
         estimated = "".join([f"\n    - {cc}" for cc in estimated])
 
@@ -156,7 +156,7 @@ class EMTrainingSession:
         # Add m and u values to original settings
         for cc in self._settings_obj.comparisons:
             orig_cc = self._original_settings_obj._get_comparison_by_name(
-                cc.comparison_name
+                cc.output_column_name
             )
             for cl in cc.comparison_levels_excluding_null:
 
@@ -167,30 +167,30 @@ class EMTrainingSession:
                 if not self._training_fix_m_probabilities:
                     not_observed = "level not observed in training dataset"
                     if cl._m_probability == not_observed:
-                        orig_cl.add_trained_m_probability(not_observed, training_desc)
+                        orig_cl._add_trained_m_probability(not_observed, training_desc)
                         logger.info(
-                            f"m probability not trained for {cc.comparison_name} - "
+                            f"m probability not trained for {cc.output_column_name} - "
                             f"{cl.label_for_charts} (comparison vector value: "
                             f"{cl.comparison_vector_value}). This usually means the "
                             "comparison level was never observed in the training data."
                         )
                     else:
-                        orig_cl.add_trained_m_probability(
+                        orig_cl._add_trained_m_probability(
                             cl.m_probability, training_desc
                         )
 
                 if not self._training_fix_u_probabilities:
                     not_observed = "level not observed in training dataset"
                     if cl._u_probability == not_observed:
-                        orig_cl.add_trained_u_probability(not_observed, training_desc)
+                        orig_cl._add_trained_u_probability(not_observed, training_desc)
                         logger.info(
-                            f"u probability not trained for {cc.comparison_name} - "
+                            f"u probability not trained for {cc.output_column_name} - "
                             f"{cl.label_for_charts} (comparison vector value: "
                             f"{cl.comparison_vector_value}). This usually means the "
                             "comparison level was never observed in the training data."
                         )
                     else:
-                        orig_cl.add_trained_u_probability(
+                        orig_cl._add_trained_u_probability(
                             cl.u_probability, training_desc
                         )
 
@@ -220,7 +220,7 @@ class EMTrainingSession:
 
             logger.log(
                 15,
-                f"Applying comparison {cl.comparison.comparison_name}"
+                f"Applying comparison {cl.comparison.output_column_name}"
                 f" using bayes factor {cl.bayes_factor:,.3f}",
             )
 
@@ -358,7 +358,7 @@ class EMTrainingSession:
 
     def __repr__(self):
         deactivated_cols = ", ".join(
-            [cc.comparison_name for cc in self._comparisons_that_cannot_be_estimated]
+            [cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated]
         )
         return (
             f"<EMTrainingSession, blocking on {self._blocking_rule_for_training}, "

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -78,12 +78,12 @@ class EMTrainingSession:
                 blocking_rule_for_training, self._settings_obj._sql_dialect
             )
             for cc in self._settings_obj.comparisons:
-                cc_cols = cc.input_columns_used_by_case_statement
+                cc_cols = cc._input_columns_used_by_case_statement
                 cc_cols = [c.input_name for c in cc_cols]
                 if set(br_cols).intersection(cc_cols):
                     comparisons_to_deactivate.append(cc)
         cc_names_to_deactivate = [
-            cc.output_column_name for cc in comparisons_to_deactivate
+            cc._output_column_name for cc in comparisons_to_deactivate
         ]
         self._comparisons_that_cannot_be_estimated: List[
             Comparison
@@ -92,7 +92,7 @@ class EMTrainingSession:
         filtered_ccs = [
             cc
             for cc in self._settings_obj.comparisons
-            if cc.output_column_name not in cc_names_to_deactivate
+            if cc._output_column_name not in cc_names_to_deactivate
         ]
 
         self._settings_obj.comparisons = filtered_ccs
@@ -105,12 +105,12 @@ class EMTrainingSession:
 
     def _training_log_message(self):
         not_estimated = [
-            cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated
+            cc._output_column_name for cc in self._comparisons_that_cannot_be_estimated
         ]
         not_estimated = "".join([f"\n    - {cc}" for cc in not_estimated])
 
         estimated = [
-            cc.output_column_name for cc in self._comparisons_that_can_be_estimated
+            cc._output_column_name for cc in self._comparisons_that_can_be_estimated
         ]
         estimated = "".join([f"\n    - {cc}" for cc in estimated])
 
@@ -156,11 +156,11 @@ class EMTrainingSession:
         # Add m and u values to original settings
         for cc in self._settings_obj.comparisons:
             orig_cc = self._original_settings_obj._get_comparison_by_name(
-                cc.output_column_name
+                cc._output_column_name
             )
-            for cl in cc.comparison_levels_excluding_null:
+            for cl in cc._comparison_levels_excluding_null:
 
-                orig_cl = orig_cc.get_comparison_level_by_comparison_vector_value(
+                orig_cl = orig_cc._get_comparison_level_by_comparison_vector_value(
                     cl.comparison_vector_value
                 )
 
@@ -169,8 +169,8 @@ class EMTrainingSession:
                     if cl._m_probability == not_observed:
                         orig_cl._add_trained_m_probability(not_observed, training_desc)
                         logger.info(
-                            f"m probability not trained for {cc.output_column_name} - "
-                            f"{cl.label_for_charts} (comparison vector value: "
+                            f"m probability not trained for {cc._output_column_name} - "
+                            f"{cl._label_for_charts} (comparison vector value: "
                             f"{cl.comparison_vector_value}). This usually means the "
                             "comparison level was never observed in the training data."
                         )
@@ -184,8 +184,8 @@ class EMTrainingSession:
                     if cl._u_probability == not_observed:
                         orig_cl._add_trained_u_probability(not_observed, training_desc)
                         logger.info(
-                            f"u probability not trained for {cc.output_column_name} - "
-                            f"{cl.label_for_charts} (comparison vector value: "
+                            f"u probability not trained for {cc._output_column_name} - "
+                            f"{cl._label_for_charts} (comparison vector value: "
                             f"{cl.comparison_vector_value}). This usually means the "
                             "comparison level was never observed in the training data."
                         )
@@ -216,12 +216,12 @@ class EMTrainingSession:
             )
 
         for cl in comp_levels:
-            adj_bayes_factor = cl.bayes_factor * adj_bayes_factor
+            adj_bayes_factor = cl._bayes_factor * adj_bayes_factor
 
             logger.log(
                 15,
-                f"Applying comparison {cl.comparison.output_column_name}"
-                f" using bayes factor {cl.bayes_factor:,.3f}",
+                f"Applying comparison {cl.comparison._output_column_name}"
+                f" using bayes factor {cl._bayes_factor:,.3f}",
             )
 
         adjusted_prop_m = bayes_factor_to_prob(adj_bayes_factor)
@@ -358,7 +358,10 @@ class EMTrainingSession:
 
     def __repr__(self):
         deactivated_cols = ", ".join(
-            [cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated]
+            [
+                cc._output_column_name
+                for cc in self._comparisons_that_cannot_be_estimated
+            ]
         )
         return (
             f"<EMTrainingSession, blocking on {self._blocking_rule_for_training}, "

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -110,7 +110,7 @@ def estimate_u_values(linker: "Linker", target_rows):
     df_sample.drop_table_from_database()
 
     m_u_records = [
-        r for r in param_records if r["comparison_name"] != "_proportion_of_matches"
+        r for r in param_records if r["output_column_name"] != "_proportion_of_matches"
     ]
 
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -115,7 +115,7 @@ def estimate_u_values(linker: "Linker", target_rows):
 
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for c in original_settings_obj.comparisons:
-        for cl in c.comparison_levels_excluding_null:
+        for cl in c._comparison_levels_excluding_null:
             append_u_probability_to_comparison_level_trained_probabilities(
                 cl, m_u_records_lookup, "estimate u by random sampling"
             )

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -33,8 +33,8 @@ def compute_new_parameters_sql(settings_obj: Settings):
     """
     union_sqls = [
         sql_template.format(
-            gamma_column=cc.gamma_column_name,
-            comparison_name=cc.output_column_name,
+            gamma_column=cc._gamma_column_name,
+            comparison_name=cc._output_column_name,
         )
         for cc in settings_obj.comparisons
     ]
@@ -96,7 +96,7 @@ def maximisation_step(em_training_session: "EMTrainingSession", param_records):
 
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in settings_obj.comparisons:
-        for cl in cc.comparison_levels_excluding_null:
+        for cl in cc._comparison_levels_excluding_null:
             populate_m_u_from_lookup(em_training_session, cl, m_u_records_lookup)
 
     em_training_session._add_iteration()

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -72,7 +72,7 @@ def populate_m_u_from_lookup(
 
     if not em_training_session._training_fix_u_probabilities:
         try:
-            u_probability = m_u_records_lookup[c.comparison_name][
+            u_probability = m_u_records_lookup[c._output_column_name][
                 cl.comparison_vector_value
             ]["u_probability"]
 

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -34,7 +34,7 @@ def compute_new_parameters_sql(settings_obj: Settings):
     union_sqls = [
         sql_template.format(
             gamma_column=cc.gamma_column_name,
-            comparison_name=cc.comparison_name,
+            comparison_name=cc.output_column_name,
         )
         for cc in settings_obj.comparisons
     ]

--- a/splink/files/settings_jsonschema.json
+++ b/splink/files/settings_jsonschema.json
@@ -77,11 +77,19 @@
         "title": "A comparison of input column(s) that is used for probabalistic matching",
         "additionalProperties": false,
         "properties": {
-          "column_name": {
+          "output_column_name": {
             "type": "string",
             "title": "The name used to refer to this column in the output dataset.  Most useful to describe comparison columns that use multiple input columns.  e.g. a location column that uses postcode and town may be named location",
             "description": "For a comparison column that uses a single input column, e.g. first_name, this will be set first_name. For comparison columns that use multiple columns, if left blank, this will be set to the concatenation of columns used.",
             "examples": ["first_name", "surname"]
+          },
+          "comparison_description": {
+            "type": "string",
+            "title": "An optional label to describe this comparison.",
+            "examples": [
+              "First name exact match",
+              "Surname with middle levenstein level"
+            ]
           },
           "comparison_levels": {
             "type": "array",

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -498,18 +498,18 @@ class Linker:
                     reverse_level.comparison.comparison_name
                 )
 
-                cl = cc.get_comparison_level_by_comparison_vector_value(
+                cl = cc._get_comparison_level_by_comparison_vector_value(
                     reverse_level.comparison_vector_value
                 )
 
                 if cl._has_estimated_values:
-                    bf = cl.trained_m_median / cl.trained_u_median
+                    bf = cl._trained_m_median / cl._trained_u_median
                 else:
-                    bf = cl.bayes_factor
+                    bf = cl._bayes_factor
 
                 logger.log(
                     15,
-                    f"Reversing comparison level {cc.output_column_name}"
+                    f"Reversing comparison level {cc._output_column_name}"
                     f" using bayes factor {bf:,.3f}",
                 )
 
@@ -540,11 +540,11 @@ class Linker:
         ccs = self._settings_obj.comparisons
 
         for cc in ccs:
-            for cl in cc.comparison_levels_excluding_null:
+            for cl in cc._comparison_levels_excluding_null:
                 if cl._has_estimated_u_values:
-                    cl.u_probability = cl.trained_u_median
+                    cl.u_probability = cl._trained_u_median
                 if cl._has_estimated_m_values:
-                    cl.m_probability = cl.trained_m_median
+                    cl.m_probability = cl._trained_m_median
 
     def _delete_tables_created_by_splink_from_db(
         self, retain_term_frequency=True, retain_df_concat_with_tf=True

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -494,8 +494,8 @@ class Linker:
             for reverse_level in reverse_levels:
 
                 # Get comparison level on current settings obj
-                cc = self._settings_obj._get_comparison_by_name(
-                    reverse_level.comparison.comparison_name
+                cc = self._settings_obj._get_comparison_by_output_column_name(
+                    reverse_level.comparison._output_column_name
                 )
 
                 cl = cc._get_comparison_level_by_comparison_vector_value(

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -17,7 +17,7 @@ from .charts import (
 from .blocking import block_using_rules_sql
 from .comparison_vector_values import compute_comparison_vector_values_sql
 from .em_training_session import EMTrainingSession
-from .misc import bayes_factor_to_prob, prob_to_bayes_factor, ensure_is_iterable
+from .misc import bayes_factor_to_prob, prob_to_bayes_factor, ensure_is_list
 from .predict import predict_from_comparison_vectors_sql
 from .settings import Settings
 from .term_frequencies import (
@@ -418,7 +418,7 @@ class Linker:
 
     def _get_input_tables_dict(self, input_table_or_tables, input_table_aliases):
 
-        input_table_or_tables = ensure_is_iterable(input_table_or_tables)
+        input_table_or_tables = ensure_is_list(input_table_or_tables)
 
         input_table_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases

--- a/splink/m_from_labels.py
+++ b/splink/m_from_labels.py
@@ -36,12 +36,12 @@ def estimate_m_from_pairwise_labels(linker, table_name):
     param_records = df_params.as_record_dict()
 
     m_u_records = [
-        r for r in param_records if r["comparison_name"] != "_proportion_of_matches"
+        r for r in param_records if r["output_column_name"] != "_proportion_of_matches"
     ]
 
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in linker._settings_obj.comparisons:
-        for cl in cc.comparison_levels_excluding_null:
+        for cl in cc._comparison_levels_excluding_null:
             append_m_probability_to_comparison_level_trained_probabilities(
                 cl, m_u_records_lookup, "estimate m from pairwise labels"
             )

--- a/splink/m_training.py
+++ b/splink/m_training.py
@@ -50,11 +50,11 @@ def estimate_m_values_from_label_column(linker, df_dict, label_colname):
     param_records = df_params.as_record_dict()
 
     m_u_records = [
-        r for r in param_records if r["comparison_name"] != "_proportion_of_matches"
+        r for r in param_records if r["output_column_name"] != "_proportion_of_matches"
     ]
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in original_settings_object.comparisons:
-        for cl in cc.comparison_levels_excluding_null:
+        for cl in cc._comparison_levels_excluding_null:
             append_m_probability_to_comparison_level_trained_probabilities(
                 cl, m_u_records_lookup, "estimate m from label column"
             )

--- a/splink/m_u_records_to_parameters.py
+++ b/splink/m_u_records_to_parameters.py
@@ -33,7 +33,7 @@ def not_trained_message(comparison_level: ComparisonLevel):
     cl = comparison_level
     return (
         f"not trained for {c._output_column_name} - "
-        f"{cl.label_for_charts} (comparison vector value: "
+        f"{cl._label_for_charts} (comparison vector value: "
         f"{cl.comparison_vector_value}). This usually means the "
         "comparison level was never observed in the training data."
     )
@@ -68,7 +68,7 @@ def append_m_probability_to_comparison_level_trained_probabilities(
     c = cl.comparison
 
     try:
-        m_probability = m_u_records_lookup[c.comparison_name][
+        m_probability = m_u_records_lookup[c._output_column_name][
             cl.comparison_vector_value
         ]["m_probability"]
 
@@ -76,7 +76,7 @@ def append_m_probability_to_comparison_level_trained_probabilities(
         m_probability = "level not observed in training dataset"
 
         logger.info(f"u probability {not_trained_message(cl)}")
-    cl.add_trained_m_probability(
+    cl._add_trained_m_probability(
         m_probability,
         training_description,
     )

--- a/splink/m_u_records_to_parameters.py
+++ b/splink/m_u_records_to_parameters.py
@@ -1,7 +1,6 @@
 import logging
 
 from .comparison_level import ComparisonLevel
-from .comparison import Comparison
 
 logger = logging.getLogger(__name__)
 

--- a/splink/m_u_records_to_parameters.py
+++ b/splink/m_u_records_to_parameters.py
@@ -1,12 +1,15 @@
 import logging
 
+from .comparison_level import ComparisonLevel
+from .comparison import Comparison
+
 logger = logging.getLogger(__name__)
 
 
 def m_u_records_to_lookup_dict(m_u_records):
     lookup = {}
     for m_u_record in m_u_records:
-        comparison_name = m_u_record["comparison_name"]
+        comparison_name = m_u_record["output_column_name"]
         level_value = m_u_record["comparison_vector_value"]
         if comparison_name not in lookup:
             lookup[comparison_name] = {}
@@ -25,11 +28,11 @@ def m_u_records_to_lookup_dict(m_u_records):
     return lookup
 
 
-def not_trained_message(comparison_level):
+def not_trained_message(comparison_level: ComparisonLevel):
     c = comparison_level.comparison
     cl = comparison_level
     return (
-        f"not trained for {c.comparison_name} - "
+        f"not trained for {c._output_column_name} - "
         f"{cl.label_for_charts} (comparison vector value: "
         f"{cl.comparison_vector_value}). This usually means the "
         "comparison level was never observed in the training data."
@@ -37,14 +40,14 @@ def not_trained_message(comparison_level):
 
 
 def append_u_probability_to_comparison_level_trained_probabilities(
-    comparison_level, m_u_records_lookup, training_description
+    comparison_level: ComparisonLevel, m_u_records_lookup, training_description
 ):
 
     cl = comparison_level
     c = cl.comparison
 
     try:
-        u_probability = m_u_records_lookup[c.comparison_name][
+        u_probability = m_u_records_lookup[c._output_column_name][
             cl.comparison_vector_value
         ]["u_probability"]
 
@@ -52,14 +55,14 @@ def append_u_probability_to_comparison_level_trained_probabilities(
         u_probability = "level not observed in training dataset"
 
         logger.info(f"u probability {not_trained_message(cl)}")
-    cl.add_trained_u_probability(
+    cl._add_trained_u_probability(
         u_probability,
         training_description,
     )
 
 
 def append_m_probability_to_comparison_level_trained_probabilities(
-    comparison_level, m_u_records_lookup, training_description
+    comparison_level: ComparisonLevel, m_u_records_lookup, training_description
 ):
     cl = comparison_level
     c = cl.comparison

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -39,3 +39,7 @@ def normalise(vals):
 
 def ensure_is_iterable(a):
     return a if isinstance(a, Iterable) else [a]
+
+
+def ensure_is_list(a):
+    return a if isinstance(a, list) else [a]

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -1,4 +1,5 @@
 from math import log2
+from typing import Iterable
 
 
 def dedupe_preserving_order(list_of_items):
@@ -34,3 +35,7 @@ def interpolate(start, end, num_elements):
 
 def normalise(vals):
     return [v / sum(vals) for v in vals]
+
+
+def ensure_is_iterable(a):
+    return a if isinstance(a, Iterable) else [a]

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -33,7 +33,7 @@ def predict_from_comparison_vectors_sql(
     select_cols_expr = ",".join(select_cols)
     mult = []
     for cc in settings_obj.comparisons:
-        mult.extend(cc.match_weight_columns_to_multiply)
+        mult.extend(cc._match_weight_columns_to_multiply)
 
     proportion_of_matches = settings_obj._proportion_of_matches
 

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -103,7 +103,7 @@ class Settings:
     def _term_frequency_columns(self):
         cols = set()
         for cc in self.comparisons:
-            cols.update(cc.tf_adjustment_input_col_names)
+            cols.update(cc._tf_adjustment_input_col_names)
         return list(cols)
 
     @property
@@ -121,7 +121,7 @@ class Settings:
             cols.append(uid_col.r_name_as_r())
 
         for cc in self.comparisons:
-            cols.extend(cc.columns_to_select_for_blocking)
+            cols.extend(cc._columns_to_select_for_blocking)
 
         for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.l_r_names_as_l_r())
@@ -138,7 +138,7 @@ class Settings:
             cols.append(uid_col.name_r())
 
         for cc in self.comparisons:
-            cols.extend(cc.columns_to_select_for_comparison_vector_values)
+            cols.extend(cc._columns_to_select_for_comparison_vector_values)
 
         for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.names_l_r())
@@ -159,7 +159,7 @@ class Settings:
             cols.append(uid_col.name_r())
 
         for cc in self.comparisons:
-            cols.extend(cc.columns_to_select_for_bayes_factor_parts)
+            cols.extend(cc._columns_to_select_for_bayes_factor_parts)
 
         for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.names_l_r())
@@ -180,7 +180,7 @@ class Settings:
             cols.append(uid_col.name_r())
 
         for cc in self.comparisons:
-            cols.extend(cc.columns_to_select_for_predict)
+            cols.extend(cc._columns_to_select_for_predict)
 
         for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.names_l_r())
@@ -193,7 +193,7 @@ class Settings:
 
     def _get_comparison_by_name(self, name):
         for cc in self.comparisons:
-            if cc.output_column_name == name:
+            if cc._output_column_name == name:
                 return cc
         raise ValueError(f"No comparison column with name {name}")
 
@@ -225,7 +225,7 @@ class Settings:
         exact_comparison_levels = []
         for cc in ccs:
             for cl in cc.comparison_levels:
-                if cl.is_exact_match:
+                if cl._is_exact_match:
                     exact_comparison_levels.append(cl)
 
         # Where exact match on multiple columns exists, use that instead of individual
@@ -248,7 +248,7 @@ class Settings:
     def _parameters_as_detailed_records(self):
         output = []
         for i, cc in enumerate(self.comparisons):
-            records = cc.as_detailed_records
+            records = cc._as_detailed_records
             for r in records:
                 r["proportion_of_matches"] = self._proportion_of_matches
                 r["comparison_sort_order"] = i
@@ -290,7 +290,7 @@ class Settings:
     def _parameter_estimates_as_records(self):
         output = []
         for i, cc in enumerate(self.comparisons):
-            records = cc.parameter_estimates_as_records
+            records = cc._parameter_estimates_as_records
             for r in records:
                 r["comparison_sort_order"] = i
             output.extend(records)
@@ -326,9 +326,9 @@ class Settings:
     def columns_without_estimated_parameters_message(self):
         message_lines = []
         for c in self.comparisons:
-            msg = c.is_trained_message
+            msg = c._is_trained_message
             if msg is not None:
-                message_lines.append(c.is_trained_message)
+                message_lines.append(c._is_trained_message)
 
         if len(message_lines) == 0:
             message = (
@@ -344,10 +344,10 @@ class Settings:
 
     @property
     def is_fully_trained(self):
-        return all([c.is_trained for c in self.comparisons])
+        return all([c._is_trained for c in self.comparisons])
 
     def not_trained_messages(self):
         messages = []
         for c in self.comparisons:
-            messages.extend(c.not_trained_messages)
+            messages.extend(c._not_trained_messages)
         return messages

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -191,7 +191,7 @@ class Settings:
         cols = dedupe_preserving_order(cols)
         return cols
 
-    def _get_comparison_by_name(self, name):
+    def _get_comparison_by_output_column_name(self, name):
         for cc in self.comparisons:
             if cc._output_column_name == name:
                 return cc
@@ -233,11 +233,11 @@ class Settings:
         # So for example, if we have a param estimate for exact match on first name AND
         # surname, prefer that
         # over individual estimtes for exact match first name and surname.
-        exact_comparison_levels.sort(key=lambda x: -len(x.exact_match_colnames))
+        exact_comparison_levels.sort(key=lambda x: -len(x._exact_match_colnames))
 
         comparison_levels_corresponding_to_blocking_rule = []
         for cl in exact_comparison_levels:
-            exact_cols = set(cl.exact_match_colnames)
+            exact_cols = set(cl._exact_match_colnames)
             if exact_cols.issubset(blocking_exact_match_columns):
                 blocking_exact_match_columns = blocking_exact_match_columns - exact_cols
                 comparison_levels_corresponding_to_blocking_rule.append(cl)

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -7,7 +7,7 @@ from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
-from ..misc import ensure_is_iterable
+from ..misc import ensure_is_list
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class SparkLinker(Linker):
         self.break_lineage_method = break_lineage_method
         self.persist_level = persist_level
 
-        input_tables = ensure_is_iterable(input_table_or_tables)
+        input_tables = ensure_is_list(input_table_or_tables)
 
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -7,6 +7,7 @@ from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
+from ..misc import ensure_is_iterable
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ class SparkLinker(Linker):
         self.break_lineage_method = break_lineage_method
         self.persist_level = persist_level
 
-        input_tables = self._coerce_to_list(input_table_or_tables)
+        input_tables = ensure_is_iterable(input_table_or_tables)
 
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases

--- a/splink/splink_comparison_viewer.py
+++ b/splink/splink_comparison_viewer.py
@@ -2,9 +2,14 @@ from jinja2 import Template
 import json
 import os
 import pkgutil
+from typing import TYPE_CHECKING
+
+# https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
+if TYPE_CHECKING:
+    from .linker import Linker
 
 
-def row_examples(linker, example_rows_per_category=2):
+def row_examples(linker: "Linker", example_rows_per_category=2):
 
     sqls = []
 
@@ -14,7 +19,7 @@ def row_examples(linker, example_rows_per_category=2):
     uid_cols = uid_cols_l + uid_cols_r
     uid_expr = " || '-' ||".join(uid_cols)
 
-    gamma_columns = [c.gamma_column_name for c in linker._settings_obj.comparisons]
+    gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
 
     gam_concat = " || ',' || ".join(gamma_columns)
 

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -45,12 +45,12 @@ def _comparison_records(record_as_dict, comparison: Comparison):
     output_records = []
     waterfall_record = {}
 
-    cc = comparison
-    cv_value = record_as_dict[cc._gamma_column_name]
+    c = comparison
+    cv_value = record_as_dict[c._gamma_column_name]
 
-    cl = cc._get_comparison_level_by_comparison_vector_value(cv_value)
+    cl = c._get_comparison_level_by_comparison_vector_value(cv_value)
 
-    waterfall_record["column_name"] = cc._output_column_name
+    waterfall_record["column_name"] = c._output_column_name
     waterfall_record["label_for_charts"] = cl._label_for_charts
 
     waterfall_record["sql_condition"] = cl.sql_condition
@@ -60,7 +60,7 @@ def _comparison_records(record_as_dict, comparison: Comparison):
     waterfall_record["m_probability"] = cl.m_probability
     waterfall_record["u_probability"] = cl.u_probability
     waterfall_record["bayes_factor_description"] = cl._bayes_factor_description
-    input_cols_used = cc._input_columns_used_by_case_statement
+    input_cols_used = c._input_columns_used_by_case_statement
     input_cols_l = [ic.name_l(escape=False) for ic in input_cols_used]
     input_cols_r = [ic.name_r(escape=False) for ic in input_cols_used]
     waterfall_record["value_l"] = ", ".join(
@@ -74,7 +74,7 @@ def _comparison_records(record_as_dict, comparison: Comparison):
     output_records.append(waterfall_record)
     # Term frequency record if needed
 
-    if cc._has_tf_adjustments:
+    if c._has_tf_adjustments:
         waterfall_record_2 = deepcopy(waterfall_record)
 
         if cl._tf_adjustment_input_column is not None:
@@ -88,7 +88,7 @@ def _comparison_records(record_as_dict, comparison: Comparison):
             waterfall_record_2["value_l"] = ""
             waterfall_record_2["value_r"] = ""
 
-        waterfall_record_2["column_name"] = "tf_" + cc._output_column_name
+        waterfall_record_2["column_name"] = "tf_" + c._output_column_name
         waterfall_record_2["term_frequency_adjustment"] = True
         waterfall_record_2["bayes_factor"] = 1.0
         waterfall_record_2["log2_bayes_factor"] = math.log2(1.0)
@@ -97,7 +97,7 @@ def _comparison_records(record_as_dict, comparison: Comparison):
                 f"Term freq adjustment on {cl._tf_adjustment_input_column.input_name} "
                 "with weight {cl.tf_adjustment_weight}"
             )
-            bf = record_as_dict[cc._bf_tf_adj_column_name]
+            bf = record_as_dict[c._bf_tf_adj_column_name]
             waterfall_record_2["bayes_factor"] = bf
             waterfall_record_2["log2_bayes_factor"] = math.log2(bf)
             waterfall_record_2["m_probability"] = None

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -2,6 +2,7 @@ import math
 from copy import deepcopy
 
 from .misc import prob_to_bayes_factor
+from .comparison import Comparison
 
 
 def _prior_record(settings_obj):
@@ -39,27 +40,27 @@ def _final_score_record(record_as_dict):
     return rec
 
 
-def _comparison_records(record_as_dict, comparison):
+def _comparison_records(record_as_dict, comparison: Comparison):
 
     output_records = []
     waterfall_record = {}
 
     cc = comparison
-    cv_value = record_as_dict[cc.gamma_column_name]
+    cv_value = record_as_dict[cc._gamma_column_name]
 
-    cl = cc.get_comparison_level_by_comparison_vector_value(cv_value)
+    cl = cc._get_comparison_level_by_comparison_vector_value(cv_value)
 
-    waterfall_record["column_name"] = cc.comparison_name
-    waterfall_record["label_for_charts"] = cl.label_for_charts
+    waterfall_record["column_name"] = cc._output_column_name
+    waterfall_record["label_for_charts"] = cl._label_for_charts
 
     waterfall_record["sql_condition"] = cl.sql_condition
-    waterfall_record["log2_bayes_factor"] = cl.log2_bayes_factor
-    waterfall_record["bayes_factor"] = cl.bayes_factor
+    waterfall_record["log2_bayes_factor"] = cl._log2_bayes_factor
+    waterfall_record["bayes_factor"] = cl._bayes_factor
     waterfall_record["comparison_vector_value"] = int(cv_value)
     waterfall_record["m_probability"] = cl.m_probability
     waterfall_record["u_probability"] = cl.u_probability
-    waterfall_record["bayes_factor_description"] = cl.bayes_factor_description
-    input_cols_used = cc.input_columns_used_by_case_statement
+    waterfall_record["bayes_factor_description"] = cl._bayes_factor_description
+    input_cols_used = cc._input_columns_used_by_case_statement
     input_cols_l = [ic.name_l(escape=False) for ic in input_cols_used]
     input_cols_r = [ic.name_r(escape=False) for ic in input_cols_used]
     waterfall_record["value_l"] = ", ".join(
@@ -73,30 +74,30 @@ def _comparison_records(record_as_dict, comparison):
     output_records.append(waterfall_record)
     # Term frequency record if needed
 
-    if cc.has_tf_adjustments:
+    if cc._has_tf_adjustments:
         waterfall_record_2 = deepcopy(waterfall_record)
 
-        if cl.tf_adjustment_input_column is not None:
+        if cl._tf_adjustment_input_column is not None:
             waterfall_record_2["value_l"] = str(
-                record_as_dict[cl.tf_adjustment_input_column.name_l(escape=False)]
+                record_as_dict[cl._tf_adjustment_input_column.name_l(escape=False)]
             )
             waterfall_record_2["value_r"] = str(
-                record_as_dict[cl.tf_adjustment_input_column.name_r(escape=False)]
+                record_as_dict[cl._tf_adjustment_input_column.name_r(escape=False)]
             )
         else:
             waterfall_record_2["value_l"] = ""
             waterfall_record_2["value_r"] = ""
 
-        waterfall_record_2["column_name"] = "tf_" + cc.comparison_name
+        waterfall_record_2["column_name"] = "tf_" + cc._output_column_name
         waterfall_record_2["term_frequency_adjustment"] = True
         waterfall_record_2["bayes_factor"] = 1.0
         waterfall_record_2["log2_bayes_factor"] = math.log2(1.0)
-        if cl.has_tf_adjustments:
+        if cl._has_tf_adjustments:
             waterfall_record_2["label_for_charts"] = (
-                f"Term freq adjustment on {cl.tf_adjustment_input_column.input_name} "
+                f"Term freq adjustment on {cl._tf_adjustment_input_column.input_name} "
                 "with weight {cl.tf_adjustment_weight}"
             )
-            bf = record_as_dict[cc.bf_tf_adj_column_name]
+            bf = record_as_dict[cc._bf_tf_adj_column_name]
             waterfall_record_2["bayes_factor"] = bf
             waterfall_record_2["log2_bayes_factor"] = math.log2(bf)
             waterfall_record_2["m_probability"] = None
@@ -105,7 +106,7 @@ def _comparison_records(record_as_dict, comparison):
 
             text = (
                 "Term frequency adjustment on "
-                f"{cl.tf_adjustment_input_column.input_name} makes comparison"
+                f"{cl._tf_adjustment_input_column.input_name} makes comparison"
             )
             if bf >= 1.0:
                 text = f"{text} {bf:,.2f} times more likely to be a match"

--- a/tests/basic_settings.py
+++ b/tests/basic_settings.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from splink.misc import bayes_factor_to_prob, prob_to_bayes_factor
 
 first_name_cc = {
-    "column_name": "first_name",
+    "output_column_name": "first_name",
     "comparison_levels": [
         {
             "sql_condition": "first_name_l IS NULL OR first_name_r IS NULL",
@@ -34,7 +34,7 @@ first_name_cc = {
 
 
 surname_cc = {
-    "column_name": "surname",
+    "output_column_name": "surname",
     "comparison_levels": [
         {
             "sql_condition": "surname_l IS NULL OR surname_r IS NULL",
@@ -57,7 +57,7 @@ surname_cc = {
 }
 
 dob_cc = {
-    "column_name": "dob",
+    "output_column_name": "dob",
     "comparison_levels": [
         {
             "sql_condition": "dob_l IS NULL OR dob_r IS NULL",
@@ -80,7 +80,7 @@ dob_cc = {
 }
 
 email_cc = {
-    "column_name": "email",
+    "output_column_name": "email",
     "comparison_levels": [
         {
             "sql_condition": "email_l IS NULL OR email_r IS NULL",
@@ -103,7 +103,7 @@ email_cc = {
 }
 
 city_cc = {
-    "column_name": "city",
+    "output_column_name": "city",
     "comparison_levels": [
         {
             "sql_condition": "city_l IS NULL OR city_r IS NULL",

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -218,7 +218,7 @@ def test_lambda():
     )
 
     for cc in linker._settings_obj.comparisons:
-        if cc.comparison_name not in ("first_name", "surname"):
+        if cc.output_column_name not in ("first_name", "surname"):
             cl = cc.get_comparison_level_by_comparison_vector_value(1)
             cl.m_probability = 0.9
             cl.u_probability = 0.1

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -205,24 +205,24 @@ def test_lambda():
 
     bf_for_first_name = (
         linker._settings_obj._get_comparison_by_name("first_name")
-        .get_comparison_level_by_comparison_vector_value(2)
-        .bayes_factor
+        ._get_comparison_level_by_comparison_vector_value(2)
+        ._bayes_factor
     )
     bf_for_surname = (
         linker._settings_obj._get_comparison_by_name("surname")
-        .get_comparison_level_by_comparison_vector_value(1)
-        .bayes_factor
+        ._get_comparison_level_by_comparison_vector_value(1)
+        ._bayes_factor
     )
     glo = bayes_factor_to_prob(
         prob_to_bayes_factor(0.3) / (bf_for_first_name * bf_for_surname)
     )
 
     for cc in linker._settings_obj.comparisons:
-        if cc.output_column_name not in ("first_name", "surname"):
-            cl = cc.get_comparison_level_by_comparison_vector_value(1)
+        if cc._output_column_name not in ("first_name", "surname"):
+            cl = cc._get_comparison_level_by_comparison_vector_value(1)
             cl.m_probability = 0.9
             cl.u_probability = 0.1
-            cl = cc.get_comparison_level_by_comparison_vector_value(0)
+            cl = cc._get_comparison_level_by_comparison_vector_value(0)
             cl.m_probability = 0.1
             cl.u_probability = 0.9
 

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -204,12 +204,12 @@ def test_lambda():
     #########
 
     bf_for_first_name = (
-        linker._settings_obj._get_comparison_by_name("first_name")
+        linker._settings_obj._get_comparison_by_output_column_name("first_name")
         ._get_comparison_level_by_comparison_vector_value(2)
         ._bayes_factor
     )
     bf_for_surname = (
-        linker._settings_obj._get_comparison_by_name("surname")
+        linker._settings_obj._get_comparison_by_output_column_name("surname")
         ._get_comparison_level_by_comparison_vector_value(1)
         ._bayes_factor
     )

--- a/tests/test_m_train.py
+++ b/tests/test_m_train.py
@@ -26,11 +26,11 @@ def test_m_train():
     linker.estimate_m_from_label_column("cluster")
     cc_name = linker._settings_obj.comparisons[0]
 
-    cl_exact = cc_name.get_comparison_level_by_comparison_vector_value(2)
+    cl_exact = cc_name._get_comparison_level_by_comparison_vector_value(2)
     assert cl_exact.m_probability == 1 / 4
-    cl_lev = cc_name.get_comparison_level_by_comparison_vector_value(1)
+    cl_lev = cc_name._get_comparison_level_by_comparison_vector_value(1)
     assert cl_lev.m_probability == 2 / 4
-    cl_no = cc_name.get_comparison_level_by_comparison_vector_value(0)
+    cl_no = cc_name._get_comparison_level_by_comparison_vector_value(0)
     assert cl_no.m_probability == 1 / 4
     assert linker._settings_obj._blocking_rules_to_generate_predictions == [
         "l.name = r.name"
@@ -59,9 +59,9 @@ def test_m_train():
     linker_pairwise.train_m_from_pairwise_labels("labels")
     cc_name = linker_pairwise._settings_obj.comparisons[0]
 
-    cl_exact = cc_name.get_comparison_level_by_comparison_vector_value(2)
+    cl_exact = cc_name._get_comparison_level_by_comparison_vector_value(2)
     assert cl_exact.m_probability == 1 / 4
-    cl_lev = cc_name.get_comparison_level_by_comparison_vector_value(1)
+    cl_lev = cc_name._get_comparison_level_by_comparison_vector_value(1)
     assert cl_lev.m_probability == 2 / 4
-    cl_no = cc_name.get_comparison_level_by_comparison_vector_value(0)
+    cl_no = cc_name._get_comparison_level_by_comparison_vector_value(0)
     assert cl_no.m_probability == 1 / 4

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -27,11 +27,11 @@ def test_u_train():
     cc_name = linker._settings_obj.comparisons[0]
 
     denom = (6 * 5) / 2  # n(n-1) / 2
-    cl_exact = cc_name.get_comparison_level_by_comparison_vector_value(2)
+    cl_exact = cc_name._get_comparison_level_by_comparison_vector_value(2)
     assert cl_exact.u_probability == 1 / denom
-    cl_lev = cc_name.get_comparison_level_by_comparison_vector_value(1)
+    cl_lev = cc_name._get_comparison_level_by_comparison_vector_value(1)
     assert cl_lev.u_probability == 1 / denom
-    cl_no = cc_name.get_comparison_level_by_comparison_vector_value(0)
+    cl_no = cc_name._get_comparison_level_by_comparison_vector_value(0)
     assert cl_no.u_probability == (denom - 2) / denom
     assert linker._settings_obj._blocking_rules_to_generate_predictions == [
         "l.name = r.name"


### PR DESCRIPTION
The functions in comparison_library and comparison_level_library now return objects rather than dicts, and it's now permissable for the settings dictionary to contain Comparisons rather than only dicts