### PR TITLE
[MAINT] Log SQL statements before, not after, they are executed in Spark

### DIFF
--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -259,9 +259,10 @@ class SparkLinker(Linker):
         if transpile:
             sql = sqlglot.transpile(sql, read=None, write="customspark", pretty=True)[0]
 
-        spark_df = self.spark.sql(sql)
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
         logger.log(5, log_sql(sql))
+        spark_df = self.spark.sql(sql)
+
         spark_df = self._break_lineage_and_repartition(
             spark_df, templated_name, physical_name
         )


### PR DESCRIPTION
It's only helpful for debugging if SQL is logged before execution (i.e. before the error occurs, not after!)