### PR TITLE
remove duplicate column selections

### DIFF
--- a/splink/misc.py
+++ b/splink/misc.py
@@ -126,7 +126,7 @@ def calculate_reduction_ratio(N, cartesian):
     return 1 - (N / cartesian)
 
 
-def unique_ordered_list(list):
+def dedupe_list_preserving_order(list):
     uniq_val = []
     [uniq_val.append(x) for x in list if x not in uniq_val]
     return uniq_val

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -124,3 +124,9 @@ def calculate_reduction_ratio(N, cartesian):
     the total search space.
     """
     return 1 - (N / cartesian)
+
+
+def unique_ordered_list(list):
+    uniq_val = []
+    [uniq_val.append(x) for x in list if x not in uniq_val]
+    return uniq_val

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -124,9 +124,3 @@ def calculate_reduction_ratio(N, cartesian):
     the total search space.
     """
     return 1 - (N / cartesian)
-
-
-def dedupe_list_preserving_order(list):
-    uniq_val = []
-    [uniq_val.append(x) for x in list if x not in uniq_val]
-    return uniq_val

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -2,13 +2,12 @@ import logging
 from copy import deepcopy
 from typing import List
 from .parse_sql import get_columns_used_from_sql
-from .misc import prob_to_bayes_factor, prob_to_match_weight
+from .misc import prob_to_bayes_factor, prob_to_match_weight, dedupe_preserving_order
 from .charts import m_u_parameters_chart, match_weights_chart
 from .comparison import Comparison
 from .comparison_level import ComparisonLevel
 from .default_from_jsonschema import default_value_from_schema
 from .input_column import InputColumn
-from .misc import dedupe_preserving_order, dedupe_list_preserving_order
 from .validate_jsonschema import validate_settings_against_schema
 from .blocking import BlockingRule
 
@@ -170,10 +169,10 @@ class Settings:
         for cc in self.comparisons:
             cols.extend(cc._columns_to_select_for_blocking)
 
-        for add_col in self._additional_columns_to_retain:
+        for add_col in self._additionamns_to_retain:
             cols.extend(add_col.l_r_names_as_l_r())
 
-        return dedupe_list_preserving_order(cols)
+        return dedupe_preserving_order(cols)
 
     @property
     def _columns_to_select_for_comparison_vector_values(self):

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -169,7 +169,7 @@ class Settings:
         for cc in self.comparisons:
             cols.extend(cc._columns_to_select_for_blocking)
 
-        for add_col in self._additionamns_to_retain:
+        for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.l_r_names_as_l_r())
 
         return dedupe_preserving_order(cols)

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -8,7 +8,7 @@ from .comparison import Comparison
 from .comparison_level import ComparisonLevel
 from .default_from_jsonschema import default_value_from_schema
 from .input_column import InputColumn
-from .misc import dedupe_preserving_order, unique_ordered_list
+from .misc import dedupe_preserving_order, dedupe_list_preserving_order
 from .validate_jsonschema import validate_settings_against_schema
 from .blocking import BlockingRule
 
@@ -173,7 +173,7 @@ class Settings:
         for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.l_r_names_as_l_r())
 
-        return unique_ordered_list(cols)
+        return dedupe_list_preserving_order(cols)
 
     @property
     def _columns_to_select_for_comparison_vector_values(self):

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -8,7 +8,7 @@ from .comparison import Comparison
 from .comparison_level import ComparisonLevel
 from .default_from_jsonschema import default_value_from_schema
 from .input_column import InputColumn
-from .misc import dedupe_preserving_order
+from .misc import dedupe_preserving_order, unique_ordered_list
 from .validate_jsonschema import validate_settings_against_schema
 from .blocking import BlockingRule
 
@@ -173,7 +173,8 @@ class Settings:
         for add_col in self._additional_columns_to_retain:
             cols.extend(add_col.l_r_names_as_l_r())
 
-        return cols
+        return unique_ordered_list(cols)
+        # return cols
 
     @property
     def _columns_to_select_for_comparison_vector_values(self):

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -174,7 +174,6 @@ class Settings:
             cols.extend(add_col.l_r_names_as_l_r())
 
         return unique_ordered_list(cols)
-        # return cols
 
     @property
     def _columns_to_select_for_comparison_vector_values(self):


### PR DESCRIPTION
Resolves [this issue](https://github.com/moj-analytical-services/splink/issues/663).

This code simply removes any duplicate columns that would normally be selected in our SQL statements.

This means that:
* When `retain_matching_columns` is set to False, we retain all columns specified without any errors.
* When `retain_matching_columns` is set to True, we remove any columns that would be output as part of the regular splink process.
* Our columns remain in their original order. Columns specifically requested for retaining will not be moved to the far right of the pandas df/record dict when output.

There may be other areas we need to apply `unique_ordered_list`, but I wanted to get this to you before I go and pass out for a bit.

**Quick example that was previously erroring:**
```
from splink.spark.spark_linker import SparkLinker
import pyspark as spark
from tests.basic_settings import get_settings_dict
from splink.spark.spark_linker import SparkLinker

from pyspark.context import SparkContext, SparkConf
from pyspark.sql import SparkSession

conf = SparkConf()
sc = SparkContext.getOrCreate(conf=conf)
spark = SparkSession(sc)

df_spark = spark.read.csv(
    "tests/datasets/fake_1000_from_splink_demos.csv", header=True
)

settings = get_settings_dict()
settings["additional_columns_to_retain"].append("unique_id")
settings["additional_columns_to_retain"].append("surname")
settings["additional_columns_to_retain"].append("dob")
settings["link_type"]="dedupe_only"
settings["retain_matching_columns"]=False # you can change this to True to check it
settings["retain_intermediate_calculation_columns"]=False

# Run our actual link job
linker = SparkLinker(
    # [df_spark,df_spark],
    df_spark,
    settings,
)

df_predict = linker.predict()
df_predict.as_pandas_dataframe()
```