### PR TITLE
Sqlglot transform for concat

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -13,6 +13,7 @@ from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..athena.athena_utils import boto_utils
 from ..input_column import InputColumn
 from ..misc import ensure_is_list
+from ..sql_transform import cast_concat_as_varchar
 
 
 logger = logging.getLogger(__name__)
@@ -153,9 +154,7 @@ class AthenaLinker(Linker):
 
         """An athena backend for our main linker class. This funnels our generated SQL
         through athena using awswrangler.
-
         See linker.py for more information on the main linker class.
-
         Attributes:
             input_table_or_tables (Union[str, list]): Input data into the linkage model.
                 Either a single string (the name of a table in a database) for
@@ -184,8 +183,6 @@ class AthenaLinker(Linker):
                 this will only delete the link between this s3 data and the database
                 (i.e. your previously created parquet files will still exist on s3
                 and can be relinked if desired).
-
-
         Examples:
             >>> # Creating a database in athena and writing to it
             >>> import awswrangler as wr
@@ -224,7 +221,6 @@ class AthenaLinker(Linker):
             >>>     output_bucket="alpha-splink-db-testing",
             >>>     output_database="splink_awswrangler_test2",
             >>> )
-
         """
 
         if settings_dict is not None and "sql_dialect" not in settings_dict:
@@ -309,6 +305,7 @@ class AthenaLinker(Linker):
         self.drop_table_from_database_if_exists(physical_name)
 
         if transpile:
+            sql = cast_concat_as_varchar(sql)
             sql = sqlglot.transpile(sql, read=None, write="presto")[0]
 
         sql = sql.replace("float", "real")

--- a/splink/comparison_vector_distribution.py
+++ b/splink/comparison_vector_distribution.py
@@ -8,9 +8,8 @@ if TYPE_CHECKING:
 def comparison_vector_distribution_sql(linker: "Linker"):
 
     gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
-    gamma_columns_cast = [f"cast({c} as varchar)" for c in gamma_columns]
     groupby_cols = " , ".join(gamma_columns)
-    gam_concat = " || ',' || ".join(gamma_columns_cast)
+    gam_concat = " || ',' || ".join(gamma_columns)
 
     case_tem = "(case when {g} = -1 then 0 when {g} = 0 then -1 else {g} end)"
     sum_gam = " + ".join([case_tem.format(g=c) for c in gamma_columns])

