### PR TITLE
fix em training tooltip

### DIFF
--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -168,7 +168,8 @@ class EMTrainingSession:
         # in the original (main) setting object
         expectation_maximisation(self, cvv)
 
-        training_desc = f"EM, blocked on: {self._blocking_rule_for_training}"
+        rule = self._blocking_rule_for_training.blocking_rule
+        training_desc = f"EM, blocked on: {rule}"
 
         # Add m and u values to original settings
         for cc in self._settings_obj.comparisons:


### PR DESCRIPTION
Quick one - fixes the tooltip found in the `parameter_estimate_comparisons_chart` for our EM training session blocking rules.

Visually, we previously had:
![Screenshot 2022-07-21 at 12 31 33](https://user-images.githubusercontent.com/45356472/180203699-55ab4fe3-b42f-4628-9b39-3ec79b6d7804.png)

And this just changes it to be:
![Screenshot 2022-07-21 at 12 31 03](https://user-images.githubusercontent.com/45356472/180203727-e275c19f-b919-45b7-9a4a-eb54c023c649.png)

