### PR TITLE
fix issue where we were trying to inner join both of our input dfs

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -41,7 +41,7 @@ def _sql_gen_where_condition(link_type, unique_id_cols):
     return where_condition
 
 
-def block_using_rules_sql(linker: "Linker", custom_rule: str = ""):
+def block_using_rules_sql(linker: "Linker"):
     """Use the blocking rules specified in the linker's settings object to
     generate a SQL statement that will create pairwise record comparions
     according to the blocking rule(s).
@@ -84,10 +84,7 @@ def block_using_rules_sql(linker: "Linker", custom_rule: str = ""):
     # you create a cartesian product, rather than having separate code
     # that generates a cross join for the case of no blocking rules
     if not blocking_rules:
-        if custom_rule:
-            blocking_rules = [custom_rule]
-        else:
-            blocking_rules = ["1=1"]
+        blocking_rules = ["1=1"]
 
     for matchkey_number, rule in enumerate(blocking_rules):
         not_previous_rules_statement = _sql_gen_and_not_previous_rules(previous_rules)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2,7 +2,6 @@ import logging
 from copy import copy, deepcopy
 from statistics import median
 import hashlib
-import re
 
 from typing import Union, List
 
@@ -149,6 +148,9 @@ class Linker:
         if self._find_new_matches_mode:
             return "__splink__df_concat_with_tf"
 
+        if self._self_link_mode:
+            return "__splink__df_concat_with_tf"
+
         if self._compare_two_records_mode:
             return "__splink__compare_two_records_left_with_tf"
 
@@ -164,6 +166,9 @@ class Linker:
 
         if self._find_new_matches_mode:
             return "__splink__df_new_records_with_tf"
+
+        if self._self_link_mode:
+            return "__splink__df_concat_with_tf"
 
         if self._compare_two_records_mode:
             return "__splink__compare_two_records_right_with_tf"
@@ -974,9 +979,6 @@ class Linker:
         self._initialise_df_concat_with_tf()
 
         sql = block_using_rules_sql(self)
-
-        comparison_reg = re.compile("__splink_df_concat_with_tf_(left|right){1}")
-        sql = re.sub(comparison_reg, "__splink__df_concat_with_tf", sql)
 
         self._enqueue_sql(sql, "__splink__df_blocked")
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -975,9 +975,7 @@ class Linker:
 
         sql = block_using_rules_sql(self)
 
-        comparison_reg = re.compile(
-            "__splink_df_concat_with_tf_(left|right){1}"
-        )
+        comparison_reg = re.compile("__splink_df_concat_with_tf_(left|right){1}")
         sql = re.sub(comparison_reg, "__splink__df_concat_with_tf", sql)
 
         self._enqueue_sql(sql, "__splink__df_blocked")

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2,6 +2,7 @@ import logging
 from copy import copy, deepcopy
 from statistics import median
 import hashlib
+import re
 
 from typing import Union, List
 
@@ -950,9 +951,6 @@ class Linker:
                 input records.
         """
 
-        # Calculate tf columns or load from cache.
-        self._initialise_df_concat_with_tf()
-
         original_blocking_rules = (
             self._settings_obj._blocking_rules_to_generate_predictions
         )
@@ -976,6 +974,11 @@ class Linker:
         self._initialise_df_concat_with_tf()
 
         sql = block_using_rules_sql(self)
+
+        comparison_reg = re.compile(
+            "__splink_df_concat_with_tf_(left|right){1}"
+        )
+        sql = re.sub(comparison_reg, "__splink__df_concat_with_tf", sql)
 
         self._enqueue_sql(sql, "__splink__df_blocked")
 


### PR DESCRIPTION
Quick fix for `self_link` where we try to create a graph within a `link_only` job.

**EDIT** following commits:
When `self._self_link` is selected, we now automatically use `__splink__df_concat_with_tf` as our input dataframe for both l and r.