### PR TITLE
Consistent use of `input_column` rather than strings

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -2,8 +2,8 @@ from .input_column import InputColumn
 from .comparison_level import ComparisonLevel
 
 
-def null_level(col_name) -> ComparisonLevel:
-    col = InputColumn(col_name)
+def null_level(col_name, dialect=None) -> ComparisonLevel:
+    col = InputColumn(col_name, dialect)
     level_dict = {
         "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
         "label_for_charts": "Null",

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import tempfile
-from typing import Union
+from typing import Union, List
 import uuid
 import sqlglot
 from tempfile import TemporaryDirectory
@@ -9,10 +9,12 @@ from tempfile import TemporaryDirectory
 from duckdb import DuckDBPyConnection
 import duckdb
 
+
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..misc import ensure_is_list
+from ..input_column import InputColumn
 
 logger = logging.getLogger(__name__)
 
@@ -58,10 +60,11 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
         self.duckdb_linker = duckdb_linker
 
     @property
-    def columns(self):
+    def columns(self) -> List[InputColumn]:
         d = self.as_record_dict(1)[0]
 
-        return list(d.keys())
+        col_strings = list(d.keys())
+        return [InputColumn(c, sql_dialect="duckdb") for c in col_strings]
 
     def validate(self):
         pass

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -5,7 +5,7 @@ from .default_from_jsonschema import default_value_from_schema
 
 
 def _detect_if_name_needs_escaping(name):
-    if name in ("group",):
+    if name in ("group", "index"):
         return True
     tree = sqlglot.parse_one(name)
     if isinstance(tree, Column) and isinstance(tree.this, Identifier):
@@ -22,12 +22,7 @@ class InputColumn:
         self._settings_obj = settings_obj
         self._has_tf_adjustments = tf_adjustments
 
-        if name.endswith("_l"):
-            self.input_name = name[:-2]
-        elif name.endswith("_r"):
-            self.input_name = name[:-2]
-        else:
-            self.input_name = name
+        self.input_name = name
 
         if sql_dialect:
             self._sql_dialect = sql_dialect

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,19 +1,24 @@
+import sqlglot
+from sqlglot.expressions import Column, Identifier
+
 from .default_from_jsonschema import default_value_from_schema
-from .misc import escape_column
 
 
-def escape_if_requested(col, escape=True):
-    if escape:
-        return escape_column(col)
+def _detect_if_name_needs_escaping(name):
+    if name in ("group",):
+        return True
+    tree = sqlglot.parse_one(name)
+    if isinstance(tree, Column) and isinstance(tree.this, Identifier):
+        return False
     else:
-        return col
+        return True
 
 
 class InputColumn:
-    def __init__(self, name, tf_adjustments=False, settings_obj=None):
+    def __init__(self, name, tf_adjustments=False, settings_obj=None, sql_dialect=None):
 
         # If settings_obj is None, then default values will be used
-        # from the jsonschame
+        # from the jsonschama
         self._settings_obj = settings_obj
         self._has_tf_adjustments = tf_adjustments
 
@@ -23,6 +28,15 @@ class InputColumn:
             self.input_name = name[:-2]
         else:
             self.input_name = name
+
+        if sql_dialect:
+            self._sql_dialect = sql_dialect
+        elif settings_obj:
+            self._sql_dialect = getattr(self._settings_obj, "_sql_dialect")
+        else:
+            self._sql_dialect = None
+
+        self._name_needs_escaping = _detect_if_name_needs_escaping(name)
 
     def from_settings_obj_else_default(self, key, schema_key=None):
         # Covers the case where no settings obj is set on the comparison level
@@ -51,14 +65,29 @@ class InputColumn:
             "_tf_prefix", "term_frequency_adjustment_column_prefix"
         )
 
+    def _escape_if_requested(self, column_name, escape):
+        if not escape:
+            return column_name
+        if self._name_needs_escaping:
+            # Create parse tree
+            parsed = sqlglot.parse_one("col")
+
+            # Quote it and replace 'col' with true column_name
+            parsed.this.args["quoted"] = True
+            parsed.this.args["this"] = column_name
+
+            return parsed.sql(dialect=self._sql_dialect)
+        else:
+            return column_name
+
     def name(self, escape=True):
-        return escape_if_requested(self.input_name, escape)
+        return self._escape_if_requested(self.input_name, escape)
 
     def name_l(self, escape=True):
-        return escape_if_requested(f"{self.input_name}_l", escape)
+        return self._escape_if_requested(f"{self.input_name}_l", escape)
 
     def name_r(self, escape=True):
