### PR TITLE
fix table exists in db

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -207,7 +207,7 @@ class DuckDBLinker(Linker):
         try:
             from duckdb import CatalogException
 
-            error = CatalogException
+            error = (RuntimeError, CatalogException)
         except ImportError:
             error = RuntimeError
 


### PR DESCRIPTION
Was still having problems with a specific pre-release of DuckDB (`'0.4.1-dev1214'`).  This fixes the problem