### PR TITLE
Sqlglot updates

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -493,7 +493,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "sqlglot"
-version = "2.7.0"
+version = "3.0.3"
 description = "An easily customizable SQL parser and transpiler"
 category = "main"
 optional = false
@@ -557,7 +557,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "66f6383543de98a8cefc43f2c6d305dbe7eaebbcf431accb72548da96d6fba7c"
+content-hash = "b9dca757229d1cc952762afffa93622e3dff754000539a69acd1e7c17892d2c6"
 
 [metadata.files]
 altair = [
@@ -1037,8 +1037,8 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 sqlglot = [
-    {file = "sqlglot-2.7.0-py3-none-any.whl", hash = "sha256:a5075b8abf2d95d3a2ecc0d2edd9281ad1085bcac02f53ff25d55a8e45f04c40"},
-    {file = "sqlglot-2.7.0.tar.gz", hash = "sha256:884eb9c52b0b211a0962d4fd53df0e1141382ee451e6660a831b6a66a93a2e6e"},
+    {file = "sqlglot-3.0.3-py3-none-any.whl", hash = "sha256:46b8fda8bb0d31e67e7355a8aaa118c09427772ccf6fffddd92b4efbb6efe614"},
+    {file = "sqlglot-3.0.3.tar.gz", hash = "sha256:05f477c31298c0fa001bd3a8c074fc3618076fbaedadbc3cb749f04be4cb9cd9"},
 ]
 tabulate = [
     {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},

--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -1,42 +1,41 @@
 import sqlglot
 from sqlglot.expressions import Column, Bracket, Lambda
+import sqlglot.expressions as exp
 
 
 def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
     column_names = set()
     syntax_tree = sqlglot.parse_one(sql, read=dialect)
-    for tup in syntax_tree.walk():
-        subtree = tup[0]
+    syntax_tree.find_all(exp.Column)
 
-        if type(subtree) in (Column, Bracket):
-
-            # check if any parents are lambdas
-            parent = subtree.parent
-            while parent is not None:
-                if type(parent) == Lambda:
-                    break
-                parent = parent.parent
-
+    for subtree in syntax_tree.find_all(exp.Column):
+        # check if any parents are lambdas
+        parent = subtree.parent
+        while parent is not None:
             if type(parent) == Lambda:
-                continue
+                break
+            parent = parent.parent
 
-            if subtree.find(Bracket) and type(subtree) == Column:
-                # Column with bracket in it
-                table = subtree.table
-                column = subtree.this.this.this
-            elif type(subtree.parent) != Column and type(subtree) == Column:
-                # Plain column
-                table = subtree.table
+        if type(parent) == Lambda:
+            continue
 
-                column = subtree.this.this
-            else:
-                # Plain bracket
-                table = None
-                column = subtree.this.this.this
+        if subtree.find(Bracket) and type(subtree) == Column:
+            # Column with bracket in it
+            table = subtree.table
+            column = subtree.this.this.this
+        elif type(subtree.parent) != Column and type(subtree) == Column:
+            # Plain column
+            table = subtree.table
 
-            if retain_table_prefix and table is not None:
-                column_names.add(f"{table.this}.{column}")
-            else:
-                column_names.add(column)
+            column = subtree.this.this
+        else:
+            # Plain bracket
+            table = None
+            column = subtree.this.this.this
+
+        if retain_table_prefix and table:
+            column_names.add(f"{table}.{column}")
+        else:
+            column_names.add(column)
 
     return list(column_names)

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -5,16 +5,17 @@ import sqlglot.expressions as exp
 def _add_l_or_r_to_identifier(node):
     if isinstance(node, exp.Identifier):
         if isinstance(node.parent, exp.Bracket):
-            l_r = node.parent.parent.table.this
+            l_r = node.parent.parent.table
         else:
-            l_r = node.parent.table.this
+            l_r = node.parent.table
         node.args["this"] += f"_{l_r}"
     return node
 
 
 def _remove_table_prefix(node):
     if isinstance(node, exp.Column):
-        node.table.args["this"] = None
+        n = node.sql().replace(f"{node.table}.", "")
+        return sqlglot.parse_one(n)
     return node
 
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -106,3 +106,20 @@ def test_full_example_duckdb(tmp_path):
 
     linker_2 = DuckDBLinker(df, connection=":memory:")
     linker_2.load_settings_from_json(path)
+
+
+def test_small_link_example_duckdb():
+
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    settings_dict = get_settings_dict()
+
+    settings_dict["link_type"] = "link_only"
+
+    linker = DuckDBLinker(
+        [df, df],
+        settings_dict,
+        connection=":memory:",
+        output_schema="splink_in_duckdb",
+    )
+
+    linker.predict()

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -44,3 +44,27 @@ def test_full_example_sqlite(tmp_path):
     linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.5)
 
     linker.unlinkables_chart(source_dataset="Testing")
+
+
+def test_small_link_example_sqlite():
+
+    from rapidfuzz.distance.Levenshtein import distance
+
+    con = sqlite3.connect(":memory:")
+    con.create_function("editdist3", 2, distance)
+
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    settings_dict = get_settings_dict()
+
+    settings_dict["link_type"] = "link_only"
+
+    df.to_sql("input_df_tablename", con)
+
+    linker = SQLiteLinker(
+        ["input_df_tablename", "input_df_tablename"],
+        settings_dict,
+        connection=con,
+        input_table_aliases=["fake_data_1", "fake_data_2"],
+    )
+
+    linker.predict()


### PR DESCRIPTION
The way `node.table` works has changed, so we are no longer able to overwrite it within [sql_transform.py](https://github.com/moj-analytical-services/splink/blob/91d0672c407d40333792e2ee3ce0ce4de4c13c43/splink/sql_transform.py#L17).

Some attributes also appear to have been converted to strings, and no longer contain the `this` argument.

Outside of that, I've also incorporated Toby's [comment](https://github.com/moj-analytical-services/splink/pull/514#issuecomment-1165267095) to streamline how we read our columns.

To compliment this (and mostly in response to the `athena` changes I'll PR you in in a second), I've also added a couple of link only tests in the `duckdb` and `sqlite` end-to-end tests. Happy to add a skip arg to both, if you'd prefer. 

These are useful to have them for checking purposes as the SQL gen sometimes breaks in `athena`. As a result, I occasionally make changes here.