### PR TITLE
Improve the performance of our training steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ linker.estimate_parameters_using_expectation_maximisation(blocking_rule_for_trai
 
 scored_comparisons = linker.predict()
 scored_comparisons.as_pandas_dataframe(limit=5)
+
 ```
 
 ## Acknowledgements

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -388,7 +388,7 @@ class EMTrainingSession:
                 for cc in self._comparisons_that_cannot_be_estimated
             ]
         )
-        blocking_rule = [r for r in self._blocking_rule_for_training][0]
+        blocking_rule = self._blocking_rule_for_training.blocking_rule
         return (
             f"<EMTrainingSession, blocking on {blocking_rule}, "
             f"deactivating comparisons {deactivated_cols}>"

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -6,7 +6,7 @@ from .blocking import block_using_rules_sql
 from .comparison_vector_values import compute_comparison_vector_values_sql
 from .expectation_maximisation import (
     compute_new_parameters_sql,
-    calculate_m_and_u_probability_averages,
+    compute_proportions_for_new_parameters,
 )
 
 from .m_u_records_to_parameters import (
@@ -105,15 +105,13 @@ def estimate_u_values(linker: "Linker", target_rows):
     training_linker._enqueue_sql(sql, "__splink__df_predict")
 
     sql = compute_new_parameters_sql(settings_obj)
-    training_linker._enqueue_sql(sql, "__splink__df_new_params")
-
+    linker._enqueue_sql(sql, "__splink__m_u_counts")
     df_params = training_linker._execute_sql_pipeline([df_sample])
 
     param_records = df_params.as_pandas_dataframe()
+    param_records = compute_proportions_for_new_parameters(param_records)
     df_params.drop_table_from_database()
     df_sample.drop_table_from_database()
-
-    param_records = calculate_m_and_u_probability_averages(param_records)
 
     m_u_records = [
         r

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING
 
 from .blocking import block_using_rules_sql
 from .comparison_vector_values import compute_comparison_vector_values_sql
-from .expectation_maximisation import compute_new_parameters_sql
+from .expectation_maximisation import (
+    compute_new_parameters_sql,
+    calculate_m_and_u_probability_averages,
+)
 
 from .m_u_records_to_parameters import (
     m_u_records_to_lookup_dict,
@@ -98,6 +101,7 @@ def estimate_u_values(linker: "Linker", target_rows):
     select *, cast(0.0 as double) as match_probability
     from __splink__df_comparison_vectors
     """
+
     training_linker._enqueue_sql(sql, "__splink__df_predict")
 
     sql = compute_new_parameters_sql(settings_obj)
@@ -105,9 +109,11 @@ def estimate_u_values(linker: "Linker", target_rows):
 
     df_params = training_linker._execute_sql_pipeline([df_sample])
 
-    param_records = df_params.as_record_dict()
+    param_records = df_params.as_pandas_dataframe()
     df_params.drop_table_from_database()
     df_sample.drop_table_from_database()
+
+    param_records = calculate_m_and_u_probability_averages(param_records)
 
     m_u_records = [
         r

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -1,6 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 import time
+import duckdb
 
 from .predict import predict_from_comparison_vectors_sqls
 from .settings import Settings
@@ -17,13 +18,13 @@ logger = logging.getLogger(__name__)
 
 
 def compute_new_parameters_sql(settings_obj: Settings):
-    """compute m and u from results of predict"""
+    """compute m and u counts from the results of predict"""
 
     sql_template = """
     select
     {gamma_column} as comparison_vector_value,
-    sum(match_probability) as m_probability,
-    sum(1-match_probability) as u_probability,
+    sum(match_probability) as m_count,
+    sum(1-match_probability) as u_count,
     '{output_column_name}' as output_column_name
     from __splink__df_predict
     group by {gamma_column}
@@ -39,8 +40,8 @@ def compute_new_parameters_sql(settings_obj: Settings):
     # Probability of two random records matching
     sql = """
     select 0 as comparison_vector_value,
-           avg(match_probability) as m_probability,
-           avg(1-match_probability) as u_probability,
+           avg(match_probability) as m_count,
+           avg(1-match_probability) as u_count,
            '_probability_two_random_records_match' as output_column_name
     from __splink__df_predict
     """
@@ -51,24 +52,36 @@ def compute_new_parameters_sql(settings_obj: Settings):
     return sql
 
 
-def calculate_m_and_u_probability_averages(m_u_df):
+def compute_proportions_for_new_parameters(m_u_df):
+    """Using the results from compute_new_parameters_sql, compute
+    m and u
+    """
 
-    data = m_u_df.copy()
+    sql = """
+    select
+        comparison_vector_value,
+        output_column_name,
+        m_count/sum(m_count) over (PARTITION BY output_column_name)
+            as m_probability,
+        u_count/sum(u_count) over (PARTITION BY output_column_name)
+            as u_probability
+    from m_u_df
+    where comparison_vector_value != -1
+    and output_column_name != '_probability_two_random_records_match'
 
-    data = data[data.comparison_vector_value != -1]
-    index = data.index.tolist()[:-1]
+    union all
 
-    m_probs = data.loc[index, "m_probability"] / data.groupby("output_column_name")[
-        "m_probability"
-    ].transform("sum").head(-1)
-    u_probs = data.loc[index, "u_probability"] / data.groupby("output_column_name")[
-        "u_probability"
-    ].transform("sum").head(-1)
+    select
+        comparison_vector_value,
+        output_column_name,
+        m_count as m_probability,
+        u_count as u_probability
+    from m_u_df
+    where output_column_name = '_probability_two_random_records_match'
+    order by output_column_name, comparison_vector_value asc
+    """
 
-    data.loc[index, "m_probability"] = m_probs
-    data.loc[index, "u_probability"] = u_probs
-
-    return data.to_dict("records")
+    return duckdb.query(sql).to_df().to_dict("records")
 
 
 def populate_m_u_from_lookup(
@@ -150,10 +163,10 @@ def expectation_maximisation(
             linker._enqueue_sql(sql["sql"], sql["output_table_name"])
 
         sql = compute_new_parameters_sql(settings_obj)
-        linker._enqueue_sql(sql, "__splink__df_new_params")
+        linker._enqueue_sql(sql, "__splink__m_u_counts")
         df_params = linker._execute_sql_pipeline([df_comparison_vector_values])
         param_records = df_params.as_pandas_dataframe()
-        param_records = calculate_m_and_u_probability_averages(param_records)
+        param_records = compute_proportions_for_new_parameters(param_records)
 
         df_params.drop_table_from_database()
 

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def compute_new_parameters_sql(settings_obj: Settings):
-    """compute u from results of predict"""
+    """compute m and u from results of predict"""
 
     sql_template = """
     select

--- a/splink/m_from_labels.py
+++ b/splink/m_from_labels.py
@@ -1,6 +1,9 @@
 import logging
 from .comparison_vector_values import compute_comparison_vector_values_sql
-from .expectation_maximisation import compute_new_parameters_sql
+from .expectation_maximisation import (
+    compute_new_parameters_sql,
+    calculate_m_and_u_probability_averages,
+)
 from .block_from_labels import block_from_labels
 from .m_u_records_to_parameters import (
     m_u_records_to_lookup_dict,
@@ -33,7 +36,8 @@ def estimate_m_from_pairwise_labels(linker, table_name):
 
     df_params = linker._execute_sql_pipeline()
 
-    param_records = df_params.as_record_dict()
+    param_records = df_params.as_pandas_dataframe()
+    param_records = calculate_m_and_u_probability_averages(param_records)
 
     m_u_records = [
         r

--- a/splink/m_from_labels.py
+++ b/splink/m_from_labels.py
@@ -2,7 +2,7 @@ import logging
 from .comparison_vector_values import compute_comparison_vector_values_sql
 from .expectation_maximisation import (
     compute_new_parameters_sql,
-    calculate_m_and_u_probability_averages,
+    compute_proportions_for_new_parameters,
 )
 from .block_from_labels import block_from_labels
 from .m_u_records_to_parameters import (
@@ -32,12 +32,11 @@ def estimate_m_from_pairwise_labels(linker, table_name):
     linker._enqueue_sql(sql, "__splink__df_predict")
 
     sql = compute_new_parameters_sql(linker._settings_obj)
-    linker._enqueue_sql(sql, "__splink__df_new_params")
+    linker._enqueue_sql(sql, "__splink__m_u_counts")
 
     df_params = linker._execute_sql_pipeline()
-
     param_records = df_params.as_pandas_dataframe()
-    param_records = calculate_m_and_u_probability_averages(param_records)
+    param_records = compute_proportions_for_new_parameters(param_records)
 
     m_u_records = [
         r

--- a/splink/m_training.py
+++ b/splink/m_training.py
@@ -5,7 +5,7 @@ from .blocking import BlockingRule, block_using_rules_sql
 from .comparison_vector_values import compute_comparison_vector_values_sql
 from .expectation_maximisation import (
     compute_new_parameters_sql,
-    calculate_m_and_u_probability_averages,
+    compute_proportions_for_new_parameters,
 )
 from .m_u_records_to_parameters import (
     m_u_records_to_lookup_dict,
@@ -47,11 +47,11 @@ def estimate_m_values_from_label_column(linker, df_dict, label_colname):
     training_linker._enqueue_sql(sql, "__splink__df_predict")
 
     sql = compute_new_parameters_sql(settings_obj)
-    training_linker._enqueue_sql(sql, "__splink__df_new_params")
+    training_linker._enqueue_sql(sql, "__splink__m_u_counts")
 
     df_params = training_linker._execute_sql_pipeline()
     param_records = df_params.as_pandas_dataframe()
-    param_records = calculate_m_and_u_probability_averages(param_records)
+    param_records = compute_proportions_for_new_parameters(param_records)
 
     m_u_records = [
         r

--- a/splink/m_training.py
+++ b/splink/m_training.py
@@ -3,7 +3,10 @@ import logging
 
 from .blocking import BlockingRule, block_using_rules_sql
 from .comparison_vector_values import compute_comparison_vector_values_sql
-from .expectation_maximisation import compute_new_parameters_sql
+from .expectation_maximisation import (
+    compute_new_parameters_sql,
+    calculate_m_and_u_probability_averages,
+)
 from .m_u_records_to_parameters import (
     m_u_records_to_lookup_dict,
     append_m_probability_to_comparison_level_trained_probabilities,
@@ -47,7 +50,8 @@ def estimate_m_values_from_label_column(linker, df_dict, label_colname):
     training_linker._enqueue_sql(sql, "__splink__df_new_params")
 
     df_params = training_linker._execute_sql_pipeline()
-    param_records = df_params.as_record_dict()
+    param_records = df_params.as_pandas_dataframe()
+    param_records = calculate_m_and_u_probability_averages(param_records)
 
     m_u_records = [
         r


### PR DESCRIPTION
Took me a while to benchmark and test everything across all of our linkers, but after a few different attempts at rewriting the SQL, this is where I'm at.

This PR changes some of the SQL that's generated to perform our m and u training sessions. 

Lots of notes just to explain what's going on here as the benchmarks are quite surprising.

## Changes:
* Adjust the sql output by `compute_new_parameters_sql`. More on this below.
* ~~Add a new function `calculate_m_and_u_probability_averages` - this uses pandas to summarise the outputs from the adjustment sql strings. Previously this was all done in SQL, but given that the outputs are always going to be small (<1000 rows), pandas won't impact performance here.~~
* `calculate_m_and_u_probability_averages` has been replaced by `compute_proportions_for_new_parameters`. This uses duckdb to perform our processing, rather than pandas.

<hr>

### `compute_new_parameters_sql` change summary

To summarise what I've actually changed...

Previously we were running both the m and u training sessions exclusively in SQL. From poking the SQL a bit, it looks like the step to remove all comparison vector values of **_-1_** (indicating a null) was really slowing down our queries.

The original sql was being generated as a series of union statements for each column the user select and looked roughly like so: 
```
    UNION ALL

    SELECT
    gamma_email AS comparison_vector_value,
    SUM(match_probability) / (
        SELECT
        SUM(match_probability)
        FROM __splink__df_predict
        WHERE
        gamma_email <> -1
    ) AS m_probability,
    SUM(1 - match_probability) / (
        SELECT
        SUM(1 - match_probability)
        FROM __splink__df_predict
        WHERE
        gamma_email <> -1
    ) AS u_probability,
    'email' AS output_column_name
    FROM __splink__df_predict
    WHERE
    gamma_email <> -1
    GROUP BY
    gamma_email

```
where all comparisons with nulls were removed in the `where gamma_email <> -1` step.

The `where` statement and `sum(prob)/sum(all probs in table)` sections were the main focus of my changes.

To address the performance issue, I've changed the union statements to look approx like so:
```
   UNION ALL

    SELECT
    gamma_email as comparison_vector_value,
    sum(match_probability) as m_probability,
    sum(1-match_probability) as u_probability,
    'email' as output_column_name
    FROM __splink__df_predict
    group by gamma_email

```
Where we are effectively running a count on the match probability column for the m_prob and u_prob columns.

~~This can then be summarised in python with some pandas code that you can see [here](https://github.com/moj-analytical-services/splink/blob/df370ea404ec79be8d51af5d43e283470bdde8d4/splink/expectation_maximisation.py#L54).~~

The pandas code is now deprecated. Instead we are now summarising directly in duckdb (for consistency with the rest of the codebase). The duckdb code can be found [here](https://github.com/moj-analytical-services/splink/blob/eaba75eeb63bfd5f51ab7a75ee5bafa8c0ddaed7/splink/expectation_maximisation.py#L55).

I did not find any real performance issues with the `cast 0.0 as match_prob` code we have in the u training step, so I've not changed that.

<hr>

**Additional Notes:**
* All tests are passing (incl. on athena).
* If you would prefer the full process to remain in SQL, an additional CTE step should be able to replicate what I am doing with pandas group bys.
* Benchmarks I'll post in follow-up comments.

<br>
<hr>

You can run [the following benchmarking code](https://github.com/moj-analytical-services/splink/blob/79ea3b4c95c73ec9c587c77ee2fd2980bf249301/benchmarking/test_u_performance.py) if you want to adjust the cartesian size/verify results.