-        return escape_if_requested(f"{self.input_name}_r", escape)
+        return self._escape_if_requested(f"{self.input_name}_r", escape)
 
     def names_l_r(self, escape=True):
         return [self.name_l(escape), self.name_r(escape)]
@@ -76,7 +105,7 @@ class InputColumn:
         bf_prefix = self.from_settings_obj_else_default(
             "_bf_prefix", "bayes_factor_column_prefix"
         )
-        return escape_if_requested(f"{bf_prefix}{self.input_name}", escape)
+        return self._escape_if_requested(f"{bf_prefix}{self.input_name}", escape)
 
     @property
     def has_tf_adjustment(self):
@@ -97,15 +126,15 @@ class InputColumn:
         name = f"{tf_prefix}{self.input_name}"
 
         if self.has_tf_adjustment:
-            return escape_if_requested(name, escape)
+            return self._escape_if_requested(name, escape)
 
     def tf_name_l(self, escape=True):
         if self.has_tf_adjustment:
-            return escape_if_requested(f"{self.tf_name(escape=False)}_l", escape)
+            return self._escape_if_requested(f"{self.tf_name(escape=False)}_l", escape)
 
     def tf_name_r(self, escape=True):
         if self.has_tf_adjustment:
-            return escape_if_requested(f"{self.tf_name(escape=False)}_r", escape)
+            return self._escape_if_requested(f"{self.tf_name(escape=False)}_r", escape)
 
     def tf_name_l_r(self, escape=True):
         if self.has_tf_adjustment:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -5,6 +5,8 @@ import hashlib
 
 from typing import Union, List
 
