### PR TITLE
[MAINT] Improve implementation of InputColumn and remove transpile

### DIFF
--- a/benchmarking/test_performance.py
+++ b/benchmarking/test_performance.py
@@ -306,7 +306,7 @@ def test_2_rounds_1k_sqlite(benchmark):
 
     def setup():
         con = sqlite3.connect(":memory:")
-        con.create_function("editdist3", 2, distance)
+        con.create_function("levenshtein", 2, distance)
         df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
         df.to_sql("input_df_tablename", con)
         return (con,), {"target_rows": 1e6}
@@ -325,7 +325,7 @@ def test_10_rounds_20k_sqlite(benchmark):
 
     def setup():
         con = sqlite3.connect(":memory:")
-        con.create_function("editdist3", 2, distance)
+        con.create_function("levenshtein", 2, distance)
         df = pd.read_csv("./benchmarking/fake_20000_from_splink_demos.csv")
         df.to_sql("input_df_tablename", con)
         return (con,), {"target_rows": 3e6}

--- a/poetry.lock
+++ b/poetry.lock
@@ -344,7 +344,7 @@ python-versions = "*"
 name = "py4j"
 version = "0.10.9.3"
 description = "Enables Python programs to dynamically access arbitrary Java objects"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -398,7 +398,7 @@ python-versions = ">=3.7"
 name = "pyspark"
 version = "3.2.1"
 description = "Apache Spark Python API"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -493,7 +493,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "sqlglot"
-version = "4.1.1"
+version = "5.1.0"
 description = "An easily customizable SQL parser and transpiler"
 category = "main"
 optional = false
@@ -557,14 +557,16 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "402699eaaf5dc77dc010735cee9c5c1402aaa19c3448c7a6d7317286e269bd4d"
+content-hash = "f6cfe6d95c1ca7329fcb2832da52823799541471e1a460caab6a1e8d00d04cc1"
 
 [metadata.files]
 altair = [
     {file = "altair-4.2.0-py3-none-any.whl", hash = "sha256:0c724848ae53410c13fa28be2b3b9a9dcb7b5caa1a70f7f217bd663bb419935a"},
     {file = "altair-4.2.0.tar.gz", hash = "sha256:d87d9372e63b48cd96b2a6415f0cf9457f50162ab79dc7a31cd7e024dd840026"},
 ]
-atomicwrites = []
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
+]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.7"
 jsonschema = "^3.2"
 pandas = "^1.0.0"
 duckdb = "^0.4.0"
-sqlglot = "^4.0.0"
+sqlglot = "5.1.0"
 altair = "^4.2.0"
 Jinja2 = "^3.0.3"
 

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -7,13 +7,15 @@ import boto3
 from typing import Union
 import uuid
 
+
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..athena.athena_utils import boto_utils
 from ..input_column import InputColumn
 from ..misc import ensure_is_list
-from ..sql_transform import cast_concat_as_varchar
+from ..sql_transform import sqlglot_transform_sql
+from ..athena.athena_transforms import cast_concat_as_varchar
 
 
 logger = logging.getLogger(__name__)
@@ -314,7 +316,7 @@ class AthenaLinker(Linker):
         # This needs to be removed manually (full s3 path provided)
         self.drop_table_from_database_if_exists(physical_name)
 
-        sql = cast_concat_as_varchar(sql)
+        sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
 
         sql = sql.replace("float", "real")
 

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -315,10 +315,9 @@ class AthenaLinker(Linker):
         # Deletes the table in the db, but not the object on s3.
         # This needs to be removed manually (full s3 path provided)
         self.drop_table_from_database_if_exists(physical_name)
-
         sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