--- a/splink/lower_id_on_lhs.py
+++ b/splink/lower_id_on_lhs.py
@@ -12,10 +12,8 @@ def _sql_expr_move_left_to_right(
     col_name_r = f"{col_name}_r"
 
     if source_dataset_col is not None:
-        id_df_inputs = [sds_l, uid_l, sds_r, uid_r]
-        id_sds = [f"cast({input} as varchar)" for input in id_df_inputs]
-        uid_expr_l = f"concat({id_sds[0]}, '-__-', {id_sds[1]})"
-        uid_expr_r = f"concat({id_sds[2]}, '-__-', {id_sds[3]})"
+        uid_expr_l = f"concat({sds_l}, '-__-', {uid_l})"
+        uid_expr_r = f"concat({sds_r}, '-__-', {uid_r})"
     else:
         uid_expr_l = uid_l
         uid_expr_r = uid_r

--- a/splink/splink_comparison_viewer.py
+++ b/splink/splink_comparison_viewer.py
@@ -15,15 +15,12 @@ def row_examples(linker: "Linker", example_rows_per_category=2):
     sqls = []
 
     uid_cols = linker._settings_obj._unique_id_input_columns
-    uid_cols_l = [f"cast({uid_col.name_l()} as varchar)" for uid_col in uid_cols]
-    uid_cols_r = [f"cast({uid_col.name_r()} as varchar)" for uid_col in uid_cols]
+    uid_cols_l = [uid_col.name_l() for uid_col in uid_cols]
+    uid_cols_r = [uid_col.name_r() for uid_col in uid_cols]
     uid_cols = uid_cols_l + uid_cols_r
     uid_expr = " || '-' ||".join(uid_cols)
 
-    gamma_columns = [
-        f"cast({c._gamma_column_name} as varchar)"
-        for c in linker._settings_obj.comparisons
-    ]
+    gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
 
     gam_concat = " || ',' || ".join(gamma_columns)
 

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -23,3 +23,22 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
     transformed_tree = expression_tree.transform(_add_l_or_r_to_identifier)
     transformed_tree = transformed_tree.transform(_remove_table_prefix)
     return transformed_tree.sql()
+
+
+def cast_as_varchar_transformer(node):
+    if isinstance(node, exp.Column):
+
+        if isinstance(node.parent, exp.Cast):
+            return node
+
+        if node.find_ancestor(exp.DPipe):
+            sql = f"cast({node.table}.{node.name} as varchar)"
+            return sqlglot.parse_one(sql)
+
+    return node
+
+
+def cast_concat_as_varchar(sql):
+    syntax_tree = sqlglot.parse_one(sql, read=None)
+    transformed_tree = syntax_tree.transform(cast_as_varchar_transformer)
+    return transformed_tree.sql()

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -32,7 +32,8 @@ def cast_as_varchar_transformer(node):
             return node
 
         if node.find_ancestor(exp.DPipe):
-            sql = f"cast({node.table}.{node.name} as varchar)"
+            # node.sql() = colname w/ table prefix
+            sql = f"cast({node.sql()} as varchar)"
             return sqlglot.parse_one(sql)
 
     return node

--- a/splink/unique_id_concat.py
+++ b/splink/unique_id_concat.py
@@ -11,7 +11,7 @@ def _composite_unique_id_from_nodes_sql(unique_id_cols, table_prefix=None):
     else:
         table_prefix = ""
 
-    cols = [f"cast({table_prefix}{c.name()} as varchar)" for c in unique_id_cols]
+    cols = [f"{table_prefix}{c.name()}" for c in unique_id_cols]
 
     return f" || '{CONCAT_SEPARATOR}' || ".join(cols)
 
@@ -33,7 +33,5 @@ def _composite_unique_id_from_edges_sql(unique_id_cols, l_or_r, table_prefix=Non
         cols = [f"{table_prefix}{c.name_r()}" for c in unique_id_cols]
     if l_or_r is None:
         cols = [f"{table_prefix}{c.name()}" for c in unique_id_cols]
-
-    cols = [f"cast({c} as varchar)" for c in cols]
 
     return f" || '{CONCAT_SEPARATOR}' || ".join(cols)

--- a/splink/utils.py
+++ b/splink/utils.py
@@ -7,7 +7,7 @@ class NumpyEncoder(json.JSONEncoder):
     Used to correctly encode numpy columns within a pd dataframe
     when dumping it to json. Without this, json.dumps errors if
     given an a column of class int32, int64 or np.array.
-    
+
     Thanks to:
     https://github.com/mpld3/mpld3/issues/434#issuecomment-340255689
     """

--- a/splink/utils.py
+++ b/splink/utils.py
@@ -7,6 +7,9 @@ class NumpyEncoder(json.JSONEncoder):
     Used to correctly encode numpy columns within a pd dataframe
     when dumping it to json. Without this, json.dumps errors if
     given an a column of class int32, int64 or np.array.
+    
+    Thanks to:
+    https://github.com/mpld3/mpld3/issues/434#issuecomment-340255689
     """
 
     def default(self, obj):


### PR DESCRIPTION
A slightly better way of dealing with [this issue](https://github.com/moj-analytical-services/splink/issues/581) in athena.

Instead of adjusting the SQL in all dialects, I think it makes more sense to just add a transformation function for athena.

`sqlite` seems to have a massive performance hit if we use `cast(var as varchar)` across the board (as you'd probably have guessed). [See benchmarks here](https://github.com/moj-analytical-services/splink/pull/594#issuecomment-1172219890).