### PR TITLE
Adjust input col sql logic

### DIFF
--- a/benchmarking/test_performance.py
+++ b/benchmarking/test_performance.py
@@ -262,6 +262,7 @@ def test_3_rounds_20k_spark(benchmark):
         conf.set("spark.default.parallelism", "8")
 
         sc = SparkContext.getOrCreate(conf=conf)
+        sc.setCheckpointDir("./tmp/splink_checkpoints")
         spark = SparkSession(sc)
 
         for table in spark.catalog.listTables():

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -55,27 +55,17 @@ def distance_function_level(
     return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
 
 
-def null_level(col_name, array=False) -> ComparisonLevel:
+def null_level(col_name) -> ComparisonLevel:
     """Represents comparisons where one or both sides of the comparison
     contains null values so the similarity cannot be evaluated.
-
     Assumed to have a partial match weight of zero (null effect on overall match weight)
-
     Args:
         col_name (str): Input column name
-        array (bool): If true, the comparison also checks if the array len is 0.
-
     Returns:
-        ComparisonLevel: Comparison level for null comparisons. Wherever a null is
-            found, the system will remove them from the classification checks.
+        ComparisonLevel: Comparison level
     """
 
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
-
-    sql_cond = f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL"
-    if array:
-        sql_cond += f"\nOR (SIZE({col.name_l()}) = 0 OR SIZE({col.name_r()}) = 0)"
-
     level_dict = {
         "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
         "label_for_charts": "Null",

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -58,12 +58,9 @@ def distance_function_level(
 def null_level(col_name) -> ComparisonLevel:
     """Represents comparisons where one or both sides of the comparison
     contains null values so the similarity cannot be evaluated.
-
     Assumed to have a partial match weight of zero (null effect on overall match weight)
-
     Args:
         col_name (str): Input column name
-
     Returns:
         ComparisonLevel: Comparison level
     """
@@ -229,10 +226,9 @@ def columns_reversed_level(
 
 
 def distance_in_km_level(
+    lat_col: str,
+    long_col: str,
     km_threshold: Union[int, float],
-    lat_lng_array: str = None,
-    lat_col: str = None,
-    long_col: str = None,
     not_null: bool = False,
     m_probability=None,
 ) -> ComparisonLevel:
@@ -240,14 +236,14 @@ def distance_in_km_level(
     into distances measured in kilometers
 
     Arguments:
+        lat_col (str): The name of a latitude column or the respective array
+            or struct column column containing the information
+            For example: long_lat['lat'] or long_lat[0]
+        long_col (str): The name of a longitudinal column or the respective array
+            or struct column column containing the information, plus an index.
+            For example: long_lat['long'] or long_lat[1]
         km_threshold (int): The total distance in kilometers to evaluate your
             comparisons against
-        lat_lng_array (str): The column name for a concatenated array containing both
-            latitude and longitude in the format: {lat: 53.111111, long: -1.111111}.
-        lat_col (str): If your data is not in array form, you can provide the name of
-            the latitude column indepedently.
-        long_col (str): If your data is not in array form, you can provide the name of
-            the longitudinal column indepedently.
         not_null (bool): If true, remove any . This is only necessary if you are not
             capturing nulls elsewhere in your comparison level.
         m_probability (float, optional): Starting value for m probability. Defaults to
@@ -259,15 +255,10 @@ def distance_in_km_level(
             two coordinates
     """
 
-    if lat_lng_array:
-        lat_long = InputColumn(lat_lng_array, sql_dialect=_mutable_params["dialect"])
-        lat_l, lat_r = f"{lat_long.name_l()}['lat']", f"{lat_long.name_r()}['lat']"
-        long_l, long_r = f"{lat_long.name_l()}['long']", f"{lat_long.name_r()}['long']"
-    else:
-        lat = InputColumn(lat_col, sql_dialect=_mutable_params["dialect"])
-        long = InputColumn(long_col, sql_dialect=_mutable_params["dialect"])
-        lat_l, lat_r = lat.name_l(), lat.name_r()
-        long_l, long_r = long.name_l(), long.name_r()
+    lat = InputColumn(lat_col, sql_dialect=_mutable_params["dialect"])
+    long = InputColumn(long_col, sql_dialect=_mutable_params["dialect"])
+    lat_l, lat_r = lat.name_l(), lat.name_r()
+    long_l, long_r = long.name_l(), long.name_r()
 
     partial_distance_sql = f"""
     (

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -36,7 +36,7 @@ class InputColumn:
         else:
             self._sql_dialect = None
 
-        self._escape_needed = _detect_if_name_needs_escaping(name)
+        self._name_needs_escaping = _detect_if_name_needs_escaping(name)
 
     def from_settings_obj_else_default(self, key, schema_key=None):
         # Covers the case where no settings obj is set on the comparison level
@@ -49,7 +49,7 @@ class InputColumn:
 
     @property
     def col(self):
-        if self._escape_needed:
+        if self._name_needs_escaping:
             return exp.Column(this=exp.Identifier(this=self.input_name, quoted=False))
         else:
             return self.input_name
@@ -74,7 +74,7 @@ class InputColumn:
 
     def _escape(self, e=True):
         # Allows for overriding of self._escape_needed.
-        return min(e, self._escape_needed)
+        return min(e, self._name_needs_escaping)
 
     def name(self, escape=True):
         return add_prefix_or_suffix_to_colname(self.col, self._escape(escape))
@@ -117,7 +117,7 @@ class InputColumn:
             return self._has_tf_adjustments
 
         if self._settings_obj:
-            if self.col in self._settings_obj._term_frequency_columns:
+            if self.input_name in self._settings_obj._term_frequency_columns:
                 return True
         return False
 

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -5,6 +5,7 @@ from sqlglot.expressions import Column, Identifier, Bracket
 from .default_from_jsonschema import default_value_from_schema
 from splink.sql_transform import add_prefix_or_suffix_to_colname
 
+
 def _detect_if_name_needs_escaping(name):
     if name in ("group", "index"):
         return True
@@ -49,7 +50,7 @@ class InputColumn:
     @property
     def col(self):
         if self._escape_needed:
-            return exp.Column(this = exp.Identifier(this = self.input_name, quoted=False))
+            return exp.Column(this=exp.Identifier(this=self.input_name, quoted=False))
         else:
             return self.input_name
 
@@ -79,10 +80,14 @@ class InputColumn:
         return add_prefix_or_suffix_to_colname(self.col, self._escape(escape))
 
     def name_l(self, escape=True):
-        return add_prefix_or_suffix_to_colname(self.col, self._escape(escape), suffix="_l")
+        return add_prefix_or_suffix_to_colname(
+            self.col, self._escape(escape), suffix="_l"
+        )
 
     def name_r(self, escape=True):
-        return add_prefix_or_suffix_to_colname(self.col, self._escape(escape), suffix="_r")
+        return add_prefix_or_suffix_to_colname(
+            self.col, self._escape(escape), suffix="_r"
+        )
 
     def names_l_r(self, escape=True):
         e = self._escape(escape)

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,13 +1,17 @@
 import sqlglot
-from sqlglot.expressions import Column, Identifier
+import sqlglot.expressions as exp
+from sqlglot.expressions import Column, Identifier, Bracket
 
 from .default_from_jsonschema import default_value_from_schema
-
+from splink.sql_transform import add_prefix_or_suffix_to_colname
 
 def _detect_if_name_needs_escaping(name):
     if name in ("group", "index"):
         return True
     tree = sqlglot.parse_one(name)
+    if isinstance(tree, Bracket):
+        tree = tree.this
+
     if isinstance(tree, Column) and isinstance(tree.this, Identifier):
         return False
     else:
@@ -31,7 +35,7 @@ class InputColumn:
         else:
             self._sql_dialect = None
 
-        self._name_needs_escaping = _detect_if_name_needs_escaping(name)
+        self._escape_needed = _detect_if_name_needs_escaping(name)
 
     def from_settings_obj_else_default(self, key, schema_key=None):
         # Covers the case where no settings obj is set on the comparison level
@@ -41,6 +45,13 @@ class InputColumn:
             if not schema_key:
                 schema_key = key
             return default_value_from_schema(schema_key, "root")
+
+    @property
+    def col(self):
+        if self._escape_needed:
+            return exp.Column(this = exp.Identifier(this = self.input_name, quoted=False))
+        else:
+            return self.input_name
 
     @property
     def gamma_prefix(self):
@@ -60,47 +71,40 @@ class InputColumn:
             "_tf_prefix", "term_frequency_adjustment_column_prefix"
         )
 
-    def _escape_if_requested(self, column_name, escape):
-        if not escape:
-            return column_name
-        if self._name_needs_escaping:
-            # Create parse tree
-            parsed = sqlglot.parse_one("col")
-
-            # Quote it and replace 'col' with true column_name
-            parsed.this.args["quoted"] = True
-            parsed.this.args["this"] = column_name
-
-            return parsed.sql(dialect=self._sql_dialect)
-        else:
-            return column_name
+    def _escape(self, e=True):
+        # Allows for overriding of self._escape_needed.
+        return min(e, self._escape_needed)
 
     def name(self, escape=True):
-        return self._escape_if_requested(self.input_name, escape)
+        return add_prefix_or_suffix_to_colname(self.col, self._escape(escape))
 
     def name_l(self, escape=True):
-        return self._escape_if_requested(f"{self.input_name}_l", escape)
+        return add_prefix_or_suffix_to_colname(self.col, self._escape(escape), suffix="_l")
 
     def name_r(self, escape=True):
-        return self._escape_if_requested(f"{self.input_name}_r", escape)
+        return add_prefix_or_suffix_to_colname(self.col, self._escape(escape), suffix="_r")
 
     def names_l_r(self, escape=True):
-        return [self.name_l(escape), self.name_r(escape)]
+        e = self._escape(escape)
+        return [self.name_l(e), self.name_r(e)]
 
     def l_name_as_l(self, escape=True):
-        return f"l.{self.name(escape)} as {self.name_l(escape)}"
+        e = self._escape(escape)
+        return f"l.{self.name(e)} as {self.name_l(e)}"
 
     def r_name_as_r(self, escape=True):
-        return f"r.{self.name(escape)} as {self.name_r(escape)}"
+        e = self._escape(escape)
+        return f"r.{self.name(e)} as {self.name_r(e)}"
 
     def l_r_names_as_l_r(self, escape=True):
-        return [self.l_name_as_l(escape), self.r_name_as_r(escape)]
+        e = self._escape(escape)
+        return [self.l_name_as_l(e), self.r_name_as_r(e)]
 
     def bf_name(self, escape=True):
-        bf_prefix = self.from_settings_obj_else_default(
-            "_bf_prefix", "bayes_factor_column_prefix"
+        bf_pref = self.bf_prefix
+        return add_prefix_or_suffix_to_colname(
+            self.col, self._escape(escape), prefix=bf_pref
         )
-        return self._escape_if_requested(f"{bf_prefix}{self.input_name}", escape)
 
     @property
     def has_tf_adjustment(self):
@@ -108,28 +112,29 @@ class InputColumn:
             return self._has_tf_adjustments
 
         if self._settings_obj:
-            if self.input_name in self._settings_obj._term_frequency_columns:
+            if self.col in self._settings_obj._term_frequency_columns:
                 return True
         return False
 
     def tf_name(self, escape=True):
 
-        tf_prefix = self.from_settings_obj_else_default(
-            "_tf_prefix", "term_frequency_adjustment_column_prefix"
-        )
-
-        name = f"{tf_prefix}{self.input_name}"
-
+        tf_pref = self.tf_prefix
         if self.has_tf_adjustment:
-            return self._escape_if_requested(name, escape)
+            return add_prefix_or_suffix_to_colname(
+                self.col, self._escape(escape), prefix=tf_pref
+            )
 
     def tf_name_l(self, escape=True):
         if self.has_tf_adjustment:
-            return self._escape_if_requested(f"{self.tf_name(escape=False)}_l", escape)
+            return add_prefix_or_suffix_to_colname(
+                self.tf_name(escape=False), self._escape(escape), suffix="_l"
+            )
 
     def tf_name_r(self, escape=True):
         if self.has_tf_adjustment:
-            return self._escape_if_requested(f"{self.tf_name(escape=False)}_r", escape)
+            return add_prefix_or_suffix_to_colname(
+                self.tf_name(escape=False), self._escape(escape), suffix="_r"
+            )
 
     def tf_name_l_r(self, escape=True):
         if self.has_tf_adjustment:

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -3,9 +3,21 @@ import sqlglot.expressions as exp
 
 
 def transformer_base(func):
-    def wrapper(sql):
-        syntax_tree = sqlglot.parse_one(sql, read=None)
-        transformed_tree = syntax_tree.transform(func)
+    def wrapper(sql, *args, **kwargs):
+        """
+        Args:
+            sql Union(str or sqlglot.SyntaxTree): If a sqlglot object
+                is passed to the transformer, it is simply given to the
+                transformer and the resulting sql is returned.
+                If a sql expression is passed, this will be parsed by the
+                sqlglot parser and the resulting syntax tree will be transformed.
+        """
+
+        if isinstance(sql, exp.Expression):
+            syntax_tree=sql
+        else:
+            syntax_tree = sqlglot.parse_one(sql, read=None)
+        transformed_tree = syntax_tree.transform(func, *args, **kwargs)
         return transformed_tree.sql()
 
     return wrapper
@@ -36,6 +48,16 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
 
 
 @transformer_base
+def add_prefix_or_suffix_to_colname(node, escape=True, prefix = "", suffix=""):
+    if isinstance(node, exp.Column):
+        node.this.args['this'] = f"{prefix}{node.sql()}{suffix}"
+        if escape:
+            node.this.args["quoted"] = True
+
+    return node
+
+
+@transformer_base
 def cast_concat_as_varchar(node):
     if isinstance(node, exp.Column):
 
@@ -43,7 +65,6 @@ def cast_concat_as_varchar(node):
             return node
 
         if node.find_ancestor(exp.DPipe):
-            # node.sql() = colname w/ table prefix
             sql = f"cast({node.sql()} as varchar)"
             return sqlglot.parse_one(sql)
 

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -14,7 +14,7 @@ def transformer_base(func):
         """
 
         if isinstance(sql, exp.Expression):
-            syntax_tree=sql
+            syntax_tree = sql
         else:
             syntax_tree = sqlglot.parse_one(sql, read=None)
         transformed_tree = syntax_tree.transform(func, *args, **kwargs)
@@ -48,9 +48,9 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
 
 
 @transformer_base
-def add_prefix_or_suffix_to_colname(node, escape=True, prefix = "", suffix=""):
+def add_prefix_or_suffix_to_colname(node, escape=True, prefix="", suffix=""):
     if isinstance(node, exp.Column):
-        node.this.args['this'] = f"{prefix}{node.sql()}{suffix}"
+        node.this.args["this"] = f"{prefix}{node.sql()}{suffix}"
         if escape:
             node.this.args["quoted"] = True
 

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -108,7 +108,7 @@ def test_haversine_level():
         row = dict(df_e.query("id_l == {} and id_r == {}".format(*id_pair)).iloc[0])
         assert row["gamma_lat_long"] == 2
 
-    id_comb = {(1,4), (2,4)}
+    id_comb = {(1, 4), (2, 4)}
     for id_pair in id_comb:
         row = dict(df_e.query("id_l == {} and id_r == {}".format(*id_pair)).iloc[0])
         assert row["gamma_lat_long"] == 1

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -6,6 +6,7 @@ from splink.sql_transform import (
 from splink.spark.custom_spark_dialect import Dialect  # noqa 401
 from splink.input_column import InputColumn
 
+
 def test_move_l_r_table_prefix_to_column_suffix():
 
     br = "l.first_name = r.first_name"
@@ -67,20 +68,22 @@ def test_set_numeric_as_double():
 
 def test_add_pref_and_suffix():
     dull = InputColumn("dull")
-    dull_l_r = ['l.dull as dull_l', 'r.dull as dull_r']
+    dull_l_r = ["l.dull as dull_l", "r.dull as dull_r"]
     assert dull.l_r_names_as_l_r() == dull_l_r
 
     assert dull.bf_name() == "bf_dull"
     dull._has_tf_adjustments = True
     assert dull.tf_name_l() == "tf_dull_l"
-    tf_dull_l_r = ['l.tf_dull as tf_dull_l', 'r.tf_dull as tf_dull_r']
+    tf_dull_l_r = ["l.tf_dull as tf_dull_l", "r.tf_dull as tf_dull_r"]
     assert dull.l_r_tf_names_as_l_r() == tf_dull_l_r
 
     ll = InputColumn("lat['long']")
     assert ll.name_l() == "lat_l['long']"
     ll._has_tf_adjustments = True
-    ll_tf_l_r = ["l.tf_lat['long'] as tf_lat_l['long']",
-            "r.tf_lat['long'] as tf_lat_r['long']"]
+    ll_tf_l_r = [
+        "l.tf_lat['long'] as tf_lat_l['long']",
+        "r.tf_lat['long'] as tf_lat_r['long']",
+    ]
     assert ll.l_r_tf_names_as_l_r() == ll_tf_l_r
 
     group = InputColumn("group")
@@ -92,8 +95,8 @@ def test_add_pref_and_suffix():
     group_tf_l_r = ['l."tf_group" as "tf_group_l"', 'r."tf_group" as "tf_group_r"']
     assert group.l_r_tf_names_as_l_r() == group_tf_l_r
 
-    cols = ['unique_id', 'SUR name', 'group']
-    out_cols = ['unique_id', '"SUR name"', '"group"']
+    cols = ["unique_id", "SUR name", "group"]
+    out_cols = ["unique_id", '"SUR name"', '"group"']
     cols_class = [InputColumn(c) for c in cols]
     assert [c.name() for c in cols_class] == out_cols
     assert [InputColumn(c).name(escape=False) for c in cols] == cols

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -4,7 +4,7 @@ from splink.sql_transform import (
     cast_concat_as_varchar,
 )
 from splink.spark.custom_spark_dialect import Dialect  # noqa 401
-
+from splink.input_column import InputColumn
 
 def test_move_l_r_table_prefix_to_column_suffix():
 
@@ -63,3 +63,37 @@ def test_set_numeric_as_double():
     sql = "select cast('a' as string), cast(0.12345 as double)"
     transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
     assert transformed_sql == "SELECT CAST('a' AS STRING), 0.12345D"
+
+
+def test_add_pref_and_suffix():
+    dull = InputColumn("dull")
+    dull_l_r = ['l.dull as dull_l', 'r.dull as dull_r']
+    assert dull.l_r_names_as_l_r() == dull_l_r
+
+    assert dull.bf_name() == "bf_dull"
+    dull._has_tf_adjustments = True
+    assert dull.tf_name_l() == "tf_dull_l"
+    tf_dull_l_r = ['l.tf_dull as tf_dull_l', 'r.tf_dull as tf_dull_r']
+    assert dull.l_r_tf_names_as_l_r() == tf_dull_l_r
+
+    ll = InputColumn("lat['long']")
+    assert ll.name_l() == "lat_l['long']"
+    ll._has_tf_adjustments = True
+    ll_tf_l_r = ["l.tf_lat['long'] as tf_lat_l['long']",
+            "r.tf_lat['long'] as tf_lat_r['long']"]
+    assert ll.l_r_tf_names_as_l_r() == ll_tf_l_r
+
+    group = InputColumn("group")
+    assert group.name_l() == '"group_l"'
+    assert group.bf_name() == '"bf_group"'
+    group_l_r_names = ['l."group" as "group_l"', 'r."group" as "group_r"']
+    assert group.l_r_names_as_l_r() == group_l_r_names
+    group._has_tf_adjustments = True
+    group_tf_l_r = ['l."tf_group" as "tf_group_l"', 'r."tf_group" as "tf_group_r"']
+    assert group.l_r_tf_names_as_l_r() == group_tf_l_r
+
+    cols = ['unique_id', 'SUR name', 'group']
+    out_cols = ['unique_id', '"SUR name"', '"group"']
+    cols_class = [InputColumn(c) for c in cols]
+    assert [c.name() for c in cols_class] == out_cols
+    assert [InputColumn(c).name(escape=False) for c in cols] == cols


### PR DESCRIPTION
Ok, this ended up being a little bit more involved than our initial discussions yesterday.

In short though, I've replaced some of the old logic in the `InputColumn` class, to now include a SQL transformation step: `add_prefix_or_suffix_to_colname`.

This step simply adds either a prefix or suffix to _**any**_ column and means it shouldn't fail for less standard column inputs that we may have forgotten. And, even if it does, it should be simple enough to fix any issues now in a single line or two of code.

