### PR TITLE
Haversine comparison level

### DIFF
--- a/benchmarking/test_performance.py
+++ b/benchmarking/test_performance.py
@@ -262,6 +262,7 @@ def test_3_rounds_20k_spark(benchmark):
         conf.set("spark.default.parallelism", "8")
 
         sc = SparkContext.getOrCreate(conf=conf)
+        sc.setCheckpointDir("./tmp/splink_checkpoints")
         spark = SparkSession(sc)
 
         for table in spark.catalog.listTables():

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -5,6 +5,7 @@ from ..comparison_level_library import (  # noqa: F401
     else_level,
     null_level,
     columns_reversed_level,
+    distance_in_km_level,
 )
 
 _mutable_params["dialect"] = "presto"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -32,7 +32,7 @@ def distance_function_level(
             None.
 
     Returns:
-        ComparisonLevel:
+        ComparisonLevel: A comparison level for a given distance function
     """
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
 
@@ -109,7 +109,7 @@ def levenshtein_level(
             None.
 
     Returns:
-        ComparisonLevel:
+        ComparisonLevel: A comparison level that evaluates the levenshtein similarity
     """
     lev_name = _mutable_params["levenshtein"]
     return distance_function_level(
@@ -207,7 +207,8 @@ def columns_reversed_level(
             adjustments if an exact match is observed. Defaults to None.
 
     Returns:
-        ComparisonLevel:
+        ComparisonLevel: A comparison level that evaluates the exact match of two
+            columns.
     """
 
     col_1 = InputColumn(col_name_1, sql_dialect=_mutable_params["dialect"])

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -58,12 +58,9 @@ def distance_function_level(
 def null_level(col_name) -> ComparisonLevel:
     """Represents comparisons where one or both sides of the comparison
     contains null values so the similarity cannot be evaluated.
-
     Assumed to have a partial match weight of zero (null effect on overall match weight)
-
     Args:
         col_name (str): Input column name
-
     Returns:
         ComparisonLevel: Comparison level
     """
@@ -229,10 +226,9 @@ def columns_reversed_level(
 
 
 def distance_in_km_level(
+    lat_col: str,
+    long_col: str,
     km_threshold: Union[int, float],
-    lat_lng_array: str = None,
-    lat_col: str = None,
-    long_col: str = None,
     not_null: bool = False,
     m_probability=None,
 ) -> ComparisonLevel:
@@ -240,14 +236,14 @@ def distance_in_km_level(
     into distances measured in kilometers
 
     Arguments:
+        lat_col (str): The name of a latitude column or the respective array
+            or struct column column containing the information
+            For example: long_lat['lat'] or long_lat[0]
+        long_col (str): The name of a longitudinal column or the respective array
+            or struct column column containing the information, plus an index.
+            For example: long_lat['long'] or long_lat[1]
         km_threshold (int): The total distance in kilometers to evaluate your
             comparisons against
-        lat_lng_array (str): The column name for a concatenated array containing both
-            latitude and longitude in the format: {lat: 53.111111, long: -1.111111}.
-        lat_col (str): If your data is not in array form, you can provide the name of
-            the latitude column indepedently.
-        long_col (str): If your data is not in array form, you can provide the name of
-            the longitudinal column indepedently.
         not_null (bool): If true, remove any . This is only necessary if you are not
             capturing nulls elsewhere in your comparison level.
         m_probability (float, optional): Starting value for m probability. Defaults to
@@ -259,15 +255,10 @@ def distance_in_km_level(
             two coordinates
     """
 
-    if lat_lng_array:
-        lat_long = InputColumn(lat_lng_array, sql_dialect=_mutable_params["dialect"])
-        lat_l, lat_r = f"{lat_long.name_l()}['lat']", f"{lat_long.name_r()}['lat']"
-        long_l, long_r = f"{lat_long.name_l()}['long']", f"{lat_long.name_r()}['long']"
-    else:
-        lat = InputColumn(lat_col, sql_dialect=_mutable_params["dialect"])
-        long = InputColumn(long_col, sql_dialect=_mutable_params["dialect"])
-        lat_l, lat_r = lat.name_l(), lat.name_r()
-        long_l, long_r = long.name_l(), long.name_r()
+    lat = InputColumn(lat_col, sql_dialect=_mutable_params["dialect"])
+    long = InputColumn(long_col, sql_dialect=_mutable_params["dialect"])
+    lat_l, lat_r = lat.names_l_r()
+    long_l, long_r = long.names_l_r()
 
     partial_distance_sql = f"""
     (

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -7,6 +7,7 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     distance_function_level,
     columns_reversed_level,
+    distance_in_km_level,
 )
 
 _mutable_params["dialect"] = "duckdb"

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -8,6 +8,7 @@ from ..comparison_level_library import (  # noqa: F401
     columns_reversed_level,
     jaccard_level,
     jaro_winkler_level,
+    distance_in_km_level,
 )
 from ..input_column import InputColumn
 from ..comparison_level import ComparisonLevel

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -3,9 +3,21 @@ import sqlglot.expressions as exp
 
 
 def transformer_base(func):
-    def wrapper(sql):
-        syntax_tree = sqlglot.parse_one(sql, read=None)
-        transformed_tree = syntax_tree.transform(func)
+    def wrapper(sql, *args, **kwargs):
+        """
+        Args:
+            sql Union(str or sqlglot.SyntaxTree): If a sqlglot object
+                is passed to the transformer, it is simply given to the
+                transformer and the resulting sql is returned.
+                If a sql expression is passed, this will be parsed by the
+                sqlglot parser and the resulting syntax tree will be transformed.
+        """
+
+        if isinstance(sql, exp.Expression):
+            syntax_tree = sql
+        else:
+            syntax_tree = sqlglot.parse_one(sql, read=None)
+        transformed_tree = syntax_tree.transform(func, *args, **kwargs)
         return transformed_tree.sql()
 
     return wrapper
@@ -36,6 +48,16 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
 
 
 @transformer_base
+def add_prefix_or_suffix_to_colname(node, escape=True, prefix="", suffix=""):
+    if isinstance(node, exp.Column):
+        node.this.args["this"] = f"{prefix}{node.sql()}{suffix}"
+        if escape:
+            node.this.args["quoted"] = True
+
+    return node
+
+
+@transformer_base
 def cast_concat_as_varchar(node):
     if isinstance(node, exp.Column):
 
@@ -43,7 +65,6 @@ def cast_concat_as_varchar(node):
             return node
 
         if node.find_ancestor(exp.DPipe):
-            # node.sql() = colname w/ table prefix
             sql = f"cast({node.sql()} as varchar)"
             return sqlglot.parse_one(sql)
 

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -60,6 +60,7 @@ def test_haversine_level():
     # Add another the array version of the lat_long column
     for d in data:
         d["lat_long"] = {"lat": d["lat"], "long": d["lon"]}
+        d["lat_long_arr"] = [d["lat"], d["lon"]]
 
     df = pa.Table.from_pylist(data)
 
@@ -78,8 +79,14 @@ def test_haversine_level():
                         long_col="lon",
                     ),
                     distance_in_km_level(
-                        10000,
-                        "lat_long",
+                        lat_col="lat_long['lat']",
+                        long_col="lat_long['long']",
+                        km_threshold=10000,
+                    ),
+                    distance_in_km_level(
+                        lat_col="lat_long_arr[1]",
+                        long_col="lat_long_arr[2]",
+                        km_threshold=100000,
                     ),
                     else_level(),
                 ],
@@ -93,10 +100,15 @@ def test_haversine_level():
     df_e = linker.predict().as_pandas_dataframe()
 
     row = dict(df_e.query("id_l == 1 and id_r == 2").iloc[0])
-    assert row["gamma_lat_long"] == 2
+    assert row["gamma_lat_long"] == 3
 
     # id comparisons w/ dist < 10000km
     id_comb = {(1, 3), (2, 3), (3, 4)}
+    for id_pair in id_comb:
+        row = dict(df_e.query("id_l == {} and id_r == {}".format(*id_pair)).iloc[0])
+        assert row["gamma_lat_long"] == 2
+
+    id_comb = {(1, 4), (2, 4)}
     for id_pair in id_comb:
         row = dict(df_e.query("id_l == {} and id_r == {}".format(*id_pair)).iloc[0])
         assert row["gamma_lat_long"] == 1

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -1,12 +1,13 @@
 import pandas as pd
+import pyarrow as pa
 
-from splink.duckdb.duckdb_comparison_level_library import (
+from splink.comparison_level_library import (
     columns_reversed_level,
     else_level,
     exact_match_level,
     null_level,
+    distance_in_km_level,
 )
-
 from splink.duckdb.duckdb_linker import DuckDBLinker
 
 
@@ -47,3 +48,55 @@ def test_column_reversal():
 
     row = dict(df_e.query("id_l == 3 and id_r == 4").iloc[0])
     assert row["gamma_full_name"] == 2
+
+
+def test_haversine_level():
+    data = [
+        {"id": 1, "lat": 22.730590, "lon": 9.388589},
+        {"id": 2, "lat": 22.836322, "lon": 9.276112},
+        {"id": 3, "lat": 37.770850, "lon": 95.689880},
+        {"id": 4, "lat": -31.336319, "lon": 145.183685},
+    ]
+    # Add another the array version of the lat_long column
+    for d in data:
+        d["lat_long"] = {"lat": d["lat"], "long": d["lon"]}
+
+    df = pa.Table.from_pylist(data)
+
+    settings = {
+        "unique_id_column_name": "id",
+        "link_type": "dedupe_only",
+        "blocking_rules_to_generate_predictions": [],
+        "comparisons": [
+            {
+                "output_column_name": "lat_long",
+                "comparison_levels": [
+                    null_level("lat"),  # no nulls in test data
+                    distance_in_km_level(
+                        km_threshold=50,
+                        lat_col="lat",
+                        long_col="lon",
+                    ),
+                    distance_in_km_level(
+                        10000,
+                        "lat_long",
+                    ),
+                    else_level(),
+                ],
+            },
+        ],
+        "retain_matching_columns": True,
+        "retain_intermediate_calculation_columns": True,
+    }
+
+    linker = DuckDBLinker(df, settings, input_table_aliases="test")
+    df_e = linker.predict().as_pandas_dataframe()
+
+    row = dict(df_e.query("id_l == 1 and id_r == 2").iloc[0])
+    assert row["gamma_lat_long"] == 2
+
+    # id comparisons w/ dist < 10000km
+    id_comb = {(1, 3), (2, 3), (3, 4)}
+    for id_pair in id_comb:
+        row = dict(df_e.query("id_l == {} and id_r == {}".format(*id_pair)).iloc[0])
+        assert row["gamma_lat_long"] == 1

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -4,6 +4,7 @@ from splink.sql_transform import (
     cast_concat_as_varchar,
 )
 from splink.spark.custom_spark_dialect import Dialect  # noqa 401
+from splink.input_column import InputColumn
 
 
 def test_move_l_r_table_prefix_to_column_suffix():
@@ -63,3 +64,39 @@ def test_set_numeric_as_double():
     sql = "select cast('a' as string), cast(0.12345 as double)"
     transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
     assert transformed_sql == "SELECT CAST('a' AS STRING), 0.12345D"
+
+
+def test_add_pref_and_suffix():
+    dull = InputColumn("dull")
+    dull_l_r = ["l.dull as dull_l", "r.dull as dull_r"]
+    assert dull.l_r_names_as_l_r() == dull_l_r
+
+    assert dull.bf_name() == "bf_dull"
+    dull._has_tf_adjustments = True
+    assert dull.tf_name_l() == "tf_dull_l"
+    tf_dull_l_r = ["l.tf_dull as tf_dull_l", "r.tf_dull as tf_dull_r"]
+    assert dull.l_r_tf_names_as_l_r() == tf_dull_l_r
+
+    ll = InputColumn("lat['long']")
+    assert ll.name_l() == "lat_l['long']"
+    ll._has_tf_adjustments = True
+    ll_tf_l_r = [
+        "l.tf_lat['long'] as tf_lat_l['long']",
+        "r.tf_lat['long'] as tf_lat_r['long']",
+    ]
+    assert ll.l_r_tf_names_as_l_r() == ll_tf_l_r
+
+    group = InputColumn("group")
+    assert group.name_l() == '"group_l"'
+    assert group.bf_name() == '"bf_group"'
+    group_l_r_names = ['l."group" as "group_l"', 'r."group" as "group_r"']
+    assert group.l_r_names_as_l_r() == group_l_r_names
+    group._has_tf_adjustments = True
+    group_tf_l_r = ['l."tf_group" as "tf_group_l"', 'r."tf_group" as "tf_group_r"']
+    assert group.l_r_tf_names_as_l_r() == group_tf_l_r
+
+    cols = ["unique_id", "SUR name", "group"]
+    out_cols = ["unique_id", '"SUR name"', '"group"']
+    cols_class = [InputColumn(c) for c in cols]
+    assert [c.name() for c in cols_class] == out_cols
+    assert [InputColumn(c).name(escape=False) for c in cols] == cols


### PR DESCRIPTION
Links to - but doesn't close - [issue #718](https://github.com/moj-analytical-services/splink/issues/718).

This PR:
* Adds a haversine distance level. The user provides a `lat_col` and a `lng_col` arguments, which can be input columns (e.g. a column containing `latitude`, but could also be accessors to a struct or an array in a col e.g. `lat_col=coordinates['lat']`

An example of haversine in action is available in the test.