### PR TITLE
add a custom translation for `cast(<val> as double)` -> `<val>D`

### DIFF
--- a/splink/spark/custom_spark_dialect.py
+++ b/splink/spark/custom_spark_dialect.py
@@ -4,6 +4,15 @@ from sqlglot.dialects import Dialect, Spark
 
 
 def cast_as_double_edit(self, expression):
+    """
+    Forces floating point numbers to the double class in spark,
+    instead of casting them to decimals.
+
+    This resolves the spark issue where decimals only support precision
+    up to 38 digits.
+
+    More info: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
+    """
     datatype = self.sql(expression, "to")
     if datatype.lower() == "double":
         if expression.this.key == "literal":

--- a/splink/spark/custom_spark_dialect.py
+++ b/splink/spark/custom_spark_dialect.py
@@ -13,8 +13,7 @@ def cast_as_double_edit(self, expression):
 
 
 class CustomSpark(Dialect):
-
     class Generator(Generator):
         TRANSFORMS = {
             exp.Cast: cast_as_double_edit,
-            }
+        }

--- a/splink/spark/custom_spark_dialect.py
+++ b/splink/spark/custom_spark_dialect.py
@@ -1,6 +1,6 @@
 from sqlglot import exp
 from sqlglot.generator import Generator
-from sqlglot.dialects import Dialect
+from sqlglot.dialects import Dialect, Spark
 
 
 def cast_as_double_edit(self, expression):
@@ -9,11 +9,15 @@ def cast_as_double_edit(self, expression):
         if expression.this.key == "literal":
             return f"{expression.name}D"
 
-    return expression.sql()
+    return expression.sql(dialect="spark")
 
 
-class CustomSpark(Dialect):
+class CustomSpark(Spark):
     class Generator(Generator):
         TRANSFORMS = {
             exp.Cast: cast_as_double_edit,
+            exp.TryCast: cast_as_double_edit,
         }
+
+
+Dialect["customspark"]

--- a/splink/spark/custom_spark_dialect.py
+++ b/splink/spark/custom_spark_dialect.py
@@ -1,0 +1,20 @@
+from sqlglot import exp
+from sqlglot.generator import Generator
+from sqlglot.dialects import Dialect
+
+
+def cast_as_double_edit(self, expression):
+    datatype = self.sql(expression, "to")
+    if datatype.lower() == "double":
+        if expression.this.key == "literal":
+            return f"{expression.name}D"
+
+    return expression.sql()
+
+
+class CustomSpark(Dialect):
+
+    class Generator(Generator):
+        TRANSFORMS = {
+            exp.Cast: cast_as_double_edit,
+            }

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -6,14 +6,13 @@ import os
 import math
 
 from pyspark.sql import Row
-from sqlglot.dialects.dialect import Dialect
+from .custom_spark_dialect import Dialect
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..misc import ensure_is_list
 from ..input_column import InputColumn
-from .custom_spark_dialect import CustomSpark  # noqa 501
 
 logger = logging.getLogger(__name__)
 
@@ -205,8 +204,7 @@ class SparkLinker(Linker):
     def _execute_sql(self, sql, templated_name, physical_name, transpile=True):
 
         if transpile:
-            sql = sqlglot.transpile(sql, read=None, write="spark", pretty=True)[0]
-            sql = sqlglot.parse_one(sql).sql(dialect="customspark")
+            sql = sqlglot.transpile(sql, read=None, write="customspark", pretty=True)[0]
 
         spark_df = self.spark.sql(sql)
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -6,14 +6,18 @@ import os
 import math
 
 from pyspark.sql import Row
+from sqlglot.dialects.dialect import Dialect
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..misc import ensure_is_list
 from ..input_column import InputColumn
+from .custom_spark_dialect import CustomSpark  # noqa 501
 
 logger = logging.getLogger(__name__)
+
+Dialect["customspark"]
 
 
 class SparkDataframe(SplinkDataFrame):
