### PR TITLE
SQL adjustment - cast ints to varchar

### DIFF
--- a/splink/comparison_vector_distribution.py
+++ b/splink/comparison_vector_distribution.py
@@ -8,8 +8,9 @@ if TYPE_CHECKING:
 def comparison_vector_distribution_sql(linker: "Linker"):
 
     gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
+    gamma_columns_cast = [f"cast({c} as varchar)" for c in gamma_columns]
     groupby_cols = " , ".join(gamma_columns)
-    gam_concat = " || ',' || ".join(gamma_columns)
+    gam_concat = " || ',' || ".join(gamma_columns_cast)
 
     case_tem = "(case when {g} = -1 then 0 when {g} = 0 then -1 else {g} end)"
     sum_gam = " + ".join([case_tem.format(g=c) for c in gamma_columns])

--- a/splink/splink_comparison_viewer.py
+++ b/splink/splink_comparison_viewer.py
@@ -14,12 +14,15 @@ def row_examples(linker: "Linker", example_rows_per_category=2):
     sqls = []
 
     uid_cols = linker._settings_obj._unique_id_input_columns
-    uid_cols_l = [uid_col.name_l() for uid_col in uid_cols]
-    uid_cols_r = [uid_col.name_r() for uid_col in uid_cols]
+    uid_cols_l = [f"cast({uid_col.name_l()} as varchar)" for uid_col in uid_cols]
+    uid_cols_r = [f"cast({uid_col.name_r()} as varchar)" for uid_col in uid_cols]
     uid_cols = uid_cols_l + uid_cols_r
     uid_expr = " || '-' ||".join(uid_cols)
 
-    gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
+    gamma_columns = [
+        f"cast({c._gamma_column_name} as varchar)"
+        for c in linker._settings_obj.comparisons
+    ]
 
     gam_concat = " || ',' || ".join(gamma_columns)
 

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -89,10 +89,8 @@ def test_full_example_athena(tmp_path):
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
     df_predict = linker.predict()
-    
-    linker.comparison_viewer_dashboard(
-        df_predict, "test_scv_athena.html", True, 2
-    )
+
+    linker.comparison_viewer_dashboard(df_predict, "test_scv_athena.html", True, 2)
 
     df_predict.as_pandas_dataframe()
 

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -66,15 +66,6 @@ def test_full_example_athena(tmp_path):
     upload_data("splink_awswrangler_test")
     settings_dict = get_settings_dict()
 
-    # SQLglot doesn't currently convert the levenshtein function,
-    # so manually adjust it for now
-    settings_dict["comparisons"][0]["comparison_levels"][2] = {
-        "sql_condition": "levenshtein_distance(first_name_l, first_name_r) <= 2",
-        "m_probability": 0.2,
-        "u_probability": 0.1,
-        "label_for_charts": "Levenstein <= 2",
-    }
-
     linker = AthenaLinker(
         settings_dict=settings_dict,
         input_table_or_tables=f"{db_name_read}.fake_1000_from_splink_demos",
@@ -98,6 +89,10 @@ def test_full_example_athena(tmp_path):
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
     df_predict = linker.predict()
+    
+    linker.comparison_viewer_dashboard(
+        df_predict, "test_scv_athena.html", True, 2
+    )
 
     df_predict.as_pandas_dataframe()
 


### PR DESCRIPTION
Explicitly cast **integer** cols to **varchar**, to both get the comparison viewer working in `athena` and also to make it more flexible if we expand to further SQL dialects in the future.