+from splink.input_column import InputColumn
+
 from .charts import (
     match_weight_histogram,
     missingness_chart,
@@ -595,8 +597,9 @@ class Linker:
         """
         sql = vertically_concatente_sql(self)
         self._enqueue_sql(sql, "__splink__df_concat")
-        sql = term_frequencies_for_single_column_sql(column_name)
-        self._enqueue_sql(sql, colname_to_tf_tablename(column_name))
+        input_col = InputColumn(column_name, tf_adjustments=True)
+        sql = term_frequencies_for_single_column_sql(input_col)
+        self._enqueue_sql(sql, colname_to_tf_tablename(input_col))
         return self._execute_sql_pipeline(materialise_as_hash=False)
 
     def deterministic_link(self) -> SplinkDataFrame:

--- a/splink/lower_id_on_lhs.py
+++ b/splink/lower_id_on_lhs.py
@@ -67,6 +67,7 @@ def lower_id_to_left_hand_side(
     """  # noqa
 
     cols = df.columns
+    cols = [c.name(escape=False) for c in cols]
 
     l_cols = [c for c in cols if c.endswith("_l")]
     r_cols = [c for c in cols if c.endswith("_r")]

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -7,11 +7,7 @@ def dedupe_preserving_order(list_of_items):
 
 
 def escape_columns(cols):
-    return [escape_column(c) for c in cols]
-
-
-def escape_column(col):
-    return f'"{col}"'
+    return [c.name(escape=True) for c in cols]
 
 
 def prob_to_bayes_factor(prob):

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -1,6 +1,3 @@
-from .input_column import InputColumn
-
-
 def missingness_sqls(columns, input_tablename):
 
     sqls = []

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -10,7 +10,6 @@ def missingness_sqls(columns, input_tablename):
                     '{col_name}' as column_name
                 from {input_tablename}"""
 
-    columns = [InputColumn(col_name) for col_name in columns]
     selects = [
         col_template.format(
             col_name_escaped=col.name(),

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -1,5 +1,6 @@
 import logging
 from copy import deepcopy
+from typing import List
 from .parse_sql import get_columns_used_from_sql
 from .misc import prob_to_bayes_factor, prob_to_match_weight
 from .charts import m_u_parameters_chart, match_weights_chart
@@ -33,7 +34,7 @@ class Settings:
         s_else_d = self._from_settings_dict_else_default
         self._sql_dialect = s_else_d("sql_dialect")
 
-        self.comparisons: list[Comparison] = []
+        self.comparisons: List[Comparison] = []
         for cc in ccs:
             self.comparisons.append(Comparison(cc, self))
 
@@ -103,11 +104,13 @@ class Settings:
         return cols
 
     @property
-    def _term_frequency_columns(self):
+    def _term_frequency_columns(self) -> List[InputColumn]:
         cols = set()
         for cc in self.comparisons:
             cols.update(cc._tf_adjustment_input_col_names)
-        return list(cols)
+        return [
+            InputColumn(c, settings_obj=self, tf_adjustments=True) for c in list(cols)
+        ]
 
     @property
     def _needs_matchkey_column(self):

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -1,6 +1,6 @@
 import logging
 import sqlglot
-from typing import Union
+from typing import Union, List
 import re
 from pyspark.sql import Row
 from ..linker import Linker
@@ -8,6 +8,7 @@ from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..misc import ensure_is_list
+from ..input_column import InputColumn
 
 logger = logging.getLogger(__name__)
 
@@ -18,11 +19,12 @@ class SparkDataframe(SplinkDataFrame):
         self.spark_linker = spark_linker
 
     @property
-    def columns(self):
+    def columns(self) -> List[InputColumn]:
         sql = f"select * from {self.physical_name} limit 1"
         spark_df = self.spark_linker.spark.sql(sql)
 
-        return list(spark_df.columns)
+        col_strings = list(spark_df.columns)
+        return [InputColumn(c, sql_dialect="spark") for c in col_strings]
 
     def validate(self):
         pass

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -1,5 +1,5 @@
 import sqlglot
-from typing import Union
+from typing import Union, List
 import logging
 from math import pow, log2
 
@@ -7,6 +7,7 @@ from math import pow, log2
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
+from ..input_column import InputColumn
 
 logger = logging.getLogger(__name__)
 
@@ -24,13 +25,14 @@ class SQLiteDataFrame(SplinkDataFrame):
         self.sqlite_linker = sqlite_linker
 
     @property
-    def columns(self):
+    def columns(self) -> List[InputColumn]:
         sql = f"""
         PRAGMA table_info({self.physical_name});
         """
         pragma_result = self.sqlite_linker.con.execute(sql).fetchall()
         cols = [r["name"] for r in pragma_result]
-        return cols
+
+        return [InputColumn(c, sql_dialect="sqlite") for c in cols]
 
     def validate(self):
         if not type(self.physical_name) is str:

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -3,31 +3,29 @@
 
 import logging
 
-from .misc import escape_column
 from .input_column import InputColumn
 
 logger = logging.getLogger(__name__)
 
 
-def colname_to_tf_tablename(colname):
-    colname = colname.replace(" ", "_")
-    return f"__splink__df_tf_{colname}"
+def colname_to_tf_tablename(input_column: InputColumn):
+    input_column = input_column.name(escape=False).replace(" ", "_")
+    return f"__splink__df_tf_{input_column}"
 
 
 def term_frequencies_for_single_column_sql(
-    column_name, table_name="__splink__df_concat"
+    input_column, table_name="__splink__df_concat"
 ):
 
     # TODO: Not escaped so if col name has a space, will fail in Spark
 
-    col = InputColumn(column_name, tf_adjustments=True)
-
-    col_name = escape_column(column_name)
+    col_name = input_column.name(escape=True)
 
     sql = f"""
     select
     {col_name}, cast(count(*) as double) / (select
-        count({col_name}) as total from {table_name}) as {col.tf_name(escape=False)}
+        count({col_name}) as total from {table_name})
+            as {input_column.tf_name()}
     from {table_name}
     where {col_name} is not null
     group by {col_name}
@@ -44,7 +42,7 @@ def _join_tf_to_input_df(settings_obj):
 
     for col in tf_cols:
         tbl = colname_to_tf_tablename(col)
-        tf_col = escape_column(f"tf_{col}")
+        tf_col = col.tf_name()
         select_cols.append(f"{tbl}.{tf_col}")
 
     select_cols.insert(0, "__splink__df_concat.*")
@@ -53,7 +51,7 @@ def _join_tf_to_input_df(settings_obj):
     templ = "left join {tbl} on __splink__df_concat.{col} = {tbl}.{col}"
 
     left_joins = [
-        templ.format(tbl=colname_to_tf_tablename(col), col=escape_column(col))
+        templ.format(tbl=colname_to_tf_tablename(col), col=col.name())
         for col in tf_cols
     ]
     left_joins = " ".join(left_joins)

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -14,7 +14,7 @@ def colname_to_tf_tablename(input_column: InputColumn):
 
 
 def term_frequencies_for_single_column_sql(
-    input_column, table_name="__splink__df_concat"
+    input_column: InputColumn, table_name="__splink__df_concat"
 ):
 
     # TODO: Not escaped so if col name has a space, will fail in Spark


### PR DESCRIPTION
Ensure use of `InputColumn` throughout to make it easier to correctly quote variables e.g. need backtick ` for Spark but quote mark `"` for most other dialects.  

Let sqlglot handle the actual quoting 