@@ -202,6 +206,7 @@ class SparkLinker(Linker):
 
         if transpile:
             sql = sqlglot.transpile(sql, read=None, write="spark", pretty=True)[0]
+            sql = sqlglot.parse_one(sql).sql(dialect="customspark")
 
         spark_df = self.spark.sql(sql)
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -2,6 +2,15 @@ import sqlglot
 import sqlglot.expressions as exp
 
 
+def transformer_base(func):
+    def wrapper(sql):
+        syntax_tree = sqlglot.parse_one(sql, read=None)
+        transformed_tree = syntax_tree.transform(func)
+        return transformed_tree.sql()
+
+    return wrapper
+
+
 def _add_l_or_r_to_identifier(node):
     if isinstance(node, exp.Identifier):
         if isinstance(node.parent, exp.Bracket):
@@ -26,7 +35,8 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
     return transformed_tree.sql()
 
 
-def cast_as_varchar_transformer(node):
+@transformer_base
+def cast_concat_as_varchar(node):
     if isinstance(node, exp.Column):
 
         if isinstance(node.parent, exp.Cast):
@@ -38,9 +48,3 @@ def cast_as_varchar_transformer(node):
             return sqlglot.parse_one(sql)
 
     return node
-
-
-def cast_concat_as_varchar(sql):
-    syntax_tree = sqlglot.parse_one(sql, read=None)
-    transformed_tree = syntax_tree.transform(cast_as_varchar_transformer)
-    return transformed_tree.sql()

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -3,7 +3,7 @@ from splink.sql_transform import (
     move_l_r_table_prefix_to_column_suffix,
     cast_concat_as_varchar,
 )
-from splink.spark.custom_spark_dialect import Dialect
+from splink.spark.custom_spark_dialect import Dialect  # noqa 401
 
 
 def test_move_l_r_table_prefix_to_column_suffix():
@@ -58,8 +58,8 @@ def test_cast_concat_as_varchar():
 def test_set_numeric_as_double():
     sql = "select cast('a' as double), cast(0.12345 as double)"
     transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
-    assert transformed_sql == "select 'a'D, 0.12345D"
+    assert transformed_sql == "SELECT aD, 0.12345D"
 
     sql = "select cast('a' as string), cast(0.12345 as double)"
     transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
-    assert transformed_sql == "select cast('a' as string), 0.12345D"
+    assert transformed_sql == "SELECT CAST('a' AS STRING), 0.12345D"

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -3,6 +3,7 @@ from splink.sql_transform import (
     move_l_r_table_prefix_to_column_suffix,
     cast_concat_as_varchar,
 )
+from splink.spark.custom_spark_dialect import Dialect
 
 
 def test_move_l_r_table_prefix_to_column_suffix():
@@ -52,3 +53,13 @@ def test_cast_concat_as_varchar():
     sql = "select source_dataset || '-__-' || unique_id as concat_id"
     transformed_sql = cast_concat_as_varchar(sql)
     assert transformed_sql == output.replace("l.", "")
+
+
+def test_set_numeric_as_double():
+    sql = "select cast('a' as double), cast(0.12345 as double)"
+    transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
+    assert transformed_sql == "select 'a'D, 0.12345D"
+
+    sql = "select cast('a' as string), cast(0.12345 as double)"
+    transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
+    assert transformed_sql == "select cast('a' as string), 0.12345D"


### PR DESCRIPTION
Closes issue #694.

This adds another transpilation step to the spark linker which forces it to use the `1.23D` syntax instead of `cast(1.23 as double)`.

The other solution (to round numbers to 35sf) can be approximately accomplished by:
```
@transformer_base
def set_decimal_limit_on_doubles_tf(node):
    if isinstance(node, exp.Cast):
        datatype = node.args.get("to")
        if datatype.this.name.lower() == "double":
            # if Decimal(node.name).as_tuple().exponent >= -35:
            node = sqlglot.parse_one(f"cast({float(node.name):.35f} as double)")

    return node
```