### PR TITLE
add duckdb helper functions to a separate script

### DIFF
--- a/splink/duckdb/duckdb_helpers.py
+++ b/splink/duckdb/duckdb_helpers.py
@@ -38,6 +38,7 @@ def validate_duckdb_connection(connection, logger):
         "to the connection string, when generating an on-disk database."
     )
 
+
 def create_temporary_duckdb_connection(self):
     """
     Create a temporary duckdb connection.

--- a/splink/duckdb/duckdb_helpers.py
+++ b/splink/duckdb/duckdb_helpers.py
@@ -2,6 +2,7 @@ import duckdb
 import uuid
 import os
 import tempfile
+from pathlib import Path
 
 
 def validate_duckdb_connection(connection, logger):
@@ -48,3 +49,15 @@ def create_temporary_duckdb_connection(self):
     path = os.path.join(self._temp_dir.name, f"{fname}.duckdb")
     con = duckdb.connect(database=path, read_only=False)
     return con
+
+
+def duckdb_load_from_file(path):
+    file_functions = {
+        ".csv": f"read_csv_auto('{path}')",
+        ".parquet": f"read_parquet('{path}')",
+    }
+    file_ext = Path(path).suffix
+    if file_ext in file_functions.keys():
+        return file_functions[file_ext]
+    else:
+        return path

--- a/splink/duckdb/duckdb_helpers.py
+++ b/splink/duckdb/duckdb_helpers.py
@@ -1,0 +1,49 @@
+import duckdb
+import uuid
+import os
+import tempfile
+
+
+def validate_duckdb_connection(connection, logger):
+
+    """Check if the duckdb connection requested by the user is valid.
+
+    Raises:
+        Exception: If the connection is invalid or a warning if
+        the naming convention is ambiguous (not adhering to the
+        duckdb convention).
+    """
+
+    if isinstance(connection, duckdb.DuckDBPyConnection):
+        return
+
+    if not isinstance(connection, str):
+        raise Exception(
+            "Connection must be a string in the form: :memory:, :temporary: "
+            "or the name of a new or existing duckdb database."
+        )
+
+    connection = connection.lower()
+
+    if connection in [":memory:", ":temporary:"]:
+        return
+
+    suffixes = (".duckdb", ".db")
+    if connection.endswith(suffixes):
+        return
+
+    logger.info(
+        f"The registered connection -- {connection} -- has an uncommon file type. "
+        "We recommend that you add a clear suffix of '.db' or '.duckdb' "
+        "to the connection string, when generating an on-disk database."
+    )
+
+def create_temporary_duckdb_connection(self):
+    """
+    Create a temporary duckdb connection.
+    """
+    self._temp_dir = tempfile.TemporaryDirectory(dir=".")
+    fname = uuid.uuid4().hex[:7]
+    path = os.path.join(self._temp_dir.name, f"{fname}.duckdb")
+    con = duckdb.connect(database=path, read_only=False)
+    return con

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from duckdb import DuckDBPyConnection
 import duckdb
 
-from .duckdb_helpers import validate_duckdb_connection, create_temporary_duckdb_connection
+from .duckdb_helpers import (
+    validate_duckdb_connection,
+    create_temporary_duckdb_connection,
+)
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..logging_messages import execute_sql_logging_message_info, log_sql

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -2,7 +2,6 @@ import logging
 from typing import Union, List
 import sqlglot
 from tempfile import TemporaryDirectory
-from pathlib import Path
 
 from duckdb import DuckDBPyConnection
 import duckdb
@@ -10,6 +9,7 @@ import duckdb
 from .duckdb_helpers import (
     validate_duckdb_connection,
     create_temporary_duckdb_connection,
+    duckdb_load_from_file,
 )
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
@@ -18,18 +18,6 @@ from ..misc import ensure_is_list, all_letter_combos
 from ..input_column import InputColumn
 
 logger = logging.getLogger(__name__)
-
-
-def duckdb_load_from_file(path):
-    file_functions = {
-        ".csv": f"read_csv_auto('{path}')",
-        ".parquet": f"read_parquet('{path}')",
-    }
-    file_ext = Path(path).suffix
-    if file_ext in file_functions.keys():
-        return file_functions[file_ext]
-    else:
-        return path
 
 
 class DuckDBLinkerDataFrame(SplinkDataFrame):


### PR DESCRIPTION
Minor change to just reformat the duckdb_linker script and clean things up a little bit.

This PR simply migrates any functions we are using for the duckdb linker to a new script - `duckdb_helpers`.