### PR TITLE
Add some additional comparison levels

### DIFF
--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -5,6 +5,8 @@ from ..comparison_level_library import (  # noqa: F401
     else_level,
     null_level,
     columns_reversed_level,
+    compare_multiple_columns_to_single_column_level,
+    distance_in_km_level,
 )
 
 _mutable_params["dialect"] = "presto"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -5,8 +5,8 @@ from .comparison_level import ComparisonLevel
 
 
 # So that we can pass in a sql_dialect to the comparison levels
-# that is different depending on whether we're in a SparkComparionLevel,
-# DuckDBComparisonLevel etc.
+# tht depending on whether we're in a SparkComparionLevel,
+# Du
 _mutable_params = {"dialect": None, "levenshtein": "levenshtein"}
 
 
@@ -32,7 +32,7 @@ def distance_function_level(
             None.
 
     Returns:
-        ComparisonLevel:
+        ComparisonLevel: A comparison level for a given distance function
     """
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
 
@@ -55,7 +55,7 @@ def distance_function_level(
     return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
 
 
-def null_level(col_name) -> ComparisonLevel:
+def null_level(col_name, array=False) -> ComparisonLevel:
     """Represents comparisons where one or both sides of the comparison
     contains null values so the similarity cannot be evaluated.
 
@@ -63,12 +63,18 @@ def null_level(col_name) -> ComparisonLevel:
 
     Args:
         col_name (str): Input column name
+        array (bool): If true, the comparison also checks if the array len is 0.
 
     Returns:
         ComparisonLevel: Comparison level
     """
 
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+
+    sql_cond = f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL"
+    if array:
+          sql_cond+=f"\nOR (SIZE({col.name_l()}) = 0 OR SIZE({col.name_r()}) = 0)"
+
     level_dict = {
         "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
         "label_for_charts": "Null",
@@ -109,7 +115,7 @@ def levenshtein_level(
             None.
 
     Returns:
-        ComparisonLevel:
+        ComparisonLevel: A comparison level that evaluates the levenshtein similarity
     """
     lev_name = _mutable_params["levenshtein"]
     return distance_function_level(
@@ -207,7 +213,7 @@ def columns_reversed_level(
             adjustments if an exact match is observed. Defaults to None.
 
     Returns:
-        ComparisonLevel:
+        ComparisonLevel: A comparison level that evaluates the exact match of two columns.
     """
 
     col_1 = InputColumn(col_name_1, sql_dialect=_mutable_params["dialect"])
@@ -223,5 +229,110 @@ def columns_reversed_level(
 
     if tf_adjustment_column:
         level_dict["tf_adjustment_column"] = tf_adjustment_column
+
+    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+
+
+def compare_multiple_columns_to_single_column_level(
+    anchor_column: str, col_list: list, m_probability=None,
+) -> ComparisonLevel:
+    """Compare the exact match of multiple columns against a given anchor column. For example,
+    surname could be compared against both forename1 and forename2, which would compute whether
+    the surname of person 1 matches either forename of person 2. This is useful for comparing
+    columns which can be accidentally swapped, such as names and dates (American vs European dates).
+
+    Args:
+        anchor_column (str): The column to use as the main comparison column
+        col_name_2 (list): A list of columns to compare against the anchor column
+        m_probability (float, optional): Starting value for m probability. Defaults to
+            None.
+
+    Returns:
+        ComparisonLevel: A comparison level that evaluates the exact match of
+            multiple columns against a single anchor column.
+    """
+
+    anchor_column = InputColumn(anchor_column, sql_dialect=_mutable_params["dialect"])
+    comparison_cols = InputColumn(col_list, sql_dialect=_mutable_params["dialect"])
+
+    cc = [InputColumn(c, sql_dialect=_mutable_params["dialect"]) for c in comparison_cols]
+
+    sql_cond = " OR ".join([
+        f"{anchor_column.name_l()} = {c.name_r()}" for c in cc
+    ])
+    level_dict = {
+        "sql_condition": sql_cond,
+        "label_for_charts": "Exact match on reversed cols",
+    }
+    if m_probability:
+        level_dict["m_probability"] = m_probability
+
+    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+
+
+def distance_in_km_level(
+        km_threshold: Union[int, float],
+        lat_lng_array:str=None,
+        lat_col:str=None,
+        long_col:str=None,
+        not_null:bool=False,
+        m_probability=None,
+    ) -> ComparisonLevel:
+    """Use the haversine formula to transform comparisons of lat,lngs
+    into distances measured in kilometers
+
+    Arguments:
+        km_threshold (int): The total distance in kilometers to evaluate your
+            comparisons against
+        lat_lng_array (str): The column name for a concatenated array containing both
+            latitude and longitude in the format: {lat: 53.111111, long: -1.111111}.
+        lat_col (str): If your data is not in array form, you can provide the name of the
+            latitude column indepedently.
+        long_col (str): If your data is not in array form, you can provide the name of the
+            longitudinal column indepedently.
+        not_null (bool): If true, remove any . This is only necessary if you are not capturing
+            nulls elsewhere in your comparison level.
+        m_probability (float, optional): Starting value for m probability. Defaults to
+            None.
+
+
+    Returns:
+        ComparisonLevel: A comparison level that evaluates the distance between two coordinates
+    """
+
+    if lat_lng_array:
+        lat_long = InputColumn(lat_lng_array, sql_dialect=_mutable_params["dialect"])
+        lat_l, lat_r = f"{lat_long.name_l()}['lat']", f"{lat_long.name_r()}['lat']"
+        long_l, long_r = f"{lat_long.name_l()}['long']", f"{lat_long.name_r()}['long']"
+    else:
+        lat = InputColumn(lat_col, sql_dialect=_mutable_params["dialect"])
+        long = InputColumn(long_col, sql_dialect=_mutable_params["dialect"])
+        lat_l, lat_r = lat.name_l(), lat.name_r()
+        long_l, long_r = long.name_l(), long.name_r()
+
+
+    partial_distance_sql = f"""
+    (
+    pow(sin(radians({lat_r} - {lat_l}))/2, 2) +
+    cos(radians({lat_l})) * cos(radians({lat_r})) *
+    pow(sin(radians({long_r} - {long_l})/2),2)
+    )
+    """
+
+    distance_km_sql = f"cast(atan2(sqrt({partial_distance_sql}), sqrt(-1*{partial_distance_sql} + 1)) * 12742 as float)"
+
+    if not_null:
+        null_sql = " AND ".join(
+            [f"{c} is not null" for c in [lat_r, lat_l, long_l, long_r]]
+        )
+        distance_km_sql = f"({null_sql}) AND {distance_km_sql}"
+
+    level_dict = {
+        "sql_condition": distance_km_sql,
+        "label_for_charts": f"Distance less than {km_threshold}km",
+    }
+
+    if m_probability:
+        level_dict["m_probability"] = m_probability
 
     return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -5,8 +5,8 @@ from .comparison_level import ComparisonLevel
 
 
 # So that we can pass in a sql_dialect to the comparison levels
-# tht depending on whether we're in a SparkComparionLevel,
-# Du
+# that is different depending on whether we're in a SparkComparionLevel,
+# DuckDBComparisonLevel etc.
 _mutable_params = {"dialect": None, "levenshtein": "levenshtein"}
 
 
@@ -213,7 +213,8 @@ def columns_reversed_level(
             adjustments if an exact match is observed. Defaults to None.
 
     Returns:
-        ComparisonLevel: A comparison level that evaluates the exact match of two columns.
+        ComparisonLevel: A comparison level that evaluates the exact match of two
+            columns.
     """
 
     col_1 = InputColumn(col_name_1, sql_dialect=_mutable_params["dialect"])
@@ -238,10 +239,11 @@ def compare_multiple_columns_to_single_column_level(
     col_list: list,
     m_probability=None,
 ) -> ComparisonLevel:
-    """Compare the exact match of multiple columns against a given anchor column. For example,
-    surname could be compared against both forename1 and forename2, which would compute whether
-    the surname of person 1 matches either forename of person 2. This is useful for comparing
-    columns which can be accidentally swapped, such as names and dates (American vs European dates).
+    """Compare the exact match of multiple columns against a given anchor column. For
+    example, surname could be compared against both forename1 and forename2, which
+    would compute whether the surname of person 1 matches either forename of person 2.
+    This is useful for comparing columns which can be accidentally swapped, such as
+    names and dates (American vs European dates).
 
     Args:
         anchor_column (str): The column to use as the main comparison column
@@ -288,18 +290,19 @@ def distance_in_km_level(
             comparisons against
         lat_lng_array (str): The column name for a concatenated array containing both
             latitude and longitude in the format: {lat: 53.111111, long: -1.111111}.
-        lat_col (str): If your data is not in array form, you can provide the name of the
-            latitude column indepedently.
-        long_col (str): If your data is not in array form, you can provide the name of the
-            longitudinal column indepedently.
-        not_null (bool): If true, remove any . This is only necessary if you are not capturing
-            nulls elsewhere in your comparison level.
+        lat_col (str): If your data is not in array form, you can provide the name of
+            the latitude column indepedently.
+        long_col (str): If your data is not in array form, you can provide the name of
+            the longitudinal column indepedently.
+        not_null (bool): If true, remove any . This is only necessary if you are not
+            capturing nulls elsewhere in your comparison level.
         m_probability (float, optional): Starting value for m probability. Defaults to
             None.
 
 
     Returns:
-        ComparisonLevel: A comparison level that evaluates the distance between two coordinates
+        ComparisonLevel: A comparison level that evaluates the distance between
+            two coordinates
     """
 
     if lat_lng_array:
@@ -320,7 +323,10 @@ def distance_in_km_level(
     )
     """
 
-    distance_km_sql = f"cast(atan2(sqrt({partial_distance_sql}), sqrt(-1*{partial_distance_sql} + 1)) * 12742 as float)"
+    distance_km_sql = f"""
+        cast(atan2(sqrt({partial_distance_sql}),
+        sqrt(-1*{partial_distance_sql} + 1)) * 12742 as float)
+    """
 
     if not_null:
         null_sql = " AND ".join(

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -73,7 +73,7 @@ def null_level(col_name, array=False) -> ComparisonLevel:
 
     sql_cond = f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL"
     if array:
-          sql_cond+=f"\nOR (SIZE({col.name_l()}) = 0 OR SIZE({col.name_r()}) = 0)"
+        sql_cond += f"\nOR (SIZE({col.name_l()}) = 0 OR SIZE({col.name_r()}) = 0)"
 
     level_dict = {
         "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
@@ -234,7 +234,9 @@ def columns_reversed_level(
 
 
 def compare_multiple_columns_to_single_column_level(
-    anchor_column: str, col_list: list, m_probability=None,
+    anchor_column: str,
+    col_list: list,
+    m_probability=None,
 ) -> ComparisonLevel:
     """Compare the exact match of multiple columns against a given anchor column. For example,
     surname could be compared against both forename1 and forename2, which would compute whether
@@ -255,11 +257,11 @@ def compare_multiple_columns_to_single_column_level(
     anchor_column = InputColumn(anchor_column, sql_dialect=_mutable_params["dialect"])
     comparison_cols = InputColumn(col_list, sql_dialect=_mutable_params["dialect"])
 
-    cc = [InputColumn(c, sql_dialect=_mutable_params["dialect"]) for c in comparison_cols]
+    cc = [
+        InputColumn(c, sql_dialect=_mutable_params["dialect"]) for c in comparison_cols
+    ]
 
-    sql_cond = " OR ".join([
-        f"{anchor_column.name_l()} = {c.name_r()}" for c in cc
-    ])
+    sql_cond = " OR ".join([f"{anchor_column.name_l()} = {c.name_r()}" for c in cc])
     level_dict = {
         "sql_condition": sql_cond,
         "label_for_charts": "Exact match on reversed cols",
@@ -271,13 +273,13 @@ def compare_multiple_columns_to_single_column_level(
 
 
 def distance_in_km_level(
-        km_threshold: Union[int, float],
-        lat_lng_array:str=None,
-        lat_col:str=None,
-        long_col:str=None,
-        not_null:bool=False,
-        m_probability=None,
-    ) -> ComparisonLevel:
+    km_threshold: Union[int, float],
+    lat_lng_array: str = None,
+    lat_col: str = None,
+    long_col: str = None,
+    not_null: bool = False,
+    m_probability=None,
+) -> ComparisonLevel:
     """Use the haversine formula to transform comparisons of lat,lngs
     into distances measured in kilometers
 
@@ -309,7 +311,6 @@ def distance_in_km_level(
         long = InputColumn(long_col, sql_dialect=_mutable_params["dialect"])
         lat_l, lat_r = lat.name_l(), lat.name_r()
         long_l, long_r = long.name_l(), long.name_r()
-
 
     partial_distance_sql = f"""
     (

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -7,6 +7,8 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     distance_function_level,
     columns_reversed_level,
+    compare_multiple_columns_to_single_column_level,
+    distance_in_km_level,
 )
 
 _mutable_params["dialect"] = "duckdb"

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -6,8 +6,10 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     distance_function_level,
     columns_reversed_level,
+    compare_multiple_columns_to_single_column_level,
     jaccard_level,
     jaro_winkler_level,
+    distance_in_km_level,
 )
 from ..input_column import InputColumn
 from ..comparison_level import ComparisonLevel


### PR DESCRIPTION
Links to - but doesn't close - [issue #718](https://github.com/moj-analytical-services/splink/issues/718).

This PR:
* Extends the null level to include a check on arrays.
* Adds a haversine distance level. This can take either an array of the form: `{lat: 53.111111, long: -1.111111}` or individual lat and long columns.
* Add another level - `compare_multiple_columns_to_single_column_level` - to allow slightly different comparisons between columns that can experience reversals (such as first name/surname and dob).

<hr>

## Some more details on the SQL outputs from the new levels:


For comparing multiple columns to an initial anchor column:

`compare_multiple_columns_to_single_column_level("surname", ["first_name1", "first_name_2", "surname"])` outputs to:
```sql
(surname_l = first_name1_r) OR (surname_l = first_name_2_r) OR (surname_l = surname_r)
```

It's intended as an alternative or addition to steps that would initially only check `surname_l = surname_r`.

<hr>

**Haversine** has been checked in both duckdb and spark, against both the column and array versions.

**Some duckdb test code for a df with unique lat and long cols:**
```python
from splink.duckdb.duckdb_comparison_level_library import distance_in_km_level
import duckdb
import pandas as pd

con = duckdb.connect(":memory:")

a_lat, a_long = 53.164179, -1.905769
b_lat, b_long = 58.116443, 42.068886

df_lat_long_indiv = pd.DataFrame({
    "lat_l": [a_lat],
    "long_l": [a_long],
    "lat_r": [b_lat],
    "long_r": [b_long]}
)

con.register("l_l_ind", df_lat_long_indiv)

sql_rads = distance_in_km_level(
    km_threshold=50,
    lat_col="lat",
    long_col="long"
)._level_dict["sql_condition"]

sql = f"""
    select {sql_rads} as rads
    from l_l_ind
"""

con.execute(sql).fetch_df()
```

**Output:**
```python
rads
2761.908936
```
