### PR TITLE
rl suggestions

### DIFF
--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -72,21 +72,29 @@ def completeness_data(linker, input_tablename=None, cols=None):
             linker._initialise_df_concat()
             input_tablename = "__splink__df_concat"
 
-    splink_dataframe = linker._table_to_splink_dataframe(
-        input_tablename, input_tablename
-    )
-    columns = splink_dataframe.columns
-    if cols is not None:
-        columns = [c for c in columns if c.name() in cols]
+    # splink_dataframe = linker._table_to_splink_dataframe(
+    #     input_tablename, input_tablename
+    # )
+    # columns = splink_dataframe.columns
+    # if cols is not None:
+    #     columns = [c for c in columns if c.name() in cols]
+
+    columns = linker._settings_obj._columns_used_by_comparisons
+
+    if linker._settings_obj._source_dataset_column_name_is_required:
+        source_name = linker._settings_obj._source_dataset_column_name
+    else:
+        # Set source dataset to a literal string if dedupe_only
+        source_name = "'_a'"
 
     for col in columns:
         sql = f"""
         (select
-            {linker._settings_obj._source_dataset_column_name} as source_dataset,
-            '{col.name()}' as column_name,
-            count(*) - count({col.name()}) as total_null_rows,
+            {source_name} as source_dataset,
+            '{col}' as column_name,
+            count(*) - count({col}) as total_null_rows,
             count(*) as total_rows_inc_nulls,
-            count({col.name()})*1.0/count(*) as completeness
+            count({col})*1.0/count(*) as completeness
         from {input_tablename}
         group by source_dataset
         order by count(*) desc)

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -172,6 +172,19 @@ class Settings:
         return len(self._blocking_rules_to_generate_predictions) > 1
 
     @property
+    def _columns_used_by_comparisons(self):
+        cols_used = []
+        if self._source_dataset_column_name_is_required:
+            cols_used.append(self._source_dataset_column_name)
+        cols_used.append(self._unique_id_column_name)
+        for cc in self.comparisons:
+            cols = cc._input_columns_used_by_case_statement
+            cols = [c.name() for c in cols]
+
+            cols_used.extend(cols)
+        return dedupe_preserving_order(cols_used)
+
+    @property
     def _columns_to_select_for_blocking(self):
         cols = []
 


### PR DESCRIPTION
- Better to explicitly select columns in use by model.  (I encountered a bug whereby it was trying to add entries for the term frequency adjustment columns in `splink_dataframe`
- Fix an issue with `dedupe_only` jobs whereby `linker._settings_obj._source_dataset_column_name` resolves to `None`