-
-        sql = sql.replace("float", "real")
+        sql = sql.replace("FLOAT", "double").replace("float", "double")
+        #         sql = sql
 
         logger.debug(
             execute_sql_logging_message_info(

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -309,17 +309,13 @@ class AthenaLinker(Linker):
             settings_dict["sql_dialect"] = "presto"
         super().initialise_settings(settings_dict)
 
-    def _execute_sql_against_backend(
-        self, sql, templated_name, physical_name, transpile=True
-    ):
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
 
         # Deletes the table in the db, but not the object on s3.
         # This needs to be removed manually (full s3 path provided)
         self.drop_table_from_database_if_exists(physical_name)
 
-        if transpile:
-            sql = cast_concat_as_varchar(sql)
-            sql = sqlglot.transpile(sql, read=None, write="presto")[0]
+        sql = cast_concat_as_varchar(sql)
 
         sql = sql.replace("float", "real")
 

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -4,7 +4,6 @@ import os
 import awswrangler as wr
 import numpy as np
 import boto3
-import sqlglot
 from typing import Union
 import uuid
 

--- a/splink/athena/athena_transforms.py
+++ b/splink/athena/athena_transforms.py
@@ -1,0 +1,15 @@
+import sqlglot
+from sqlglot import expressions as exp
+
+
+def cast_concat_as_varchar(node):
+    if isinstance(node, exp.Column):
+
+        if isinstance(node.parent, exp.Cast):
+            return node
+
+        if node.find_ancestor(exp.DPipe):
+            sql = f"cast({node.sql()} as varchar)"
+            return sqlglot.parse_one(sql)
+
+    return node

--- a/splink/cluster_studio.py
+++ b/splink/cluster_studio.py
@@ -143,7 +143,6 @@ def _get_random_cluster_ids(
     df_sample = linker._sql_to_splink_dataframe_checking_cache(
         sql,
         "__splink__df_concat_with_tf_sample",
-        transpile=False,
     )
     return [r["cluster_id"] for r in df_sample.as_record_dict()]
 

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -448,7 +448,7 @@ class Comparison:
     def _human_readable_description_succinct(self):
 
         input_cols = join_list_with_commas_final_and(
-            [c.name(escape=False) for c in self._input_columns_used_by_case_statement]
+            [c.name() for c in self._input_columns_used_by_case_statement]
         )
 
         comp_levels = self._comparison_level_description_list
@@ -467,7 +467,7 @@ class Comparison:
     def human_readable_description(self):
 
         input_cols = join_list_with_commas_final_and(
-            [c.name(escape=False) for c in self._input_columns_used_by_case_statement]
+            [c.name() for c in self._input_columns_used_by_case_statement]
         )
 
         comp_levels = self._comparison_level_description_list

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -46,7 +46,7 @@ def _exact_match_colname(sql, sql_dialect=None):
     syntax_tree = sqlglot.parse_one(sql.lower(), read=sql_dialect)
 
     for identifier in syntax_tree.find_all(Identifier):
-        identifier.set(arg="quoted", value=False)
+        identifier.args["quoted"] = False
 
     for tup in syntax_tree.walk():
         subtree = tup[0]

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -161,7 +161,7 @@ class ComparisonLevel:
 
         val = self._level_dict_val_else_default("tf_adjustment_column")
         if val:
-            return InputColumn(val, tf_adjustments=True, sql_dialect=self._sql_dialect)
+            return InputColumn(val, sql_dialect=self._sql_dialect)
         else:
             return None
 
@@ -405,14 +405,8 @@ class ComparisonLevel:
             # We could have tf adjustments for surname on a dmeta_surname column
             # If so, we want to set the tf adjustments against the surname col,
             # not the dmeta_surname one
-            if c == self._tf_adjustment_input_column_name:
-                input_cols.append(
-                    InputColumn(c, tf_adjustments=True, sql_dialect=self._sql_dialect)
-                )
-            else:
-                input_cols.append(
-                    InputColumn(c, tf_adjustments=False, sql_dialect=self._sql_dialect)
-                )
+
+            input_cols.append(InputColumn(c, sql_dialect=self._sql_dialect))
 
         return input_cols
 
@@ -424,7 +418,8 @@ class ComparisonLevel:
 
         for c in cols:
             output_cols.extend(c.l_r_names_as_l_r())
-            output_cols.extend(c.l_r_tf_names_as_l_r())
+            if self._tf_adjustment_input_column:
+                output_cols.extend(c.l_r_tf_names_as_l_r())
 
         return dedupe_preserving_order(output_cols)
 

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -671,7 +671,7 @@ class ComparisonLevel:
     def human_readable_description(self):
 
         input_cols = join_list_with_commas_final_and(
-            [c.name(escape=False) for c in self._input_columns_used_by_sql_condition]
+            [c.name() for c in self._input_columns_used_by_sql_condition]
         )
         desc = (
             f"Comparison level: {self._label_for_charts} of {input_cols}\n"

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -10,7 +10,7 @@ import sqlglot
 from sqlglot.expressions import EQ, Column, Identifier
 
 from .default_from_jsonschema import default_value_from_schema
-from .input_column import InputColumn, unquote
+from .input_column import InputColumn
 from .misc import (
     dedupe_preserving_order,
     interpolate,
@@ -173,7 +173,7 @@ class ComparisonLevel:
     def _tf_adjustment_input_column_name(self):
         input_column = self._tf_adjustment_input_column
         if input_column:
-            return unquote(input_column.input_name)
+            return input_column.unquote().name()
 
     @property
     def _has_comparison(self):

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -166,16 +166,11 @@ class DuckDBLinker(Linker):
     ) -> DuckDBLinkerDataFrame:
         return DuckDBLinkerDataFrame(templated_name, physical_name, self)
 
-    def _execute_sql_against_backend(
-        self, sql, templated_name, physical_name, transpile=True
-    ):
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
 
         # In the case of a table already existing in the database,
         # execute sql is only reached if the user has explicitly turned off the cache
         self._delete_table_from_database(physical_name)
-
-        if transpile:
-            sql = sqlglot.transpile(sql, read=None, write="duckdb", pretty=True)[0]
 
         logger.debug(
             execute_sql_logging_message_info(

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Union, List
-import sqlglot
 from tempfile import TemporaryDirectory
 
 from duckdb import DuckDBPyConnection

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -85,7 +85,6 @@ def estimate_u_values(linker: "Linker", target_rows):
     df_sample = training_linker._sql_to_splink_dataframe_checking_cache(
         sql,
         "__splink__df_concat_with_tf_sample",
-        transpile=False,
     )
 
     settings_obj._blocking_rules_to_generate_predictions = []

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,5 +1,6 @@
 import sqlglot
 import sqlglot.expressions as exp
+from copy import deepcopy
 
 from sqlglot.errors import ParseError
 
@@ -49,11 +50,6 @@ def remove_quotes_from_identifiers(tree):
     return tree
 
 
-def unquote(sql_string):
-
-    return sql_string.replace("`", "").replace('"', "")
-
-
 class InputColumn:
     def __init__(self, name, settings_obj=None, sql_dialect=None):
 
@@ -80,11 +76,21 @@ class InputColumn:
         self.input_name = name
 
         self.input_name_as_tree = self.parse_input_name_to_sqlglot_tree()
-        self.quote()
 
-    def quote(self):
         for identifier in self.input_name_as_tree.find_all(exp.Identifier):
             identifier.set(arg="quoted", value=True)
+
+    def quote(self):
+        self_copy = deepcopy(self)
+        for identifier in self_copy.input_name_as_tree.find_all(exp.Identifier):
+            identifier.set(arg="quoted", value=True)
+        return self_copy
+
+    def unquote(self):
+        self_copy = deepcopy(self)
+        for identifier in self_copy.input_name_as_tree.find_all(exp.Identifier):
+            identifier.set(arg="quoted", value=False)
+        return self_copy
 
     def parse_input_name_to_sqlglot_tree(self):
 

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -75,6 +75,7 @@ class InputColumn:
         self.input_name = name
 
         self.input_name_as_tree = self.parse_input_name_to_sqlglot_tree()
+        self.quote()
 
     def quote(self):
         for identifier in self.input_name_as_tree.find_all(exp.Identifier):

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,170 +1,188 @@
-# import sqlglot
-# import sqlglot.expressions as exp
-# from sqlglot.expressions import Column, Identifier, Bracket
+import sqlglot
+import sqlglot.expressions as exp
 
-# from .default_from_jsonschema import default_value_from_schema
-# from splink.sql_transform import add_prefix_or_suffix_to_colname
+from sqlglot.errors import ParseError
 
-
-# def _detect_if_name_needs_escaping(name):
-#     if name in ("group", "index"):
-#         return True
-#     tree = sqlglot.parse_one(name)
-#     if isinstance(tree, Bracket):
-#         tree = tree.this
-
-#     if isinstance(tree, Column) and isinstance(tree.this, Identifier):
-#         return False
-#     else:
-#         return True
+from .default_from_jsonschema import default_value_from_schema
+from splink.sql_transform import add_prefix_or_suffix_to_colname
 
 
-# class InputColumn:
-#     def __init__(self, name, tf_adjustments=False, settings_obj=None, sql_dialect=None):
+def sqlglot_tree_signature(tree):
+    """
+    A short string representation of a SQLglot tree.
 
-#         # If settings_obj is None, then default values will be used
-#         # from the jsonschama
-#         self._settings_obj = settings_obj
-#         self._has_tf_adjustments = tf_adjustments
+    Allows you to easily check that a tree contains certain nodes
 
-#         self.input_name = name
-
-#         if sql_dialect:
-#             self._sql_dialect = sql_dialect
-#         elif settings_obj:
-#             self._sql_dialect = getattr(self._settings_obj, "_sql_dialect")
-#         else:
-#             self._sql_dialect = None
-
-#         self._name_needs_escaping = _detect_if_name_needs_escaping(name)
-
-#     def from_settings_obj_else_default(self, key, schema_key=None):
-#         # Covers the case where no settings obj is set on the comparison level
-#         if self._settings_obj:
-#             return getattr(self._settings_obj, key)
-#         else:
-#             if not schema_key:
-#                 schema_key = key
-#             return default_value_from_schema(schema_key, "root")
-
-#     @property
-#     def col(self):
-#         if self._name_needs_escaping:
-#             return exp.Column(this=exp.Identifier(this=self.input_name, quoted=False))
-#         else:
-#             return self.input_name
-
-#     @property
-#     def gamma_prefix(self):
-#         return self.from_settings_obj_else_default(
-#             "_gamma_prefix", "comparison_vector_value_column_prefix"
-#         )
-
-#     @property
-#     def bf_prefix(self):
-#         return self.from_settings_obj_else_default(
-#             "_bf_prefix", "bayes_factor_column_prefix"
-#         )
-
-#     @property
-#     def tf_prefix(self):
-#         return self.from_settings_obj_else_default(
-#             "_tf_prefix", "term_frequency_adjustment_column_prefix"
-#         )
-
-#     def _escape(self, e=True):
-#         # Allows for overriding of self._escape_needed.
-#         return min(e, self._name_needs_escaping)
-
-#     def name(self, escape=True):
-#         return add_prefix_or_suffix_to_colname(self.col, self._escape(escape))
-
-#     def name_l(self, escape=True):
-#         return add_prefix_or_suffix_to_colname(
-#             self.col, self._escape(escape), suffix="_l"
-#         )
-
-#     def name_r(self, escape=True):
-#         return add_prefix_or_suffix_to_colname(
-#             self.col, self._escape(escape), suffix="_r"
-#         )
-
-#     def names_l_r(self, escape=True):
-#         e = self._escape(escape)
-#         return [self.name_l(e), self.name_r(e)]
-
-#     def l_name_as_l(self, escape=True):
-#         e = self._escape(escape)
-#         return f"l.{self.name(e)} as {self.name_l(e)}"
-
-#     def r_name_as_r(self, escape=True):
-#         e = self._escape(escape)
-#         return f"r.{self.name(e)} as {self.name_r(e)}"
-
-#     def l_r_names_as_l_r(self, escape=True):
-#         e = self._escape(escape)
-#         return [self.l_name_as_l(e), self.r_name_as_r(e)]
-
-#     def bf_name(self, escape=True):
-#         bf_pref = self.bf_prefix
-#         return add_prefix_or_suffix_to_colname(
-#             self.col, self._escape(escape), prefix=bf_pref
-#         )
-
-#     @property
-#     def has_tf_adjustment(self):
-#         if self._has_tf_adjustments is not None:
-#             return self._has_tf_adjustments
-
-#         if self._settings_obj:
-#             if self.input_name in self._settings_obj._term_frequency_columns:
-#                 return True
-#         return False
-
-#     def tf_name(self, escape=True):
-
-#         tf_pref = self.tf_prefix
-#         if self.has_tf_adjustment:
-#             return add_prefix_or_suffix_to_colname(
-#                 self.col, self._escape(escape), prefix=tf_pref
-#             )
-
-#     def tf_name_l(self, escape=True):
-#         if self.has_tf_adjustment:
-#             return add_prefix_or_suffix_to_colname(
-#                 self.tf_name(escape=False), self._escape(escape), suffix="_l"
-#             )
-
-#     def tf_name_r(self, escape=True):
-#         if self.has_tf_adjustment:
-#             return add_prefix_or_suffix_to_colname(
-#                 self.tf_name(escape=False), self._escape(escape), suffix="_r"
-#             )
-
-#     def tf_name_l_r(self, escape=True):
-#         if self.has_tf_adjustment:
-#             return [self.tf_name_l(escape), self.tf_name_r(escape)]
-#         else:
-#             return []
-
-#     def l_tf_name_as_l(self, escape=True):
-#         if self.has_tf_adjustment:
-#             return f"l.{self.tf_name(escape)} as {self.tf_name_l(escape)}"
-
-#     def r_tf_name_as_r(self, escape=True):
-#         if self.has_tf_adjustment:
-#             return f"r.{self.tf_name(escape)} as {self.tf_name_r(escape)}"
-
-#     def l_r_tf_names_as_l_r(self, escape=True):
-#         if self.has_tf_adjustment:
-#             return [self.l_tf_name_as_l(escape), self.r_tf_name_as_r(escape)]
-#         else:
-#             return []
+    For instance, the string "robin['hi']" becomes:
+    'bracket column literal identifier'
+    """
+    return " ".join(n[0].key for n in tree.walk())
 
 
 class InputColumn:
     def __init__(self, name, tf_adjustments=False, settings_obj=None, sql_dialect=None):
-        self.parsed_col = sqlglot.parse_one(name)
 
-        # Check whether escape is needed by attempting to parse and asking whether the
-        # tree starts with a bracket or column
+        # If settings_obj is None, then default values will be used
+        # from the jsonschama
+        self._settings_obj = settings_obj
+        self._has_tf_adjustments = tf_adjustments
+
+        self.input_name = name
+
+        if sql_dialect:
+            self._sql_dialect = sql_dialect
+        elif settings_obj:
+            self._sql_dialect = getattr(self._settings_obj, "_sql_dialect")
+        else:
+            self._sql_dialect = None
+
+        self.input_name_as_tree = self.parse_input_name_to_sqlglot_tree()
+
+        # Make sure the identifier (column name) is quoted in all cases
+        self.input_name_as_tree.find(exp.Identifier).set(arg="quoted", value=True)
+
+    def parse_input_name_to_sqlglot_tree(self):
+
+        # Cases that could occur for self.input_name:
+        # SUR name  -> parses to 'alias column identifier identifier'
+        # first and surname -> parses to 'and column column identifier identifier'
+        # a b c -> parse error
+        # "SUR name" -> parses to 'column identifier'
+        # geocode['lat'] -> parsees to bracket column literal identifier
+        # geocode[1] -> parsees to bracket column literal identifier
+
+        # Note we don't expect SUR name[1] since the user should have quoted this
+
+        try:
+            tree = sqlglot.parse_one(self.input_name)
+        except ParseError:
+            tree = sqlglot.parse_one(f'"{self.input_name}"')
+
+        tree_signature = sqlglot_tree_signature(tree)
+        valid_signatures = ["column identifier", "bracket column literal identifier"]
+
+        if tree_signature in valid_signatures:
+            return tree
+        else:
+            # e.g. SUR name parses to 'alias column identifier identifier'
+            # but we want "SUR name"
+            tree = sqlglot.parse_one(f'"{self.input_name}"')
+            return tree
+
+    def from_settings_obj_else_default(self, key, schema_key=None):
+        # Covers the case where no settings obj is set on the comparison level
+        if self._settings_obj:
+            return getattr(self._settings_obj, key)
+        else:
+            if not schema_key:
+                schema_key = key
+            return default_value_from_schema(schema_key, "root")
+
+    @property
+    def gamma_prefix(self):
+        return self.from_settings_obj_else_default(
+            "_gamma_prefix", "comparison_vector_value_column_prefix"
+        )
+
+    @property
+    def bf_prefix(self):
+        return self.from_settings_obj_else_default(
+            "_bf_prefix", "bayes_factor_column_prefix"
+        )
+
+    def add_suffix(self, tree, suffix):
+        tree = tree.copy()
+        identifier_string = tree.find(exp.Identifier).this
+        identifier_string = f"{identifier_string}{suffix}"
+        tree.find(exp.Identifier).set(arg="this", value=identifier_string)
+        return tree
+
+    def add_prefix(self, tree, prefix):
+        tree = tree.copy()
+        identifier_string = tree.find(exp.Identifier).this
+        identifier_string = f"{prefix}{identifier_string}"
+        tree.find(exp.Identifier).set(arg="this", value=identifier_string)
+        return tree
+
+    def add_table(self, tree, tablename):
+        tree = tree.copy()
+        table_identifier = exp.Identifier(this=tablename, quoted=True)
+        identifier = tree.find(exp.Column)
+        identifier.set(arg="table", value=table_identifier)
+        return tree
+
+    @property
+    def tf_prefix(self):
+        return self.from_settings_obj_else_default(
+            "_tf_prefix", "term_frequency_adjustment_column_prefix"
+        )
+
+    def name(self):
+        return self.input_name_as_tree.sql()
+
+    def name_l(self):
+        return self.add_suffix(self.input_name_as_tree, suffix="_l").sql()
+
+    def name_r(self):
+        return self.add_suffix(self.input_name_as_tree, suffix="_l").sql()
+
+    def names_l_r(self):
+        return [self.name_l(), self.name_r()]
+
+    def l_name_as_l(self):
+        name_with_l_table = self.add_table(self.input_name_as_tree, "l").sql()
+        return f"{name_with_l_table} as {self.name_l()}"
+
+    def r_name_as_r(self):
+        name_with_r_table = self.add_table(self.input_name_as_tree, "r").sql()
+        return f"{name_with_r_table} as {self.name_l()}"
+
+    def l_r_names_as_l_r(self):
+        return [self.l_name_as_l(), self.r_name_as_r()]
+
+    def bf_name(self):
+        return self.add_prefix(self.input_name_as_tree, suffix=self.bf_prefix).sql()
+
+    @property
+    def has_tf_adjustment(self):
+        if self._has_tf_adjustments is not None:
+            return self._has_tf_adjustments
+
+        if self._settings_obj:
+            if self.input_name in self._settings_obj._term_frequency_columns:
+                return True
+        return False
+
+    def tf_name(self):
+
+        tf_pref = self.tf_prefix
+        if self.has_tf_adjustment:
+            return add_prefix_or_suffix_to_colname(self.col, prefix=tf_pref)
+
+    def tf_name_l(self):
+        if self.has_tf_adjustment:
+            return add_prefix_or_suffix_to_colname(self.tf_name(), suffix="_l")
+
+    def tf_name_r(self):
+        if self.has_tf_adjustment:
+            return add_prefix_or_suffix_to_colname(self.tf_name(), suffix="_r")
+
+    def tf_name_l_r(self):
+        if self.has_tf_adjustment:
+            return [self.tf_name_l(), self.tf_name_r()]
+        else:
+            return []
+
+    def l_tf_name_as_l(self):
+        if self.has_tf_adjustment:
+            return f"l.{self.tf_name()} as {self.tf_name_l()}"
+
+    def r_tf_name_as_r(self):
+        if self.has_tf_adjustment:
+            return f"r.{self.tf_name()} as {self.tf_name_r()}"
+
+    def l_r_tf_names_as_l_r(self):
+        if self.has_tf_adjustment:
+            return [self.l_tf_name_as_l(), self.r_tf_name_as_r()]
+        else:
+            return []

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -51,7 +51,7 @@ def remove_quotes_from_identifiers(tree):
 
 def unquote(sql_string):
 
-    return sql_string.replace("`", "", '"', "")
+    return sql_string.replace("`", "").replace('"', "")
 
 
 class InputColumn:

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -49,6 +49,11 @@ def remove_quotes_from_identifiers(tree):
     return tree
 
 
+def unquote(sql_string):
+
+    return sql_string.replace("`", "", '"', "")
+
+
 class InputColumn:
     def __init__(self, name, settings_obj=None, sql_dialect=None):
 
@@ -80,12 +85,6 @@ class InputColumn:
     def quote(self):
         for identifier in self.input_name_as_tree.find_all(exp.Identifier):
             identifier.set(arg="quoted", value=True)
-        return self
-
-    def unquote(self):
-        for identifier in self.input_name_as_tree.find_all(exp.Identifier):
-            identifier.set(arg="quoted", value=False)
-        return self
 
     def parse_input_name_to_sqlglot_tree(self):
 

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,162 +1,170 @@
-import sqlglot
-import sqlglot.expressions as exp
-from sqlglot.expressions import Column, Identifier, Bracket
+# import sqlglot
+# import sqlglot.expressions as exp
+# from sqlglot.expressions import Column, Identifier, Bracket
 
-from .default_from_jsonschema import default_value_from_schema
-from splink.sql_transform import add_prefix_or_suffix_to_colname
+# from .default_from_jsonschema import default_value_from_schema
+# from splink.sql_transform import add_prefix_or_suffix_to_colname
 
 
-def _detect_if_name_needs_escaping(name):
-    if name in ("group", "index"):
-        return True
-    tree = sqlglot.parse_one(name)
-    if isinstance(tree, Bracket):
-        tree = tree.this
+# def _detect_if_name_needs_escaping(name):
+#     if name in ("group", "index"):
+#         return True
+#     tree = sqlglot.parse_one(name)
+#     if isinstance(tree, Bracket):
+#         tree = tree.this
 
-    if isinstance(tree, Column) and isinstance(tree.this, Identifier):
-        return False
-    else:
-        return True
+#     if isinstance(tree, Column) and isinstance(tree.this, Identifier):
+#         return False
+#     else:
+#         return True
+
+
+# class InputColumn:
+#     def __init__(self, name, tf_adjustments=False, settings_obj=None, sql_dialect=None):
+
+#         # If settings_obj is None, then default values will be used
+#         # from the jsonschama
+#         self._settings_obj = settings_obj
+#         self._has_tf_adjustments = tf_adjustments
+
+#         self.input_name = name
+
+#         if sql_dialect:
+#             self._sql_dialect = sql_dialect
+#         elif settings_obj:
+#             self._sql_dialect = getattr(self._settings_obj, "_sql_dialect")
+#         else:
+#             self._sql_dialect = None
+
+#         self._name_needs_escaping = _detect_if_name_needs_escaping(name)
+
+#     def from_settings_obj_else_default(self, key, schema_key=None):
+#         # Covers the case where no settings obj is set on the comparison level
+#         if self._settings_obj:
+#             return getattr(self._settings_obj, key)
+#         else:
+#             if not schema_key:
+#                 schema_key = key
+#             return default_value_from_schema(schema_key, "root")
+
+#     @property
+#     def col(self):
+#         if self._name_needs_escaping:
+#             return exp.Column(this=exp.Identifier(this=self.input_name, quoted=False))
+#         else:
+#             return self.input_name
+
+#     @property
+#     def gamma_prefix(self):
+#         return self.from_settings_obj_else_default(
+#             "_gamma_prefix", "comparison_vector_value_column_prefix"
+#         )
+
+#     @property
+#     def bf_prefix(self):
+#         return self.from_settings_obj_else_default(
+#             "_bf_prefix", "bayes_factor_column_prefix"
+#         )
+
+#     @property
+#     def tf_prefix(self):
+#         return self.from_settings_obj_else_default(
+#             "_tf_prefix", "term_frequency_adjustment_column_prefix"
+#         )
+
+#     def _escape(self, e=True):
+#         # Allows for overriding of self._escape_needed.
+#         return min(e, self._name_needs_escaping)
+
+#     def name(self, escape=True):
+#         return add_prefix_or_suffix_to_colname(self.col, self._escape(escape))
+
+#     def name_l(self, escape=True):
+#         return add_prefix_or_suffix_to_colname(
+#             self.col, self._escape(escape), suffix="_l"
+#         )
+
+#     def name_r(self, escape=True):
+#         return add_prefix_or_suffix_to_colname(
+#             self.col, self._escape(escape), suffix="_r"
+#         )
+
+#     def names_l_r(self, escape=True):
+#         e = self._escape(escape)
+#         return [self.name_l(e), self.name_r(e)]
+
+#     def l_name_as_l(self, escape=True):
+#         e = self._escape(escape)
+#         return f"l.{self.name(e)} as {self.name_l(e)}"
+
+#     def r_name_as_r(self, escape=True):
+#         e = self._escape(escape)
+#         return f"r.{self.name(e)} as {self.name_r(e)}"
+
+#     def l_r_names_as_l_r(self, escape=True):
+#         e = self._escape(escape)
+#         return [self.l_name_as_l(e), self.r_name_as_r(e)]
+
+#     def bf_name(self, escape=True):
+#         bf_pref = self.bf_prefix
+#         return add_prefix_or_suffix_to_colname(
+#             self.col, self._escape(escape), prefix=bf_pref
+#         )
+
+#     @property
+#     def has_tf_adjustment(self):
+#         if self._has_tf_adjustments is not None:
+#             return self._has_tf_adjustments
+
+#         if self._settings_obj:
+#             if self.input_name in self._settings_obj._term_frequency_columns:
+#                 return True
+#         return False
+
+#     def tf_name(self, escape=True):
+
+#         tf_pref = self.tf_prefix
+#         if self.has_tf_adjustment:
+#             return add_prefix_or_suffix_to_colname(
+#                 self.col, self._escape(escape), prefix=tf_pref
+#             )
+
+#     def tf_name_l(self, escape=True):
+#         if self.has_tf_adjustment:
+#             return add_prefix_or_suffix_to_colname(
+#                 self.tf_name(escape=False), self._escape(escape), suffix="_l"
+#             )
+
+#     def tf_name_r(self, escape=True):
+#         if self.has_tf_adjustment:
+#             return add_prefix_or_suffix_to_colname(
+#                 self.tf_name(escape=False), self._escape(escape), suffix="_r"
+#             )
+
+#     def tf_name_l_r(self, escape=True):
+#         if self.has_tf_adjustment:
+#             return [self.tf_name_l(escape), self.tf_name_r(escape)]
+#         else:
+#             return []
+
+#     def l_tf_name_as_l(self, escape=True):
+#         if self.has_tf_adjustment:
+#             return f"l.{self.tf_name(escape)} as {self.tf_name_l(escape)}"
+
+#     def r_tf_name_as_r(self, escape=True):
+#         if self.has_tf_adjustment:
+#             return f"r.{self.tf_name(escape)} as {self.tf_name_r(escape)}"
+
+#     def l_r_tf_names_as_l_r(self, escape=True):
+#         if self.has_tf_adjustment:
+#             return [self.l_tf_name_as_l(escape), self.r_tf_name_as_r(escape)]
+#         else:
+#             return []
 
 
 class InputColumn:
     def __init__(self, name, tf_adjustments=False, settings_obj=None, sql_dialect=None):
+        self.parsed_col = sqlglot.parse_one(name)
 
-        # If settings_obj is None, then default values will be used
-        # from the jsonschama
-        self._settings_obj = settings_obj
-        self._has_tf_adjustments = tf_adjustments
-
-        self.input_name = name
-
-        if sql_dialect:
-            self._sql_dialect = sql_dialect
-        elif settings_obj:
-            self._sql_dialect = getattr(self._settings_obj, "_sql_dialect")
-        else:
-            self._sql_dialect = None
-
-        self._name_needs_escaping = _detect_if_name_needs_escaping(name)
-
-    def from_settings_obj_else_default(self, key, schema_key=None):
-        # Covers the case where no settings obj is set on the comparison level
-        if self._settings_obj:
-            return getattr(self._settings_obj, key)
-        else:
-            if not schema_key:
-                schema_key = key
-            return default_value_from_schema(schema_key, "root")
-
-    @property
-    def col(self):
-        if self._name_needs_escaping:
-            return exp.Column(this=exp.Identifier(this=self.input_name, quoted=False))
-        else:
-            return self.input_name
-
-    @property
-    def gamma_prefix(self):
-        return self.from_settings_obj_else_default(
-            "_gamma_prefix", "comparison_vector_value_column_prefix"
-        )
-
-    @property
-    def bf_prefix(self):
-        return self.from_settings_obj_else_default(
-            "_bf_prefix", "bayes_factor_column_prefix"
-        )
-
-    @property
-    def tf_prefix(self):
-        return self.from_settings_obj_else_default(
-            "_tf_prefix", "term_frequency_adjustment_column_prefix"
-        )
-
-    def _escape(self, e=True):
-        # Allows for overriding of self._escape_needed.
-        return min(e, self._name_needs_escaping)
-
-    def name(self, escape=True):
-        return add_prefix_or_suffix_to_colname(self.col, self._escape(escape))
-
-    def name_l(self, escape=True):
-        return add_prefix_or_suffix_to_colname(
-            self.col, self._escape(escape), suffix="_l"
-        )
-
-    def name_r(self, escape=True):
-        return add_prefix_or_suffix_to_colname(
-            self.col, self._escape(escape), suffix="_r"
-        )
-
-    def names_l_r(self, escape=True):
-        e = self._escape(escape)
-        return [self.name_l(e), self.name_r(e)]
-
-    def l_name_as_l(self, escape=True):
-        e = self._escape(escape)
-        return f"l.{self.name(e)} as {self.name_l(e)}"
-
-    def r_name_as_r(self, escape=True):
-        e = self._escape(escape)
-        return f"r.{self.name(e)} as {self.name_r(e)}"
-
-    def l_r_names_as_l_r(self, escape=True):
-        e = self._escape(escape)
-        return [self.l_name_as_l(e), self.r_name_as_r(e)]
-
-    def bf_name(self, escape=True):
-        bf_pref = self.bf_prefix
-        return add_prefix_or_suffix_to_colname(
-            self.col, self._escape(escape), prefix=bf_pref
-        )
-
-    @property
-    def has_tf_adjustment(self):
-        if self._has_tf_adjustments is not None:
-            return self._has_tf_adjustments
-
-        if self._settings_obj:
-            if self.input_name in self._settings_obj._term_frequency_columns:
-                return True
-        return False
-
-    def tf_name(self, escape=True):
-
-        tf_pref = self.tf_prefix
-        if self.has_tf_adjustment:
-            return add_prefix_or_suffix_to_colname(
-                self.col, self._escape(escape), prefix=tf_pref
-            )
-
-    def tf_name_l(self, escape=True):
-        if self.has_tf_adjustment:
-            return add_prefix_or_suffix_to_colname(
-                self.tf_name(escape=False), self._escape(escape), suffix="_l"
-            )
-
-    def tf_name_r(self, escape=True):
-        if self.has_tf_adjustment:
-            return add_prefix_or_suffix_to_colname(
-                self.tf_name(escape=False), self._escape(escape), suffix="_r"
-            )
-
-    def tf_name_l_r(self, escape=True):
-        if self.has_tf_adjustment:
-            return [self.tf_name_l(escape), self.tf_name_r(escape)]
-        else:
-            return []
-
-    def l_tf_name_as_l(self, escape=True):
-        if self.has_tf_adjustment:
-            return f"l.{self.tf_name(escape)} as {self.tf_name_l(escape)}"
-
-    def r_tf_name_as_r(self, escape=True):
-        if self.has_tf_adjustment:
-            return f"r.{self.tf_name(escape)} as {self.tf_name_r(escape)}"
-
-    def l_r_tf_names_as_l_r(self, escape=True):
-        if self.has_tf_adjustment:
-            return [self.l_tf_name_as_l(escape), self.r_tf_name_as_r(escape)]
-        else:
-            return []
+        # Check whether escape is needed by attempting to parse and asking whether the
+        # tree starts with a bracket or column

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -685,7 +685,7 @@ class Linker:
         """
         sql = vertically_concatenate_sql(self)
         self._enqueue_sql(sql, "__splink__df_concat")
-        input_col = InputColumn(column_name)
+        input_col = InputColumn(column_name, settings_obj=self._settings_obj)
         sql = term_frequencies_for_single_column_sql(input_col)
         self._enqueue_sql(sql, colname_to_tf_tablename(input_col))
         return self._execute_sql_pipeline(materialise_as_hash=False)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -312,7 +312,6 @@ class Linker:
         input_dataframes: List[SplinkDataFrame] = [],
         materialise_as_hash=True,
         use_cache=True,
-        transpile=True,
     ) -> SplinkDataFrame:
 
         """Execute the SQL queued in the current pipeline as a single statement
@@ -326,8 +325,6 @@ class Linker:
                 in a unique identifer. Defaults to True.
             use_cache (bool, optional): If true, look at whether the SQL pipeline has
                 been executed before, and if so, use the existing result. Defaults to
-                True.
-            transpile (bool, optional): Transpile the SQL using SQLGlot. Defaults to
                 True.
 
         Returns:
@@ -345,7 +342,6 @@ class Linker:
                 output_tablename_templated,
                 materialise_as_hash,
                 use_cache,
-                transpile,
             )
             self._pipeline.reset()
             return dataframe
@@ -363,14 +359,11 @@ class Linker:
                     output_tablename,
                     materialise_as_hash=False,
                     use_cache=False,
-                    transpile=transpile,
                 )
             self._pipeline.reset()
             return dataframe
 
-    def _execute_sql_against_backend(
-        self, sql, templated_name, physical_name, transpile=True
-    ):
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
         raise NotImplementedError(
             f"_execute_sql_against_backend not implemented for {type(self)}"
         )
@@ -381,7 +374,6 @@ class Linker:
         output_tablename_templated,
         materialise_as_hash=True,
         use_cache=True,
-        transpile=True,
     ) -> SplinkDataFrame:
         """Execute sql, or if identical sql has been run before, return cached results.
 
@@ -419,14 +411,13 @@ class Linker:
 
         if materialise_as_hash:
             splink_dataframe = self._execute_sql_against_backend(
-                sql, output_tablename_templated, table_name_hash, transpile=transpile
+                sql, output_tablename_templated, table_name_hash
             )
         else:
             splink_dataframe = self._execute_sql_against_backend(
                 sql,
                 output_tablename_templated,
                 output_tablename_templated,
-                transpile=transpile,
             )
 
         self._names_of_tables_created_by_splink.append(splink_dataframe.physical_name)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -694,7 +694,7 @@ class Linker:
         """
         sql = vertically_concatenate_sql(self)
         self._enqueue_sql(sql, "__splink__df_concat")
-        input_col = InputColumn(column_name, tf_adjustments=True)
+        input_col = InputColumn(column_name)
         sql = term_frequencies_for_single_column_sql(input_col)
         self._enqueue_sql(sql, colname_to_tf_tablename(input_col))
         return self._execute_sql_pipeline(materialise_as_hash=False)

--- a/splink/lower_id_on_lhs.py
+++ b/splink/lower_id_on_lhs.py
@@ -67,7 +67,7 @@ def lower_id_to_left_hand_side(
     """  # noqa
 
     cols = df.columns
-    cols = [c.name(escape=False) for c in cols]
+    cols = [c.name() for c in cols]
 
     l_cols = [c for c in cols if c.endswith("_l")]
     r_cols = [c for c in cols if c.endswith("_r")]

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -10,10 +10,6 @@ def dedupe_preserving_order(list_of_items):
     return list(dict.fromkeys(list_of_items))
 
 
-def escape_columns(cols):
-    return [c.name(escape=True) for c in cols]
-
-
 def prob_to_bayes_factor(prob):
     return prob / (1 - prob)
 

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -1,6 +1,3 @@
-from .input_column import unquote
-
-
 def missingness_sqls(columns, input_tablename):
 
     sqls = []
@@ -13,7 +10,7 @@ def missingness_sqls(columns, input_tablename):
     selects = [
         col_template.format(
             col_name_escaped=col.name(),
-            col_name=unquote(col.name()),
+            col_name=col.unquote().name(),
             input_tablename=input_tablename,
         )
         for col in columns

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -10,7 +10,7 @@ def missingness_sqls(columns, input_tablename):
     selects = [
         col_template.format(
             col_name_escaped=col.name(),
-            col_name=col.name(escape=False),
+            col_name=col.name().replace('"', ""),
             input_tablename=input_tablename,
         )
         for col in columns

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -1,3 +1,6 @@
+from .input_column import unquote
+
+
 def missingness_sqls(columns, input_tablename):
 
     sqls = []
@@ -10,7 +13,7 @@ def missingness_sqls(columns, input_tablename):
     selects = [
         col_template.format(
             col_name_escaped=col.name(),
-            col_name=col.name().replace('"', ""),
+            col_name=unquote(col.name()),
             input_tablename=input_tablename,
         )
         for col in columns

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -75,7 +75,7 @@ def _get_df_percentiles():
     order by group_name, value_count desc
     """
 
-    sqls.append({"sql": sql, "output_table_name": "__splink__df_total_in_value_counts"})
+    sqls.append({"sql": sql, "output_table_name": "df_total_in_value_counts"})
 
     sql = """
     select sum(sum_tokens_in_value_count_group)
@@ -86,13 +86,10 @@ def _get_df_percentiles():
     total_non_null_rows,
     total_rows_inc_nulls,
     distinct_value_count
-    from __splink__df_total_in_value_counts
+    from df_total_in_value_counts
     """
     sqls.append(
-        {
-            "sql": sql,
-            "output_table_name": "__splink__df_total_in_value_counts_cumulative",
-        }
+        {"sql": sql, "output_table_name": "df_total_in_value_counts_cumulative"}
     )
 
     sql = """
@@ -103,8 +100,7 @@ def _get_df_percentiles():
         as percentile_inc_nulls,
     value_count, group_name, total_non_null_rows, total_rows_inc_nulls,
     sum_tokens_in_value_count_group, distinct_value_count
-    from __splink__df_total_in_value_counts_cumulative
-
+    from df_total_in_value_counts_cumulative
     """
     sqls.append({"sql": sql, "output_table_name": "__splink__df_percentiles"})
     return sqls
@@ -148,7 +144,6 @@ def _col_or_expr_frequencies_raw_data_sql(cols_or_exprs, table_name):
             (select count(*) from {table_name}) as total_rows_inc_nulls,
             (select count(distinct {col_or_expr}) from {table_name})
                 as distinct_value_count
-
         from {table_name}
         where {col_or_expr} is not null
         group by {col_or_expr}

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -75,7 +75,7 @@ def _get_df_percentiles():
     order by group_name, value_count desc
     """
 
-    sqls.append({"sql": sql, "output_table_name": "df_total_in_value_counts"})
+    sqls.append({"sql": sql, "output_table_name": "__splink__df_total_in_value_counts"})
 
     sql = """
     select sum(sum_tokens_in_value_count_group)
@@ -86,10 +86,13 @@ def _get_df_percentiles():
     total_non_null_rows,
     total_rows_inc_nulls,
     distinct_value_count
-    from df_total_in_value_counts
+    from __splink__df_total_in_value_counts
     """
     sqls.append(
-        {"sql": sql, "output_table_name": "df_total_in_value_counts_cumulative"}
+        {
+            "sql": sql,
+            "output_table_name": "__splink__df_total_in_value_counts_cumulative",
+        }
     )
 
     sql = """
@@ -100,7 +103,7 @@ def _get_df_percentiles():
         as percentile_inc_nulls,
     value_count, group_name, total_non_null_rows, total_rows_inc_nulls,
     sum_tokens_in_value_count_group, distinct_value_count
-    from df_total_in_value_counts_cumulative
+    from __splink__df_total_in_value_counts_cumulative
 
     """
     sqls.append({"sql": sql, "output_table_name": "__splink__df_percentiles"})

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -181,23 +181,23 @@ def profile_columns(linker, column_expressions, top_n=10, bottom_n=10):
     sql = _col_or_expr_frequencies_raw_data_sql(column_expressions, input_tablename)
 
     linker._enqueue_sql(sql, "__splink__df_all_column_value_frequencies")
-    df_raw = linker._execute_sql_pipeline(materialise_as_hash=True, transpile=True)
+    df_raw = linker._execute_sql_pipeline(materialise_as_hash=True)
 
     sqls = _get_df_percentiles()
     for sql in sqls:
         linker._enqueue_sql(sql["sql"], sql["output_table_name"])
 
-    df_percentiles = linker._execute_sql_pipeline([df_raw], transpile=False)
+    df_percentiles = linker._execute_sql_pipeline([df_raw])
     percentile_rows_all = df_percentiles.as_record_dict()
 
     sql = _get_df_top_bottom_n(column_expressions, top_n, "desc")
     linker._enqueue_sql(sql, "__splink__df_top_n")
-    df_top_n = linker._execute_sql_pipeline([df_raw], transpile=False)
+    df_top_n = linker._execute_sql_pipeline([df_raw])
     top_n_rows_all = df_top_n.as_record_dict()
 
     sql = _get_df_top_bottom_n(column_expressions, bottom_n, "asc")
     linker._enqueue_sql(sql, "__splink__df_bottom_n")
-    df_bottom_n = linker._execute_sql_pipeline([df_raw], transpile=False)
+    df_bottom_n = linker._execute_sql_pipeline([df_raw])
     bottom_n_rows_all = df_bottom_n.as_record_dict()
 
     inner_charts = []

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -104,7 +104,7 @@ class Settings:
     @property
     def _additional_columns_to_retain(self):
         cols = self._from_settings_dict_else_default("additional_columns_to_retain")
-        return [InputColumn(c, tf_adjustments=False, settings_obj=self) for c in cols]
+        return [InputColumn(c, settings_obj=self) for c in cols]
 
     @property
     def _source_dataset_column_name_is_required(self):
@@ -142,9 +142,7 @@ class Settings:
         cols = set()
         for cc in self.comparisons:
             cols.update(cc._tf_adjustment_input_col_names)
-        return [
-            InputColumn(c, settings_obj=self, tf_adjustments=True) for c in list(cols)
-        ]
+        return [InputColumn(c, settings_obj=self) for c in list(cols)]
 
     @property
     def _needs_matchkey_column(self) -> bool:

--- a/splink/spark/custom_spark_dialect.py
+++ b/splink/spark/custom_spark_dialect.py
@@ -1,16 +1,15 @@
 from sqlglot import exp
-from sqlglot.generator import Generator
+
 from sqlglot.dialects import Dialect, Spark
+from sqlglot.generator import Generator
 
 
 def cast_as_double_edit(self, expression):
     """
     Forces floating point numbers to the double class in spark,
     instead of casting them to decimals.
-
     This resolves the spark issue where decimals only support precision
     up to 38 digits.
-
     More info: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
     """
     datatype = self.sql(expression, "to")
@@ -22,8 +21,19 @@ def cast_as_double_edit(self, expression):
 
 
 class CustomSpark(Spark):
+    class Parser(Spark.Parser):
+        FUNCTIONS = {
+            **Spark.Parser.FUNCTIONS,
+        }
+
     class Generator(Generator):
+
+        TYPE_MAPPING = {
+            **Spark.Generator.TYPE_MAPPING,
+        }
+
         TRANSFORMS = {
+            **Spark.Generator.TRANSFORMS,
             exp.Cast: cast_as_double_edit,
             exp.TryCast: cast_as_double_edit,
         }

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -6,13 +6,14 @@ import os
 import math
 
 from pyspark.sql import Row
-from .custom_spark_dialect import Dialect
+
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..term_frequencies import colname_to_tf_tablename
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..misc import ensure_is_list
 from ..input_column import InputColumn
+from .custom_spark_dialect import Dialect
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +254,8 @@ class SparkLinker(Linker):
         return spark_df
 
     def _execute_sql_against_backend(self, sql, templated_name, physical_name):
+
+        sql = sqlglot.transpile(sql, read="spark", write="customspark", pretty=True)[0]
 
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
         logger.log(5, log_sql(sql))

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -252,12 +252,7 @@ class SparkLinker(Linker):
                 )
         return spark_df
 
-    def _execute_sql_against_backend(
-        self, sql, templated_name, physical_name, transpile=True
-    ):
-
-        if transpile:
-            sql = sqlglot.transpile(sql, read=None, write="customspark", pretty=True)[0]
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
 
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
         logger.log(5, log_sql(sql))

--- a/splink/splink_dataframe.py
+++ b/splink/splink_dataframe.py
@@ -1,7 +1,5 @@
 import logging
 
-from .misc import escape_columns
-
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +23,7 @@ class SplinkDataFrame:
     @property
     def columns_escaped(self):
         cols = self.columns
-        return escape_columns(cols)
+        return [c.name() for c in cols]
 
     def validate():
         pass

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -2,25 +2,10 @@ import sqlglot
 import sqlglot.expressions as exp
 
 
-def transformer_base(func):
-    def wrapper(sql, *args, **kwargs):
-        """
-        Args:
-            sql Union(str or sqlglot.SyntaxTree): If a sqlglot object
-                is passed to the transformer, it is simply given to the
-                transformer and the resulting sql is returned.
-                If a sql expression is passed, this will be parsed by the
-                sqlglot parser and the resulting syntax tree will be transformed.
-        """
-
-        if isinstance(sql, exp.Expression):
-            syntax_tree = sql
-        else:
-            syntax_tree = sqlglot.parse_one(sql, read=None)
-        transformed_tree = syntax_tree.transform(func, *args, **kwargs)
-        return transformed_tree.sql()
-
-    return wrapper
+def sqlglot_transform_sql(sql, func):
+    syntax_tree = sqlglot.parse_one(sql, read=None)
+    transformed_tree = syntax_tree.transform(func)
+    return transformed_tree.sql()
 
 
 def _add_l_or_r_to_identifier(node):
@@ -45,17 +30,3 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
     transformed_tree = expression_tree.transform(_add_l_or_r_to_identifier)
     transformed_tree = transformed_tree.transform(_remove_table_prefix)
     return transformed_tree.sql()
-
-
-@transformer_base
-def cast_concat_as_varchar(node):
-    if isinstance(node, exp.Column):
-
-        if isinstance(node.parent, exp.Cast):
-            return node
-
-        if node.find_ancestor(exp.DPipe):
-            sql = f"cast({node.sql()} as varchar)"
-            return sqlglot.parse_one(sql)
-
-    return node

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -48,16 +48,6 @@ def move_l_r_table_prefix_to_column_suffix(blocking_rule):
 
 
 @transformer_base
-def add_prefix_or_suffix_to_colname(node, escape=True, prefix="", suffix=""):
-    if isinstance(node, exp.Column):
-        node.this.args["this"] = f"{prefix}{node.sql()}{suffix}"
-        if escape:
-            node.this.args["quoted"] = True
-
-    return node
-
-
-@transformer_base
 def cast_concat_as_varchar(node):
     if isinstance(node, exp.Column):
 

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -1,4 +1,3 @@
-import sqlglot
 from typing import Union, List
 import logging
 from math import pow, log2
@@ -112,12 +111,7 @@ class SQLiteLinker(Linker):
             settings_dict["sql_dialect"] = "sqlite"
         super().initialise_settings(settings_dict)
 
-    def _execute_sql_against_backend(
-        self, sql, templated_name, physical_name, transpile=True
-    ):
-
-        if transpile:
-            sql = sqlglot.transpile(sql, read=None, write="sqlite")[0]
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
 
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
         logger.log(5, log_sql(sql))

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -4,7 +4,7 @@
 import logging
 from typing import List, TYPE_CHECKING
 
-from .input_column import InputColumn
+from .input_column import InputColumn, remove_quotes_from_identifiers
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:
@@ -14,7 +14,11 @@ logger = logging.getLogger(__name__)
 
 
 def colname_to_tf_tablename(input_column: InputColumn):
-    input_column = input_column.name(escape=False).replace(" ", "_")
+    input_col_no_quotes = remove_quotes_from_identifiers(
+        input_column.input_name_as_tree
+    )
+
+    input_column = input_col_no_quotes.sql().replace(" ", "_")
     return f"__splink__df_tf_{input_column}"
 
 
@@ -22,9 +26,7 @@ def term_frequencies_for_single_column_sql(
     input_column: InputColumn, table_name="__splink__df_concat"
 ):
 
-    # TODO: Not escaped so if col name has a space, will fail in Spark
-
-    col_name = input_column.name(escape=True)
+    col_name = input_column.name()
 
     sql = f"""
     select

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -61,8 +61,8 @@ def _comparison_records(record_as_dict, comparison: Comparison):
     waterfall_record["u_probability"] = cl.u_probability
     waterfall_record["bayes_factor_description"] = cl._bayes_factor_description
     input_cols_used = c._input_columns_used_by_case_statement
-    input_cols_l = [ic.name_l(escape=False) for ic in input_cols_used]
-    input_cols_r = [ic.name_r(escape=False) for ic in input_cols_used]
+    input_cols_l = [ic.unquote().name_l() for ic in input_cols_used]
+    input_cols_r = [ic.unquote().name_r() for ic in input_cols_used]
     waterfall_record["value_l"] = ", ".join(
         [str(record_as_dict[n]) for n in input_cols_l]
     )
@@ -79,10 +79,10 @@ def _comparison_records(record_as_dict, comparison: Comparison):
 
         if cl._tf_adjustment_input_column is not None:
             waterfall_record_2["value_l"] = str(
-                record_as_dict[cl._tf_adjustment_input_column.name_l(escape=False)]
+                record_as_dict[cl._tf_adjustment_input_column.unquote().name_l()]
             )
             waterfall_record_2["value_r"] = str(
-                record_as_dict[cl._tf_adjustment_input_column.name_r(escape=False)]
+                record_as_dict[cl._tf_adjustment_input_column.unquote().name_r()]
             )
         else:
             waterfall_record_2["value_l"] = ""

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 
 from .misc import prob_to_bayes_factor
 from .comparison import Comparison
-from .input_column import unquote
 
 
 def _prior_record(settings_obj):
@@ -62,8 +61,8 @@ def _comparison_records(record_as_dict, comparison: Comparison):
     waterfall_record["u_probability"] = cl.u_probability
     waterfall_record["bayes_factor_description"] = cl._bayes_factor_description
     input_cols_used = c._input_columns_used_by_case_statement
-    input_cols_l = [unquote(ic.name_l()) for ic in input_cols_used]
-    input_cols_r = [unquote(ic.name_r()) for ic in input_cols_used]
+    input_cols_l = [ic.unquote().name_l() for ic in input_cols_used]
+    input_cols_r = [ic.unquote().name_r() for ic in input_cols_used]
     waterfall_record["value_l"] = ", ".join(
         [str(record_as_dict[n]) for n in input_cols_l]
     )
@@ -80,10 +79,10 @@ def _comparison_records(record_as_dict, comparison: Comparison):
 
         if cl._tf_adjustment_input_column is not None:
             waterfall_record_2["value_l"] = str(
-                record_as_dict[unquote(cl._tf_adjustment_input_column.name_l())]
+                record_as_dict[cl._tf_adjustment_input_column.unquote().name_l()]
             )
             waterfall_record_2["value_r"] = str(
-                record_as_dict[unquote(cl._tf_adjustment_input_column.name_r())]
+                record_as_dict[cl._tf_adjustment_input_column.unquote().name_r()]
             )
         else:
             waterfall_record_2["value_l"] = ""

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 
 from .misc import prob_to_bayes_factor
 from .comparison import Comparison
+from .input_column import unquote
 
 
 def _prior_record(settings_obj):
@@ -61,8 +62,8 @@ def _comparison_records(record_as_dict, comparison: Comparison):
     waterfall_record["u_probability"] = cl.u_probability
     waterfall_record["bayes_factor_description"] = cl._bayes_factor_description
     input_cols_used = c._input_columns_used_by_case_statement
-    input_cols_l = [ic.unquote().name_l() for ic in input_cols_used]
-    input_cols_r = [ic.unquote().name_r() for ic in input_cols_used]
+    input_cols_l = [unquote(ic.name_l()) for ic in input_cols_used]
+    input_cols_r = [unquote(ic.name_r()) for ic in input_cols_used]
     waterfall_record["value_l"] = ", ".join(
         [str(record_as_dict[n]) for n in input_cols_l]
     )
@@ -79,10 +80,10 @@ def _comparison_records(record_as_dict, comparison: Comparison):
 
         if cl._tf_adjustment_input_column is not None:
             waterfall_record_2["value_l"] = str(
-                record_as_dict[cl._tf_adjustment_input_column.unquote().name_l()]
+                record_as_dict[unquote(cl._tf_adjustment_input_column.name_l())]
             )
             waterfall_record_2["value_r"] = str(
-                record_as_dict[cl._tf_adjustment_input_column.unquote().name_r()]
+                record_as_dict[unquote(cl._tf_adjustment_input_column.name_r())]
             )
         else:
             waterfall_record_2["value_l"] = ""

--- a/tests/basic_settings.py
+++ b/tests/basic_settings.py
@@ -1,14 +1,36 @@
 from copy import deepcopy
 from splink.misc import bayes_factor_to_prob, prob_to_bayes_factor
-from splink.comparison_library import levenshtein_at_thresholds, exact_match
 
-
-first_name_cc = levenshtein_at_thresholds(
-    "first_name", 2, term_frequency_adjustments=True
-)
-dob_cc = exact_match("dob")
-email_cc = exact_match("email")
-city_cc = exact_match("city")
+first_name_cc = {
+    "output_column_name": "first_name",
+    "comparison_levels": [
+        {
+            "sql_condition": "first_name_l IS NULL OR first_name_r IS NULL",
+            "label_for_charts": "Comparison includes null",
+            "is_null_level": True,
+        },
+        {
+            "sql_condition": "first_name_l = first_name_r",
+            "label_for_charts": "Exact match",
+            "m_probability": 0.7,
+            "u_probability": 0.1,
+            "tf_adjustment_column": "first_name",
+            "tf_adjustment_weight": 0.6,
+        },
+        {
+            "sql_condition": "levenshtein(first_name_l, first_name_r) <= 2",
+            "m_probability": 0.2,
+            "u_probability": 0.1,
+            "label_for_charts": "levenshtein <= 2",
+        },
+        {
+            "sql_condition": "ELSE",
+            "label_for_charts": "All other comparisons",
+            "m_probability": 0.1,
+            "u_probability": 0.8,
+        },
+    ],
+}
 
 surname_cc = {
     "output_column_name": "surname",
@@ -20,6 +42,75 @@ surname_cc = {
         },
         {
             "sql_condition": "surname_l = surname_r",
+            "label_for_charts": "Exact match",
+            "m_probability": 0.9,
+            "u_probability": 0.1,
+        },
+        {
+            "sql_condition": "ELSE",
+            "label_for_charts": "All other comparisons",
+            "m_probability": 0.1,
+            "u_probability": 0.9,
+        },
+    ],
+}
+
+dob_cc = {
+    "output_column_name": "dob",
+    "comparison_levels": [
+        {
+            "sql_condition": "dob_l IS NULL OR dob_r IS NULL",
+            "label_for_charts": "Comparison includes null",
+            "is_null_level": True,
+        },
+        {
+            "sql_condition": "dob_l = dob_r",
+            "label_for_charts": "Exact match",
+            "m_probability": 0.9,
+            "u_probability": 0.1,
+        },
+        {
+            "sql_condition": "ELSE",
+            "label_for_charts": "All other comparisons",
+            "m_probability": 0.1,
+            "u_probability": 0.9,
+        },
+    ],
+}
+
+email_cc = {
+    "output_column_name": "email",
+    "comparison_levels": [
+        {
+            "sql_condition": "email_l IS NULL OR email_r IS NULL",
+            "label_for_charts": "Comparison includes null",
+            "is_null_level": True,
+        },
+        {
+            "sql_condition": "email_l = email_r",
+            "label_for_charts": "Exact match",
+            "m_probability": 0.9,
+            "u_probability": 0.1,
+        },
+        {
+            "sql_condition": "ELSE",
+            "label_for_charts": "All other comparisons",
+            "m_probability": 0.1,
+            "u_probability": 0.9,
+        },
+    ],
+}
+
+city_cc = {
+    "output_column_name": "city",
+    "comparison_levels": [
+        {
+            "sql_condition": "city_l IS NULL OR city_r IS NULL",
+            "label_for_charts": "Comparison includes null",
+            "is_null_level": True,
+        },
+        {
+            "sql_condition": "city_l = city_r",
             "label_for_charts": "Exact match",
             "m_probability": 0.9,
             "u_probability": 0.1,

--- a/tests/basic_settings.py
+++ b/tests/basic_settings.py
@@ -1,37 +1,14 @@
 from copy import deepcopy
 from splink.misc import bayes_factor_to_prob, prob_to_bayes_factor
+from splink.comparison_library import levenshtein_at_thresholds, exact_match
 
-first_name_cc = {
-    "output_column_name": "first_name",
-    "comparison_levels": [
-        {
-            "sql_condition": "first_name_l IS NULL OR first_name_r IS NULL",
-            "label_for_charts": "Comparison includes null",
-            "is_null_level": True,
-        },
-        {
-            "sql_condition": "first_name_l = first_name_r",
-            "label_for_charts": "Exact match",
-            "m_probability": 0.7,
-            "u_probability": 0.1,
-            "tf_adjustment_column": "first_name",
-            "tf_adjustment_weight": 0.6,
-        },
-        {
-            "sql_condition": "levenshtein(first_name_l, first_name_r) <= 2",
-            "m_probability": 0.2,
-            "u_probability": 0.1,
-            "label_for_charts": "levenshtein <= 2",
-        },
-        {
-            "sql_condition": "ELSE",
-            "label_for_charts": "All other comparisons",
-            "m_probability": 0.1,
-            "u_probability": 0.8,
-        },
-    ],
-}
 
+first_name_cc = levenshtein_at_thresholds(
+    "first_name", 2, term_frequency_adjustments=True
+)
+dob_cc = exact_match("dob")
+email_cc = exact_match("email")
+city_cc = exact_match("city")
 
 surname_cc = {
     "output_column_name": "surname",
@@ -43,75 +20,6 @@ surname_cc = {
         },
         {
             "sql_condition": "surname_l = surname_r",
-            "label_for_charts": "Exact match",
-            "m_probability": 0.9,
-            "u_probability": 0.1,
-        },
-        {
-            "sql_condition": "ELSE",
-            "label_for_charts": "All other comparisons",
-            "m_probability": 0.1,
-            "u_probability": 0.9,
-        },
-    ],
-}
-
-dob_cc = {
-    "output_column_name": "dob",
-    "comparison_levels": [
-        {
-            "sql_condition": "dob_l IS NULL OR dob_r IS NULL",
-            "label_for_charts": "Comparison includes null",
-            "is_null_level": True,
-        },
-        {
-            "sql_condition": "dob_l = dob_r",
-            "label_for_charts": "Exact match",
-            "m_probability": 0.9,
-            "u_probability": 0.1,
-        },
-        {
-            "sql_condition": "ELSE",
-            "label_for_charts": "All other comparisons",
-            "m_probability": 0.1,
-            "u_probability": 0.9,
-        },
-    ],
-}
-
-email_cc = {
-    "output_column_name": "email",
-    "comparison_levels": [
-        {
-            "sql_condition": "email_l IS NULL OR email_r IS NULL",
-            "label_for_charts": "Comparison includes null",
-            "is_null_level": True,
-        },
-        {
-            "sql_condition": "email_l = email_r",
-            "label_for_charts": "Exact match",
-            "m_probability": 0.9,
-            "u_probability": 0.1,
-        },
-        {
-            "sql_condition": "ELSE",
-            "label_for_charts": "All other comparisons",
-            "m_probability": 0.1,
-            "u_probability": 0.9,
-        },
-    ],
-}
-
-city_cc = {
-    "output_column_name": "city",
-    "comparison_levels": [
-        {
-            "sql_condition": "city_l IS NULL OR city_r IS NULL",
-            "label_for_charts": "Comparison includes null",
-            "is_null_level": True,
-        },
-        {
-            "sql_condition": "city_l = city_r",
             "label_for_charts": "Exact match",
             "m_probability": 0.9,
             "u_probability": 0.1,

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -54,10 +54,11 @@ def test_splink_2_predict_sqlite():
     from rapidfuzz.distance.Levenshtein import distance
 
     con = sqlite3.connect(":memory:")
-    con.create_function("editdist3", 2, distance)
+    con.create_function("levenshtein", 2, distance)
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     df.to_sql("fake_data_1", con, if_exists="replace")
     settings_dict = get_settings_dict()
+
     linker = SQLiteLinker(
         "fake_data_1",
         settings_dict,

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -63,7 +63,7 @@ def test_splink_converges_to_known_params():
     linker = DuckDBLinker(df, settings)
 
     # need to register df_blocked and go from there
-    linker._con.register("__splink__df_comparison_vectors_b11fc1b", df)
+    linker._con.register("__splink__df_comparison_vectors_b026065", df)
 
     em_training_session = EMTrainingSession(
         linker,
@@ -83,7 +83,7 @@ def test_splink_converges_to_known_params():
 
     cv = DuckDBLinkerDataFrame(
         "__splink__df_comparison_vectors",
-        "__splink__df_comparison_vectors_b11fc1b",
+        "__splink__df_comparison_vectors_b026065",
         linker,
     )
 

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -63,7 +63,7 @@ def test_splink_converges_to_known_params():
     linker = DuckDBLinker(df, settings)
 
     # need to register df_blocked and go from there
-    linker._con.register("__splink__df_comparison_vectors_ac53420", df)
+    linker._con.register("__splink__df_comparison_vectors_b11fc1b", df)
 
     em_training_session = EMTrainingSession(
         linker,
@@ -83,7 +83,7 @@ def test_splink_converges_to_known_params():
 
     cv = DuckDBLinkerDataFrame(
         "__splink__df_comparison_vectors",
-        "__splink__df_comparison_vectors_ac53420",
+        "__splink__df_comparison_vectors_b11fc1b",
         linker,
     )
 

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -2,15 +2,6 @@ import pandas as pd
 import pytest
 import os
 
-from splink.comparison_level_library import (
-    _mutable_params,
-)
-
-_mutable_params["dialect"] = "presto"
-_mutable_params["levenshtein"] = "levenshtein_distance"
-
-from basic_settings import get_settings_dict
-
 skip = False
 try:
     import awswrangler as wr
@@ -22,6 +13,7 @@ if not skip:
     from splink.athena.athena_linker import AthenaLinker
     import boto3
     from dataengineeringutils3.s3 import delete_s3_folder_contents
+    from splink.athena.athena_comparison_library import levenshtein_at_thresholds
 
 
 def setup_athena_db(my_session, db_name="splink_awswrangler_test"):
@@ -92,9 +84,33 @@ def test_full_example_athena(tmp_path):
     in the AthenaLinker to clean the process before we proceed.
     """
 
+    from basic_settings import get_settings_dict
     # creates a session at least on the platform...
     my_session = boto3.Session(region_name="eu-west-1")
     settings_dict = get_settings_dict()
+
+    first_name_cc = levenshtein_at_thresholds(
+        col_name="first_name",
+        distance_threshold_or_thresholds=2,
+        include_exact_match_level=True,
+        term_frequency_adjustments=True,
+        m_probability_exact_match=0.7,
+        m_probability_or_probabilities_lev=0.2,
+        m_probability_else=0.1,
+    )
+
+    # Update tf weight and u probabilities to match v2 settings
+    first_name_cc._comparison_dict[
+        'comparison_levels'
+        ][1]._tf_adjustment_weight = 0.6
+    u_probabilities_first_name = [0.1, 0.1, 0.8]
+    for u_prob, level in zip(u_probabilities_first_name,
+        first_name_cc._comparison_dict['comparison_levels'][1:]):
+        level._u_probability = u_prob
+
+    # Update settings w/ our edited first_name col
+    settings_dict["comparisons"][0] = first_name_cc
+
     db_name_read = "splink_awswrangler_test"
     db_name_write = f"{db_name_read}2"
 

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -85,6 +85,7 @@ def test_full_example_athena(tmp_path):
     """
 
     from basic_settings import get_settings_dict
+
     # creates a session at least on the platform...
     my_session = boto3.Session(region_name="eu-west-1")
     settings_dict = get_settings_dict()
@@ -100,12 +101,12 @@ def test_full_example_athena(tmp_path):
     )
 
     # Update tf weight and u probabilities to match v2 settings
-    first_name_cc._comparison_dict[
-        'comparison_levels'
-        ][1]._tf_adjustment_weight = 0.6
+    first_name_cc._comparison_dict["comparison_levels"][1]._tf_adjustment_weight = 0.6
     u_probabilities_first_name = [0.1, 0.1, 0.8]
-    for u_prob, level in zip(u_probabilities_first_name,
-        first_name_cc._comparison_dict['comparison_levels'][1:]):
+    for u_prob, level in zip(
+        u_probabilities_first_name,
+        first_name_cc._comparison_dict["comparison_levels"][1:],
+    ):
         level._u_probability = u_prob
 
     # Update settings w/ our edited first_name col

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -2,6 +2,13 @@ import pandas as pd
 import pytest
 import os
 
+from splink.comparison_level_library import (
+    _mutable_params,
+)
+
+_mutable_params["dialect"] = "presto"
+_mutable_params["levenshtein"] = "levenshtein_distance"
+
 from basic_settings import get_settings_dict
 
 skip = False

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -11,6 +11,7 @@ from splink.comparison_level_library import (
 
 from basic_settings import get_settings_dict
 
+
 def test_full_example_duckdb(tmp_path):
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -5,14 +5,11 @@ from splink.duckdb.duckdb_comparison_library import jaccard_at_thresholds, exact
 from splink.duckdb.duckdb_comparison_level_library import _mutable_params
 import pandas as pd
 import pyarrow.parquet as pq
-from basic_settings import get_settings_dict
-
 from splink.comparison_level_library import (
     _mutable_params,
 )
 
-_mutable_params["dialect"] = "duckdb"
-
+from basic_settings import get_settings_dict
 
 def test_full_example_duckdb(tmp_path):
 
@@ -23,6 +20,7 @@ def test_full_example_duckdb(tmp_path):
     # Overwrite the surname comparison to include duck-db specific syntax
 
     _mutable_params["dialect"] = "duckdb"
+    _mutable_params["levenshtein"] = "levenshtein"
     settings_dict["comparisons"][1] = jaccard_at_thresholds("SUR name")
     settings_dict["blocking_rules_to_generate_predictions"] = [
         'l."SUR name" = r."SUR name"',

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -7,6 +7,12 @@ import pandas as pd
 import pyarrow.parquet as pq
 from basic_settings import get_settings_dict
 
+from splink.comparison_level_library import (
+    _mutable_params,
+)
+
+_mutable_params["dialect"] = "duckdb"
+
 
 def test_full_example_duckdb(tmp_path):
 

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -8,26 +8,18 @@ from splink.spark.spark_comparison_level_library import (
     else_level,
 )
 
-from basic_settings import get_settings_dict
-
 from pyspark.sql.functions import array
-
-from splink.comparison_level_library import (
-    _mutable_params,
-)
-
-_mutable_params["dialect"] = "spark"
+from basic_settings import get_settings_dict
 
 
 def test_full_example_spark(df_spark, tmp_path):
 
     # Convert a column to an array to enable testing intersection
     df_spark = df_spark.withColumn("email", array("email"))
-
+    _mutable_params["dialect"] = "spark"
     settings_dict = get_settings_dict()
 
     # Only needed because the value can be overwritten by other tests
-    _mutable_params["dialect"] = "spark"
     settings_dict["comparisons"][1] = cl.exact_match("surname")
 
     settings = {

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -12,6 +12,12 @@ from basic_settings import get_settings_dict
 
 from pyspark.sql.functions import array
 
+from splink.comparison_level_library import (
+    _mutable_params,
+)
+
+_mutable_params["dialect"] = "spark"
+
 
 def test_full_example_spark(df_spark, tmp_path):
 

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -5,6 +5,12 @@ import pandas as pd
 
 from basic_settings import get_settings_dict
 
+from splink.comparison_level_library import (
+    _mutable_params,
+)
+
+_mutable_params["dialect"] = "sqlite"
+
 
 def test_full_example_sqlite(tmp_path):
 

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -11,7 +11,7 @@ def test_full_example_sqlite(tmp_path):
     from rapidfuzz.distance.Levenshtein import distance
 
     con = sqlite3.connect(":memory:")
-    con.create_function("editdist3", 2, distance)
+    con.create_function("levenshtein", 2, distance)
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     df.to_sql("input_df_tablename", con)
@@ -51,7 +51,7 @@ def test_small_link_example_sqlite():
     from rapidfuzz.distance.Levenshtein import distance
 
     con = sqlite3.connect(":memory:")
-    con.create_function("editdist3", 2, distance)
+    con.create_function("levenshtein", 2, distance)
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -3,13 +3,13 @@ import os
 import sqlite3
 import pandas as pd
 
-from basic_settings import get_settings_dict
-
 from splink.comparison_level_library import (
     _mutable_params,
 )
 
 _mutable_params["dialect"] = "sqlite"
+_mutable_params["levenshtein"] = "levenshtein"
+from basic_settings import get_settings_dict
 
 
 def test_full_example_sqlite(tmp_path):

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -1,0 +1,33 @@
+from splink.input_column import InputColumn
+
+
+def test_input_column():
+
+    c = InputColumn("my_col")
+    assert c.name() == '"my_col"'
+    assert c.unquote().name() == "my_col"
+
+    assert c.name_l() == '"my_col_l"'
+    assert c.tf_name_l() == '"tf_my_col_l"'
+    assert c.unquote().quote().l_tf_name_as_l() == '"l"."tf_my_col" as "tf_my_col_l"'
+    assert c.unquote().l_tf_name_as_l() == '"l".tf_my_col as tf_my_col_l'
+
+    c = InputColumn("SUR name")
+    assert c.name() == '"SUR name"'
+    assert c.name_r() == '"SUR name_r"'
+    assert c.r_name_as_r() == '"r"."SUR name" as "SUR name_r"'
+
+    c = InputColumn("col['lat']")
+
+    name = """
+    "col"['lat']
+    """.strip()
+    assert c.name() == name
+
+    l_tf_name_as_l = """
+    "l"."tf_col"['lat'] as "tf_col_l"['lat']
+    """.strip()
+    assert c.l_tf_name_as_l() == l_tf_name_as_l
+
+    assert c.unquote().name() == "col['lat']"
+    assert c.unquote().quote().name() == name

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -2,7 +2,9 @@ from copy import deepcopy
 import pandas as pd
 from splink.comparison_library import exact_match
 from splink.duckdb.duckdb_linker import DuckDBLinker
+from splink.comparison_level_library import _mutable_params
 
+_mutable_params["dialect"] = "duckdb"
 settings_template = {
     "probability_two_random_records_match": 0.01,
     "unique_id_column_name": "id",
@@ -63,7 +65,7 @@ def test_dedupe_only_join_condition():
     settings_salt["link_type"] = "dedupe_only"
 
     for s in [settings, settings_salt]:
-        linker = DuckDBLinker(df, s)
+        linker = DuckDBLinker(df.copy(), s)
 
         df_predict = linker.predict().as_pandas_dataframe()
 

--- a/tests/test_m_train.py
+++ b/tests/test_m_train.py
@@ -1,6 +1,7 @@
 from splink.duckdb.duckdb_linker import DuckDBLinker
 from splink.duckdb.duckdb_comparison_library import levenshtein_at_thresholds
 import pandas as pd
+from splink.comparison_level_library import _mutable_params
 
 
 def test_m_train():
@@ -14,6 +15,7 @@ def test_m_train():
     ]
     df = pd.DataFrame(data)
 
+    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "dedupe_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -1,8 +1,9 @@
 import sqlglot
 from splink.sql_transform import (
     move_l_r_table_prefix_to_column_suffix,
-    cast_concat_as_varchar,
+    sqlglot_transform_sql,
 )
+from splink.athena.athena_transforms import cast_concat_as_varchar
 from splink.spark.custom_spark_dialect import Dialect  # noqa 401
 from splink.input_column import InputColumn
 
@@ -34,25 +35,25 @@ def test_cast_concat_as_varchar():
     output = sqlglot.parse_one(output).sql()
 
     sql = "select l.source_dataset || '-__-' || l.unique_id as concat_id"
-    transformed_sql = cast_concat_as_varchar(sql)
+    transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output
 
     sql = """
         select cast(l.source_dataset as varchar) || '-__-' ||
         l.unique_id as concat_id
     """
-    transformed_sql = cast_concat_as_varchar(sql)
+    transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output
 
     sql = """
         select cast(l.source_dataset as varchar) || '-__-' ||
         cast(l.unique_id as varchar) as concat_id
     """
-    transformed_sql = cast_concat_as_varchar(sql)
+    transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output
 
     sql = "select source_dataset || '-__-' || unique_id as concat_id"
-    transformed_sql = cast_concat_as_varchar(sql)
+    transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output.replace("l.", "")
 
 

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -68,35 +68,34 @@ def test_set_numeric_as_double():
 
 def test_add_pref_and_suffix():
     dull = InputColumn("dull")
-    dull_l_r = ["l.dull as dull_l", "r.dull as dull_r"]
+    dull_l_r = ['"l"."dull" as "dull_l"', '"r"."dull" as "dull_r"']
     assert dull.l_r_names_as_l_r() == dull_l_r
 
-    assert dull.bf_name() == "bf_dull"
-    dull._has_tf_adjustments = True
-    assert dull.tf_name_l() == "tf_dull_l"
-    tf_dull_l_r = ["l.tf_dull as tf_dull_l", "r.tf_dull as tf_dull_r"]
+    assert dull.bf_name() == '"bf_dull"'
+    assert dull.tf_name_l() == '"tf_dull_l"'
+    tf_dull_l_r = ['"l"."tf_dull" as "tf_dull_l"', '"r"."tf_dull" as "tf_dull_r"']
     assert dull.l_r_tf_names_as_l_r() == tf_dull_l_r
 
     ll = InputColumn("lat['long']")
-    assert ll.name_l() == "lat_l['long']"
-    ll._has_tf_adjustments = True
+    assert ll.name_l() == "\"lat_l\"['long']"
+
     ll_tf_l_r = [
-        "l.tf_lat['long'] as tf_lat_l['long']",
-        "r.tf_lat['long'] as tf_lat_r['long']",
+        '"l"."tf_lat"[\'long\'] as "tf_lat_l"[\'long\']',
+        '"r"."tf_lat"[\'long\'] as "tf_lat_r"[\'long\']',
     ]
+
     assert ll.l_r_tf_names_as_l_r() == ll_tf_l_r
 
     group = InputColumn("group")
     assert group.name_l() == '"group_l"'
     assert group.bf_name() == '"bf_group"'
-    group_l_r_names = ['l."group" as "group_l"', 'r."group" as "group_r"']
+    group_l_r_names = ['"l"."group" as "group_l"', '"r"."group" as "group_r"']
     assert group.l_r_names_as_l_r() == group_l_r_names
-    group._has_tf_adjustments = True
-    group_tf_l_r = ['l."tf_group" as "tf_group_l"', 'r."tf_group" as "tf_group_r"']
+
+    group_tf_l_r = ['"l"."tf_group" as "tf_group_l"', '"r"."tf_group" as "tf_group_r"']
     assert group.l_r_tf_names_as_l_r() == group_tf_l_r
 
     cols = ["unique_id", "SUR name", "group"]
-    out_cols = ["unique_id", '"SUR name"', '"group"']
+    out_cols = ['"unique_id"', '"SUR name"', '"group"']
     cols_class = [InputColumn(c) for c in cols]
     assert [c.name() for c in cols_class] == out_cols
-    assert [InputColumn(c).name(escape=False) for c in cols] == cols

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -1,6 +1,7 @@
 from splink.duckdb.duckdb_comparison_library import levenshtein_at_thresholds
 from splink.duckdb.duckdb_linker import DuckDBLinker
 import pandas as pd
+from splink.comparison_level_library import _mutable_params
 
 
 def test_u_train():
@@ -15,6 +16,7 @@ def test_u_train():
     ]
     df = pd.DataFrame(data)
 
+    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "dedupe_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],


### PR DESCRIPTION
Transpilation was a remnant of an original idea within splink3 to use Spark as the base SQL flavour and transpile everything from Spark into other target backends.

I later realised it was easier to write everything in a 'vanilla' sql dialect which is parsable by all major engines i.e. avoiding dialect specific features

As a result transpilation is no longer necessary

The implementation of `InputColumn` here has been improved to allow for columns like `geocode['lat']` which previously caused problems.

This enables the `haversine` Comparison to work better.

## Things changed:

- All input columns are escaped by default.  This makes the SQL a little harder to read but simplifies code
- The transpilation step which previously existed in each backend specific linker is now removed.  It remains for spark, so that we can convert cast(0.234 as double) to 0.234D
- Converted the athena cast transform into a slightly simpler format
- The `InputColumn` used to have an arg for term frequency adjustments.  If false, and you called e.g. ` inputcol.tf_name_r` it would return nothing.  I think this was a bit surprising so I've moved the logic.

Closes #726 and #727