### PR TITLE
Splink3 sqlglot fixes

### DIFF
--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -2,17 +2,56 @@ import sqlglot
 from sqlglot.expressions import Column, Bracket, Lambda
 
 
+# def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
+#     column_names = set()
+#     syntax_tree = sqlglot.parse_one(sql, read=dialect)
+#     path = {}
+#     for tup in syntax_tree.walk():
+#         subtree = tup[0]
+#         if hasattr(subtree, "depth"):
+#             path[subtree.depth] = type(subtree)
+#         if Lambda in path.values():
+#             continue
+#         if type(subtree) in (Column, Bracket):
+
+#             if subtree.find(Bracket) and type(subtree) == Column:
+#                 # Column with bracket in it
+#                 table = subtree.table
+#                 column = subtree.this.this.this
+#             elif type(subtree.parent) != Column and type(subtree) == Column:
+#                 # Plain column
+#                 table = subtree.table
+
+#                 column = subtree.this.this
+#             else:
+#                 # Plain bracket
+#                 table = None
+#                 column = subtree.this.this.this
+
+#             if retain_table_prefix and table is not None:
+#                 column_names.add(f"{table.this}.{column}")
+#             else:
+#                 column_names.add(column)
+
+#     return list(column_names)
+
 def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
     column_names = set()
     syntax_tree = sqlglot.parse_one(sql, read=dialect)
-    path = {}
     for tup in syntax_tree.walk():
         subtree = tup[0]
-        if hasattr(subtree, "depth"):
-            path[subtree.depth] = type(subtree)
-        if Lambda in path.values():
-            continue
+
         if type(subtree) in (Column, Bracket):
+
+            # check if any parents are lambdas
+            parent = subtree.parent
+            while parent is not None:
+                if type(parent) == Lambda:
+                    break
+                parent = parent.parent
+
+            if type(parent) == Lambda:
+                continue
 
             if subtree.find(Bracket) and type(subtree) == Column:
                 # Column with bracket in it
@@ -26,7 +65,7 @@ def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
             else:
                 # Plain bracket
                 table = None
-                column = subtree.this.this
+                column = subtree.this.this.this
 
             if retain_table_prefix and table is not None:
                 column_names.add(f"{table.this}.{column}")

--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -2,39 +2,6 @@ import sqlglot
 from sqlglot.expressions import Column, Bracket, Lambda
 
 
-# def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
-#     column_names = set()
-#     syntax_tree = sqlglot.parse_one(sql, read=dialect)
-#     path = {}
-#     for tup in syntax_tree.walk():
-#         subtree = tup[0]
-#         if hasattr(subtree, "depth"):
-#             path[subtree.depth] = type(subtree)
-#         if Lambda in path.values():
-#             continue
-#         if type(subtree) in (Column, Bracket):
-
-#             if subtree.find(Bracket) and type(subtree) == Column:
-#                 # Column with bracket in it
-#                 table = subtree.table
-#                 column = subtree.this.this.this
-#             elif type(subtree.parent) != Column and type(subtree) == Column:
-#                 # Plain column
-#                 table = subtree.table
-
-#                 column = subtree.this.this
-#             else:
-#                 # Plain bracket
-#                 table = None
-#                 column = subtree.this.this.this
-
-#             if retain_table_prefix and table is not None:
-#                 column_names.add(f"{table.this}.{column}")
-#             else:
-#                 column_names.add(column)
-
-#     return list(column_names)
-
 def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
     column_names = set()
     syntax_tree = sqlglot.parse_one(sql, read=dialect)


### PR DESCRIPTION
First commit is my bad. I forgot to delete my commented code...

This PR just adjusts the logic for `parse_sql`. 

Instead of relying on the `walk()` method to 'walk' through our SQL trees sequentially, we instead use the parent attribute in each class.

This allows us to check the current tree, while remaining agnostic to any changes to the ordering that walk works in.

I'll add a comment re: the old order vs the new order of `walk()` tomorrow morning.

