### PR TITLE
Update sqlglot v5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -344,7 +344,7 @@ python-versions = "*"
 name = "py4j"
 version = "0.10.9.3"
 description = "Enables Python programs to dynamically access arbitrary Java objects"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -398,7 +398,7 @@ python-versions = ">=3.7"
 name = "pyspark"
 version = "3.2.1"
 description = "Apache Spark Python API"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -493,7 +493,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "sqlglot"
-version = "4.1.1"
+version = "5.1.0"
 description = "An easily customizable SQL parser and transpiler"
 category = "main"
 optional = false
@@ -557,14 +557,16 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "402699eaaf5dc77dc010735cee9c5c1402aaa19c3448c7a6d7317286e269bd4d"
+content-hash = "f6cfe6d95c1ca7329fcb2832da52823799541471e1a460caab6a1e8d00d04cc1"
 
 [metadata.files]
 altair = [
     {file = "altair-4.2.0-py3-none-any.whl", hash = "sha256:0c724848ae53410c13fa28be2b3b9a9dcb7b5caa1a70f7f217bd663bb419935a"},
     {file = "altair-4.2.0.tar.gz", hash = "sha256:d87d9372e63b48cd96b2a6415f0cf9457f50162ab79dc7a31cd7e024dd840026"},
 ]
-atomicwrites = []
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
+]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.7"
 jsonschema = "^3.2"
 pandas = "^1.0.0"
 duckdb = "^0.4.0"
-sqlglot = "^4.0.0"
+sqlglot = "5.1.0"
 altair = "^4.2.0"
 Jinja2 = "^3.0.3"
 

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -46,7 +46,7 @@ def _exact_match_colname(sql, sql_dialect=None):
     syntax_tree = sqlglot.parse_one(sql.lower(), read=sql_dialect)
 
     for identifier in syntax_tree.find_all(Identifier):
-        identifier.set(arg="quoted", value=False)
+        identifier.args['quoted'] = False
 
     for tup in syntax_tree.walk():
         subtree = tup[0]

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -46,7 +46,7 @@ def _exact_match_colname(sql, sql_dialect=None):
     syntax_tree = sqlglot.parse_one(sql.lower(), read=sql_dialect)
 
     for identifier in syntax_tree.find_all(Identifier):
-        identifier.args['quoted'] = False
+        identifier.args["quoted"] = False
 
     for tup in syntax_tree.walk():
         subtree = tup[0]


### PR DESCRIPTION
This PR:
* Uses **sqlglot** to extract quote characters, instead of doing it manually.
* Updates the code such that it will run with sqlglot `>=5.0.0`. The `set()` method was breaking in the newer versions.