### PR TITLE
Add support for pairwise format of clusters

### DIFF
--- a/splink/connected_components.py
+++ b/splink/connected_components.py
@@ -354,10 +354,59 @@ def _cc_create_unique_id_cols(
     )
 
 
+def _exit_query(
+    pairwise_mode=False,
+    df_predict=None,
+    representatives=None,
+    uid_cols=None,
+    pairwise_filter=False,
+):
+
+    if pairwise_mode:
+
+        uid_concat_l = _composite_unique_id_from_edges_sql(uid_cols, "l", "n")
+        uid_concat_r = _composite_unique_id_from_edges_sql(uid_cols, "r", "n")
+
+        filter_cond = "where cluster_id_l = cluster_id_r" if pairwise_filter else ""
+
+        return f"""
+            select
+                n.*,
+                repr_l.representative as cluster_id_l,
+                repr_r.representative as cluster_id_r
+            from {df_predict} as n
+            left join
+            {representatives} as repr_l
+                on {uid_concat_l} = repr_l.node_id
+            left join
+            {representatives} as repr_r
+                on {uid_concat_r} = repr_r.node_id
+            {filter_cond}
+            order by
+                cluster_id_l, cluster_id_r
+        """
+
+    else:
+
+        uid_concat = _composite_unique_id_from_nodes_sql(uid_cols, "n")
+
+        return f"""
+            select
+                c.representative as cluster_id, n.*
+            from {representatives} as c
+
+            left join __splink__df_concat_with_tf as n
+            on {uid_concat} = c.node_id
+        """
+
+
 def solve_connected_components(
     linker: "Linker",
     edges_table: SplinkDataFrame,
-    _generated_graph=False,
+    df_predict: SplinkDataFrame,
+    pairwise_output: bool = False,
+    filter_pairwise_format_for_clusters: bool = False,
+    _generated_graph: bool = False,
 ):
     """Connected Components main algorithm.
 
@@ -464,17 +513,15 @@ def solve_connected_components(
     # Create our final representatives table
     # Need to edit how we export the table based on whether we are
     # performing a link or dedupe job.
-
     uid_cols = linker._settings_obj._unique_id_input_columns
-    uid_concat = _composite_unique_id_from_nodes_sql(uid_cols, "n")
 
-    exit_query = f"""
-        select c.representative as cluster_id, n.*
-        from {representatives.physical_name} as c
-        left join __splink__df_concat_with_tf as n
-        on {uid_concat} = c.node_id
-
-    """
+    exit_query = _exit_query(
+        pairwise_mode=pairwise_output,
+        df_predict=df_predict.physical_name,
+        representatives=representatives.physical_name,
+        uid_cols=uid_cols,
+        pairwise_filter=filter_pairwise_format_for_clusters,
+    )
 
     representatives = linker._sql_to_splink_dataframe_checking_cache(
         exit_query,

--- a/splink/connected_components.py
+++ b/splink/connected_components.py
@@ -362,6 +362,9 @@ def _exit_query(
     pairwise_filter=False,
 ):
 
+    representatives = representatives.physical_name if representatives else None
+    df_predict = df_predict.physical_name if df_predict else None
+
     if pairwise_mode:
 
         uid_concat_l = _composite_unique_id_from_edges_sql(uid_cols, "l", "n")
@@ -517,8 +520,8 @@ def solve_connected_components(
 
     exit_query = _exit_query(
         pairwise_mode=pairwise_output,
-        df_predict=df_predict.physical_name,
-        representatives=representatives.physical_name,
+        df_predict=df_predict,
+        representatives=representatives,
         uid_cols=uid_cols,
         pairwise_filter=filter_pairwise_format_for_clusters,
     )

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1210,7 +1210,11 @@ class Linker:
         return predictions
 
     def cluster_pairwise_predictions_at_threshold(
-        self, df_predict: SplinkDataFrame, threshold_match_probability: float
+        self,
+        df_predict: SplinkDataFrame,
+        threshold_match_probability: float,
+        pairwise_formatting: bool = False,
+        filter_pairwise_format_for_clusters: bool = True,
     ) -> SplinkDataFrame:
         """Clusters the pairwise match predictions that result from `linker.predict()`
         into groups of connected record using the connected components graph clustering
@@ -1226,6 +1230,13 @@ class Linker:
                 to include only pairwise comparisons with a match_probability above this
                 threshold. This dataframe is then fed into the clustering
                 algorithm.
+            pairwise_formatting (bool): Whether to output the pairwise match predictions
+                from linker.predict() with cluster IDs.
+                If this is set to false, the output will be a list of all IDs, clustered
+                into groups based on the desired match threshold.
+            filter_pairwise_format_for_clusters (bool): If pairwise formatting has been
+                selected, whether to output all columns found within linker.predict(),
+                or just return clusters.
 
         Returns:
             SplinkDataFrame: A SplinkDataFrame containing a list of all IDs, clustered
@@ -1241,7 +1252,13 @@ class Linker:
             threshold_match_probability,
         )
 
-        cc = solve_connected_components(self, edges_table)
+        cc = solve_connected_components(
+            self,
+            edges_table,
+            df_predict,
+            pairwise_formatting,
+            filter_pairwise_format_for_clusters,
+        )
 
         return cc
 

--- a/tests/cc_testing_utils.py
+++ b/tests/cc_testing_utils.py
@@ -51,7 +51,7 @@ def run_cc_implementation(splink_df):
 
     # finally, run our connected components algorithm
     cc = solve_connected_components(
-        splink_df.duckdb_linker, splink_df, _generated_graph=True
+        splink_df.duckdb_linker, splink_df, df_predict=None, _generated_graph=True
     ).as_pandas_dataframe()
     cc = cc.rename(columns={"unique_id": "node_id", "cluster_id": "representative"})
     cc = cc[["node_id", "representative"]]


### PR DESCRIPTION
Code that allows users to evaluate their clusters in the context of the `linker.predict()` output. Specifically, this allows users the ability to view the match threshold associated with cluster links.

I'm in two minds as to whether this should be its own separate method.
On the one hand it would simplify the original clustering method call and clearly allows us to differentiate between the two.
On the other hand, it introduces a second method that will confuse users too, while they try to wade through all of the documentation.

<br>

**For dedupe jobs, the new output looks like so:**
![Screenshot 2022-08-12 at 16 22 15](https://user-images.githubusercontent.com/45356472/184387220-2c1c4976-9cd0-47fc-8e28-acc713033b90.png)

**And for link jobs, the new format looks like:**
![Screenshot 2022-08-12 at 16 21 15](https://user-images.githubusercontent.com/45356472/184387069-75925b6a-41da-40a3-adf6-43db127e3820.png)


I'll clean up the commentary and add a quick test if you're happy with this as a new feature.