### PR TITLE
Duckdb - check lowercase connection string

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -136,6 +136,9 @@ class DuckDBLinker(Linker):
             settings_dict["sql_dialect"] = "duckdb"
 
         validate_duckdb_connection(connection)
+        
+        if isinstance(connection, str):
+            connection = connection.lower()
 
         if isinstance(connection, DuckDBPyConnection):
             con = connection

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -138,13 +138,12 @@ class DuckDBLinker(Linker):
         validate_duckdb_connection(connection)
         
         if isinstance(connection, str):
-            connection = connection.lower()
-
+            con_lower = connection.lower()
         if isinstance(connection, DuckDBPyConnection):
             con = connection
-        elif connection == ":memory:":
+        elif con_lower == ":memory:":
             con = duckdb.connect(database=connection)
-        elif connection == ":temporary:":
+        elif con_lower == ":temporary:":
             self._temp_dir = tempfile.TemporaryDirectory(dir=".")
             fname = uuid.uuid4().hex[:7]
             path = os.path.join(self._temp_dir.name, f"{fname}.duckdb")

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -136,7 +136,7 @@ class DuckDBLinker(Linker):
             settings_dict["sql_dialect"] = "duckdb"
 
         validate_duckdb_connection(connection)
-        
+
         if isinstance(connection, str):
             con_lower = connection.lower()
         if isinstance(connection, DuckDBPyConnection):


### PR DESCRIPTION
Boring one for you. 

I think we should check `connection.lower()` when assessing what kind of connection is being requested by the user. It's a really minor thing, but might just pick up on some typos from users.