### PR TITLE
Register tables

### DIFF
--- a/docs/linker.md
+++ b/docs/linker.md
@@ -37,6 +37,8 @@ tags:
         - prediction_errors_from_label_column
         - prediction_errors_from_labels_table
         - profile_columns
+        - query_sql
+        - register_table
         - roc_chart_from_labels_column
         - roc_chart_from_labels_table
         - save_settings_to_json

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -4,7 +4,6 @@ from tempfile import TemporaryDirectory
 
 from duckdb import DuckDBPyConnection
 import duckdb
-import hashlib
 import pandas as pd
 
 from .duckdb_helpers import (

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 
 from duckdb import DuckDBPyConnection
 import duckdb
+import pandas as pd
 
 from .duckdb_helpers import (
     validate_duckdb_connection,
@@ -187,6 +188,27 @@ class DuckDBLinker(Linker):
 
         return DuckDBLinkerDataFrame(templated_name, physical_name, self)
 
+    def query_sql(self, sql):
+        return self._con.execute(sql).fetch_df()
+
+    def register_table(self, input, table_name, overwrite=False):
+
+        # Check if table name is already in use
+        exists = self._table_exists_in_database(table_name)
+        if exists:
+            if not overwrite:
+                raise ValueError(f"Table '{table_name}' already exists in database.")
+            else:
+                self._con.unregister(table_name)
+
+        if isinstance(input, dict):
+            input = pd.DataFrame(input)
+        elif isinstance(input, list):
+            input = pd.DataFrame.from_records(input)
+
+        # Will error if an invalid data type is passed
+        self._con.register(table_name, input)
+
     def initialise_settings(self, settings_dict: dict):
         if "sql_dialect" not in settings_dict:
             settings_dict["sql_dialect"] = "duckdb"
@@ -216,15 +238,6 @@ class DuckDBLinker(Linker):
         except error:
             return False
         return True
-
-    def _records_to_table(self, records, as_table_name):
-        for r in records:
-            r["source_dataset"] = as_table_name
-
-        import pandas as pd
-
-        df = pd.DataFrame(records)
-        self._con.register(as_table_name, df)
 
     def _delete_table_from_database(self, name):
         drop_sql = f"""

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -55,9 +55,9 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
         return self.duckdb_linker.query_sql(sql, output_type)
 
     def as_record_dict(self, limit=None):
-        return self.as_dataframe(
-            output_type="pandas", limit=limit
-            ).to_dict(orient="records")
+        return self.as_dataframe(output_type="pandas", limit=limit).to_dict(
+            orient="records"
+        )
 
     def as_pandas_dataframe(self, limit=None):
         return self.as_dataframe(output_type="pandas", limit=limit)
@@ -208,7 +208,7 @@ class DuckDBLinker(Linker):
         else:
             raise ValueError(
                 f"output_type '{output_type}' is not supported.",
-                "Must be one of 'splink_df'/'splinkdf', 'pandas' or 'arrow'/'pyarrow'"
+                "Must be one of 'splink_df'/'splinkdf', 'pandas' or 'arrow'/'pyarrow'",
             )
 
     def register_table(self, input, table_name, overwrite=False):

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -378,6 +378,43 @@ class Linker:
             f"_execute_sql_against_backend not implemented for {type(self)}"
         )
 
+    def register_table(self, input, table_name):
+        """
+        Register a table to your backend database, to be used in one of the
+        splink methods, or simply to allow querying.
+
+        Tables can be of type: dictionary, record level dictionary,
+        pandas dataframe, pyarrow table and in the spark case, a spark df.
+
+        Examples:
+            >>> test_dict = {"a": [666,777,888],"b": [4,5,6]}
+            >>> linker.register_table(test_dict, "test_dict")
+            >>> linker.query_sql("select * from test_dict")
+
+        Args:
+            input: The data you wish to register. This can be either a dictionary,
+                pandas dataframe, pyarrow table or a spark dataframe.
+            table_name (str): The name you wish to assign to the table.
+        """
+
+        raise NotImplementedError(f"register_table not implemented for {type(self)}")
+
+    def query_sql(self, sql):
+        """
+        Run a SQL query against your backend database and return
+        the resulting output.
+
+        Examples:
+            >>> linker = DuckDBLinker(df, settings)
+            >>> df_predict = linker.predict()
+            >>> linker.query_sql(f"select * from {df_predict.physical_name} limit 10")
+
+        Args:
+            sql (str): The SQL to be queried.
+        """
+
+        raise NotImplementedError(f"query_sql not implemented for {type(self)}")
+
     def _sql_to_splink_dataframe_checking_cache(
         self,
         sql,
@@ -594,12 +631,6 @@ class Linker:
             "reciprocal "
             f"{1/self._settings_obj._probability_two_random_records_match:,.3f}",
         )
-
-    def _records_to_table(records, as_table_name):
-        # Create table in database containing records
-        # Probably quite difficult to implement correctly
-        # Due to data type issues.
-        raise NotImplementedError
 
     def _populate_m_u_from_trained_values(self):
         ccs = self._settings_obj.comparisons
@@ -1065,7 +1096,7 @@ class Linker:
         original_link_type = self._settings_obj._link_type
 
         if not isinstance(records_or_tablename, str):
-            self._records_to_table(records_or_tablename, "__splink__df_new_records")
+            self.register_table(records_or_tablename, "__splink__df_new_records")
             new_records_tablename = "__splink__df_new_records"
         else:
             new_records_tablename = records_or_tablename
@@ -1137,8 +1168,8 @@ class Linker:
         self._compare_two_records_mode = True
         self._settings_obj._blocking_rules_to_generate_predictions = []
 
-        self._records_to_table([record_1], "__splink__compare_two_records_left")
-        self._records_to_table([record_2], "__splink__compare_two_records_right")
+        self.register_table([record_1], "__splink__compare_two_records_left")
+        self.register_table([record_2], "__splink__compare_two_records_right")
 
         sql_join_tf = _join_tf_to_input_df_sql(self)
 

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -135,8 +135,8 @@ def _check_dependency_installed(module):
     except pkg_resources.DistributionNotFound:
         raise ValueError(
             f"{module} is not installed.",
-            "Please install and import it before continuing."
-            )
+            "Please install and import it before continuing.",
+        )
 
 
 def query_sql_to_splink_df(linker, sql):

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -4,6 +4,8 @@ import numpy as np
 import json
 from string import ascii_lowercase
 import itertools
+import pkg_resources
+import hashlib
 
 
 def dedupe_preserving_order(list_of_items):
@@ -125,3 +127,23 @@ def calculate_reduction_ratio(N, cartesian):
     the total search space.
     """
     return 1 - (N / cartesian)
+
+
+def _check_dependency_installed(module):
+    try:
+        dist = pkg_resources.get_distribution(module)
+    except pkg_resources.DistributionNotFound:
+        raise ValueError(
+            f"{module} is not installed.",
+            "Please install and import it before continuing."
+            )
+
+
+def query_sql_to_splink_df(linker, sql):
+    """
+    Quick wrapper for querying SQL -> outputting a splink df.
+    This is used in all of our linker classes currently.
+    """
+    hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
+    out_name = "__splink__df_dummy"
+    return linker._execute_sql_against_backend(sql, out_name, f"{out_name}_{hash}")

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -137,13 +137,3 @@ def _check_dependency_installed(module):
             f"{module} is not installed.",
             "Please install and import it before continuing.",
         )
-
-
-def query_sql_to_splink_df(linker, sql):
-    """
-    Quick wrapper for querying SQL -> outputting a splink df.
-    This is used in all of our linker classes currently.
-    """
-    hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
-    out_name = "__splink__df_dummy"
-    return linker._execute_sql_against_backend(sql, out_name, f"{out_name}_{hash}")

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -5,7 +5,6 @@ import json
 from string import ascii_lowercase
 import itertools
 import pkg_resources
-import hashlib
 
 
 def dedupe_preserving_order(list_of_items):
@@ -131,7 +130,7 @@ def calculate_reduction_ratio(N, cartesian):
 
 def _check_dependency_installed(module):
     try:
-        dist = pkg_resources.get_distribution(module)
+        pkg_resources.get_distribution(module)
     except pkg_resources.DistributionNotFound:
         raise ValueError(
             f"{module} is not installed.",

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -5,6 +5,8 @@ import re
 import os
 import math
 
+import pandas as pd
+
 from pyspark.sql import Row
 
 from ..linker import Linker
@@ -78,36 +80,36 @@ class SparkLinker(Linker):
         num_partitions_on_repartition=100,
     ):
         """Initialise the linker object, which manages the data linkage process and
-        holds the data linkage model.
+                holds the data linkage model.
 
-        Args:
-            input_table_or_tables: Input data into the linkage model.  Either a
-                single table or a list of tables.  Tables can be provided either as
-                a Spark DataFrame, or as the name of the table as a string, as
-                registered in the Spark catalog
-            settings_dict (dict, optional): A Splink settings dictionary. If not
-                provided when the object is created, can later be added using
-                `linker.initialise_settings()` Defaults to None.
-            break_lineage_method (str, optional): Method to use to cache intermediate
-                results.  Can be "checkpoint", "persist" or "parquet".  Defaults to
-                "parquet".
-            set_up_basic_logging (bool, optional): If true, sets ups up basic logging
-                so that Splink sends messages at INFO level to stdout. Defaults to True.
-            input_table_aliases (Union[str, list], optional): Labels assigned to
-                input tables in Splink outputs.  If the names of the tables in the
-                input database are long or unspecific, this argument can be used
-                to attach more easily readable/interpretable names. Defaults to None.
-            spark: The SparkSession. Required only if `input_table_or_tables` are
-                provided as string - otherwise will be inferred from the provided
-                Spark Dataframes.
-            repartition_after_blocking (bool, optional): In some cases, especially when
-                the comparisons are very computationally intensive, performance may be
-                improved by repartitioning after blocking to distribute the workload of
-                computing the comparison vectors more evenly and reduce the number of
-                tasks. Defaults to False.
-            num_partitions_on_repartition (int, optional): When saving out intermediate
-                results, how many partitions to use?  This should be set so that
-                partitions are roughly 100Mb. Defaults to 100.
+                Args:
+                    input_table_or_tables: Input data into the linkage model.  Either a
+                        single table or a list of tables.  Tables can be provided either as
+                        a Spark DataFrame, or as the name of the table as a string, as
+                        registered in the Spark catalog
+                    settings_dict (dict, optional): A Splink settings dictionary. If not
+                        provided when the object is created, can later be added using
+                        `linker.initialise_settings()` Defaults to None.
+                    break_lineage_method (str, optional): Method to use to cache intermediate
+                        results.  Can be "checkpoint", "persist" or "parquet".  Defaults to
+                        "parquet".
+                    set_up_basic_logging (bool, optional): If true, sets ups up basic logging
+                        so that Splink sends messages at INFO level to stdout. Defaults to True.
+                    input_table_aliases (Union[str, list], optional): Labels assigned to
+                        input tables in Splink outputs.  If the names of the tables in the
+                        input database are long or unspecific, this argument can be used
+                        to attach more easily readable/interpretable names. Defaults to None.
+                    spark: The SparkSession. Required only if `input_table_or_tables` are
+                        provided as string - otherwise will be inferred from the provided
+                        Spark Dataframes.
+                    repartition_after_blocking (bool, optional): In some cases, especially when
+                        the comparisons are very computationally intensive, performance may be
+                        improved by repartitioning after blocking to distribute the workload of
+        omputing the comparison vectors more evenly and reduce the number of
+                        tasks. Defaults to False.
+                    num_partitions_on_repartition (int, optional): When saving out intermediate
+                        results, how many partitions to use?  This should be set so that
+                        partitions are roughly 100Mb. Defaults to 100.
 
         """
 
@@ -272,6 +274,28 @@ class SparkLinker(Linker):
         output_df = self._table_to_splink_dataframe(templated_name, physical_name)
         return output_df
 
+    def query_sql(self, sql):
+        return self.spark.sql(sql).toPandas()
+
+    def register_table(self, input, table_name, overwrite=False):
+
+        # Check if table name is already in use
+        exists = self._table_exists_in_database(table_name)
+        if exists:
+            if not overwrite:
+                raise ValueError(f"Table '{table_name}' already exists in database.")
+
+        if isinstance(input, dict):
+            input = pd.DataFrame(input)
+            input = self.spark.createDataFrame(input)
+        elif isinstance(input, list):
+            input = pd.DataFrame.from_records(input)
+            input = self.spark.createDataFrame(input)
+        elif type(input).__name__ in ["DataFrame", "Table"]:
+            input = self.spark.createDataFrame(input)
+
+        input.createOrReplaceTempView(table_name)
+
     def _random_sample_sql(self, proportion, sample_size):
         if proportion == 1.0:
             return ""
@@ -284,10 +308,6 @@ class SparkLinker(Linker):
             if t.name == table_name:
                 return True
         return False
-
-    def _records_to_table(self, records, as_table_name):
-        df = self.spark.createDataFrame(Row(**x) for x in records)
-        df.createOrReplaceTempView(as_table_name)
 
     def register_tf_table(self, df, col_name):
         df.createOrReplaceTempView(colname_to_tf_tablename(col_name))

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -62,9 +62,9 @@ class SparkDataframe(SplinkDataFrame):
         return self.spark_linker.query_sql(sql, output_type)
 
     def as_record_dict(self, limit=None):
-        return self.as_dataframe(
-            output_type="pandas", limit=limit
-            ).to_dict(orient="records")
+        return self.as_dataframe(output_type="pandas", limit=limit).to_dict(
+            orient="records"
+        )
 
     def as_pandas_dataframe(self, limit=None):
         return self.as_dataframe(output_type="pandas", limit=limit)
@@ -292,7 +292,7 @@ class SparkLinker(Linker):
         else:
             raise ValueError(
                 f"output_type '{output_type}' is not supported.",
-                "Must be one of 'splink_df'/'splinkdf', 'pandas' or 'spark'"
+                "Must be one of 'splink_df'/'splinkdf', 'pandas' or 'spark'",
             )
 
     def register_table(self, input, table_name, overwrite=False):

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -4,7 +4,6 @@ from typing import Union, List
 import re
 import os
 import math
-import hashlib
 
 import pandas as pd
 

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -146,7 +146,7 @@ class SQLiteLinker(Linker):
         else:
             raise ValueError(
                 f"output_type '{output_type}' is not supported.",
-                "Must be one of 'splink_df'/'splinkdf' or 'pandas'"
+                "Must be one of 'splink_df'/'splinkdf' or 'pandas'",
             )
 
     def register_table(self, input, table_name, overwrite=False):

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -8,7 +8,6 @@ from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
 from ..input_column import InputColumn
-from ..misc import query_sql_to_splink_df
 
 logger = logging.getLogger(__name__)
 
@@ -69,16 +68,6 @@ class SQLiteDataFrame(SplinkDataFrame):
         cur = self.sqlite_linker.con.cursor()
         cur.execute(drop_sql)
 
-    def as_dataframe(self, output_type, limit=None):
-        sql = f"select * from {self.physical_name}"
-        if limit:
-            sql += f" limit {limit}"
-
-        return self.sqlite_linker.query_sql(sql, output_type)
-
-    def as_pandas_dataframe(self, limit=None):
-        return self.as_dataframe(output_type="pandas", limit=limit)
-
     def as_record_dict(self, limit=None):
         sql = f"""
         select *
@@ -137,17 +126,6 @@ class SQLiteLinker(Linker):
 
         output_obj = self._table_to_splink_dataframe(templated_name, physical_name)
         return output_obj
-
-    def query_sql(self, sql, output_type="pandas"):
-        if output_type in ("splink_df", "splinkdf"):
-            return query_sql_to_splink_df(self, sql)
-        elif output_type == "pandas":
-            return pd.read_sql_query(sql, self.con)
-        else:
-            raise ValueError(
-                f"output_type '{output_type}' is not supported.",
-                "Must be one of 'splink_df'/'splinkdf' or 'pandas'",
-            )
 
     def register_table(self, input, table_name, overwrite=False):
 

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -2,7 +2,6 @@ from typing import Union, List
 import logging
 from math import pow, log2
 import pandas as pd
-import hashlib
 
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..linker import Linker

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -22,10 +22,7 @@ def _test_table_registration(linker):
     with pytest.raises(ValueError):
         linker.register_table(test_dict, "__splink_df_pd")
     # Test overwriting works
-    try:
-        linker.register_table(test_dict, "__splink_df_pd", overwrite=True)
-    except:
-        raise Exception("Overwriting of table failed")
+    linker.register_table(test_dict, "__splink_df_pd", overwrite=True)
 
     # Record level dictionary
     b = [

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -35,18 +35,26 @@ def _test_table_registration(linker, query_types=[]):
     ]
 
     linker.register_table(b, "__splink_df_record_df")
-    record_df = linker.query_sql("select * from __splink_df_record_df", output_type="pandas")
+    record_df = linker.query_sql(
+        "select * from __splink_df_record_df", output_type="pandas"
+    )
     assert check_df_equality(record_df, pd.DataFrame.from_records(b))
 
     with pytest.raises(ValueError):
-        linker.query_sql("select * from __splink_df_test_dict", output_type = "testing")
-    df=linker.query_sql("select * from __splink_df_test_dict", output_type = "splinkdf").as_pandas_dataframe()
+        linker.query_sql("select * from __splink_df_test_dict", output_type="testing")
+    df = linker.query_sql(
+        "select * from __splink_df_test_dict", output_type="splinkdf"
+    ).as_pandas_dataframe()
     assert check_df_equality(df, test_dict_df)
-    r_dict=linker.query_sql("select * from __splink_df_record_df", output_type = "splinkdf").as_record_dict()
-    assert check_df_equality(pd.DataFrame.from_records(r_dict), pd.DataFrame.from_records(b))
+    r_dict = linker.query_sql(
+        "select * from __splink_df_record_df", output_type="splinkdf"
+    ).as_record_dict()
+    assert check_df_equality(
+        pd.DataFrame.from_records(r_dict), pd.DataFrame.from_records(b)
+    )
     # Just check any additional output types are working as expected
     for out_type in query_types:
-        linker.query_sql("select * from __splink_df_test_dict", output_type = out_type)
+        linker.query_sql("select * from __splink_df_test_dict", output_type=out_type)
 
 
 def register_roc_data(linker):

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -1,0 +1,65 @@
+import pandas as pd
+from tests.cc_testing_utils import check_df_equality
+import pytest
+import pyarrow as pa
+
+
+def _test_table_registration(linker):
+
+    # Standard pandas df...
+    a = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    linker.register_table(a, "pd")
+    pd_df = linker.query_sql("select * from pd")
+    assert check_df_equality(pd_df, a)
+
+    # Standard dictionary
+    test_dict = {"a": [666, 777, 888], "b": [4, 5, 6]}
+    linker.register_table(test_dict, "test_dict")
+    t_dict = linker.query_sql("select * from test_dict")
+    assert check_df_equality(t_dict, pd.DataFrame(test_dict))
+
+    # Duplicate table name (check for error)
+    with pytest.raises(ValueError):
+        linker.register_table(test_dict, "pd")
+    # Test overwriting works
+    try:
+        linker.register_table(test_dict, "pd", overwrite=True)
+    except:
+        assert False
+
+    # Record level dictionary
+    b = [
+        {"a": 1, "b": 22, "c": 333},
+        {"a": 2, "b": 33, "c": 444},
+        {"a": 3, "b": 44, "c": 555},
+    ]
+
+    linker.register_table(b, "record_df")
+    record_df = linker.query_sql("select * from record_df")
+    assert check_df_equality(record_df, pd.DataFrame.from_records(b))
+
+
+def register_roc_data(linker):
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df_10 = df.head(10).copy()
+    df_10["merge"] = 1
+    df_10["source_dataset"] = "fake_data_1"
+
+    df_l = df_10[["unique_id", "source_dataset", "group", "merge"]].copy()
+    df_r = df_l.copy()
+
+    df_labels = df_l.merge(df_r, on="merge", suffixes=("_l", "_r"))
+    f1 = df_labels["unique_id_l"] < df_labels["unique_id_r"]
+    df_labels = df_labels[f1]
+
+    df_labels["clerical_match_score"] = (
+        df_labels["group_l"] == df_labels["group_r"]
+    ).astype(float)
+
+    df_labels = df_labels.drop(
+        ["group_l", "group_r", "source_dataset_l", "source_dataset_r", "merge"],
+        axis=1,
+    )
+
+    linker.register_table(df_labels, "labels")

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -3,14 +3,14 @@ from tests.cc_testing_utils import check_df_equality
 import pytest
 
 
-def _test_table_registration(linker, query_types=[]):
+def _test_table_registration(linker):
 
     # Standard pandas df...
     a = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
     linker.register_table(a, "__splink_df_pd")
-    pd_df = linker.query_sql("select * from __splink_df_pd", output_type="pandas")
-    assert check_df_equality(pd_df, a)
+    pd_df = linker.query_sql("select * from __splink_df_pd", output_type="splinkdf")
+    assert check_df_equality(pd_df.as_pandas_dataframe(), a)
 
     # Standard dictionary
     test_dict = {"a": [666, 777, 888], "b": [4, 5, 6]}
@@ -52,9 +52,6 @@ def _test_table_registration(linker, query_types=[]):
     assert check_df_equality(
         pd.DataFrame.from_records(r_dict), pd.DataFrame.from_records(b)
     )
-    # Just check any additional output types are working as expected
-    for out_type in query_types:
-        linker.query_sql("select * from __splink_df_test_dict", output_type=out_type)
 
 
 def register_roc_data(linker):

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from tests.cc_testing_utils import check_df_equality
 import pytest
-import pyarrow as pa
 
 
 def _test_table_registration(linker):
@@ -9,22 +8,22 @@ def _test_table_registration(linker):
     # Standard pandas df...
     a = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
-    linker.register_table(a, "pd")
-    pd_df = linker.query_sql("select * from pd")
+    linker.register_table(a, "__splink_df_pd")
+    pd_df = linker.query_sql("select * from __splink_df_pd")
     assert check_df_equality(pd_df, a)
 
     # Standard dictionary
     test_dict = {"a": [666, 777, 888], "b": [4, 5, 6]}
-    linker.register_table(test_dict, "test_dict")
-    t_dict = linker.query_sql("select * from test_dict")
+    linker.register_table(test_dict, "__splink_df_test_dict")
+    t_dict = linker.query_sql("select * from __splink_df_test_dict")
     assert check_df_equality(t_dict, pd.DataFrame(test_dict))
 
     # Duplicate table name (check for error)
     with pytest.raises(ValueError):
-        linker.register_table(test_dict, "pd")
+        linker.register_table(test_dict, "__splink_df_pd")
     # Test overwriting works
     try:
-        linker.register_table(test_dict, "pd", overwrite=True)
+        linker.register_table(test_dict, "__splink_df_pd", overwrite=True)
     except:
         assert False
 
@@ -35,8 +34,8 @@ def _test_table_registration(linker):
         {"a": 3, "b": 44, "c": 555},
     ]
 
-    linker.register_table(b, "record_df")
-    record_df = linker.query_sql("select * from record_df")
+    linker.register_table(b, "__splink_df_record_df")
+    record_df = linker.query_sql("select * from __splink_df_record_df")
     assert check_df_equality(record_df, pd.DataFrame.from_records(b))
 
 

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -25,7 +25,7 @@ def _test_table_registration(linker):
     try:
         linker.register_table(test_dict, "__splink_df_pd", overwrite=True)
     except:
-        assert False
+        raise Exception("Overwriting of table failed")
 
     # Record level dictionary
     b = [

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -156,7 +156,7 @@ def test_full_example_athena(tmp_path):
     )
 
     linker.unlinkables_chart(source_dataset="Testing")
-    
+
     _test_table_registration(linker)
 
 

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -4,6 +4,7 @@ import os
 
 from basic_settings import get_settings_dict
 from linker_utils import _test_table_registration
+from splink.athena.athena_comparison_library import levenshtein_at_thresholds
 
 skip = False
 try:
@@ -16,7 +17,6 @@ if not skip:
     from splink.athena.athena_linker import AthenaLinker
     import boto3
     from dataengineeringutils3.s3 import delete_s3_folder_contents
-    from splink.athena.athena_comparison_library import levenshtein_at_thresholds
 
 
 settings_dict = get_settings_dict()

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -19,6 +19,31 @@ if not skip:
     from splink.athena.athena_comparison_library import levenshtein_at_thresholds
 
 
+settings_dict = get_settings_dict()
+
+first_name_cc = levenshtein_at_thresholds(
+    col_name="first_name",
+    distance_threshold_or_thresholds=2,
+    include_exact_match_level=True,
+    term_frequency_adjustments=True,
+    m_probability_exact_match=0.7,
+    m_probability_or_probabilities_lev=0.2,
+    m_probability_else=0.1,
+)
+
+# Update tf weight and u probabilities to match v2 settings
+first_name_cc._comparison_dict["comparison_levels"][1]._tf_adjustment_weight = 0.6
+u_probabilities_first_name = [0.1, 0.1, 0.8]
+for u_prob, level in zip(
+    u_probabilities_first_name,
+    first_name_cc._comparison_dict["comparison_levels"][1:],
+):
+    level._u_probability = u_prob
+
+# Update settings w/ our edited first_name col
+settings_dict["comparisons"][0] = first_name_cc
+
+
 def setup_athena_db(my_session, db_name="splink_awswrangler_test"):
 
     """
@@ -89,30 +114,6 @@ def test_full_example_athena(tmp_path):
 
     # creates a session at least on the platform...
     my_session = boto3.Session(region_name="eu-west-1")
-    settings_dict = get_settings_dict()
-
-    first_name_cc = levenshtein_at_thresholds(
-        col_name="first_name",
-        distance_threshold_or_thresholds=2,
-        include_exact_match_level=True,
-        term_frequency_adjustments=True,
-        m_probability_exact_match=0.7,
-        m_probability_or_probabilities_lev=0.2,
-        m_probability_else=0.1,
-    )
-
-    # Update tf weight and u probabilities to match v2 settings
-    first_name_cc._comparison_dict["comparison_levels"][1]._tf_adjustment_weight = 0.6
-    u_probabilities_first_name = [0.1, 0.1, 0.8]
-    for u_prob, level in zip(
-        u_probabilities_first_name,
-        first_name_cc._comparison_dict["comparison_levels"][1:],
-    ):
-        level._u_probability = u_prob
-
-    # Update settings w/ our edited first_name col
-    settings_dict["comparisons"][0] = first_name_cc
-
     db_name_read = "splink_awswrangler_test"
     db_name_write = f"{db_name_read}2"
 
@@ -165,7 +166,6 @@ def test_athena_garbage_collection():
 
     # creates a session at least on the platform...
     my_session = boto3.Session(region_name="eu-west-1")
-    settings_dict = get_settings_dict()
     db_name_read = "splink_awswrangler_test"
     db_name_write = f"{db_name_read}2"
 
@@ -233,7 +233,6 @@ def test_athena_df_as_input():
 
     # creates a session at least on the platform...
     my_session = boto3.Session(region_name="eu-west-1")
-    settings_dict = get_settings_dict()
     db_name_read = "splink_awswrangler_test"
     db_name_write = f"{db_name_read}2"
 
@@ -259,7 +258,6 @@ def test_athena_link_only():
 
     # creates a session at least on the platform...
     my_session = boto3.Session(region_name="eu-west-1")
-    settings_dict = get_settings_dict()
     settings_dict["link_type"] = "link_and_dedupe"
     db_name_read = "splink_awswrangler_test"
     db_name_write = f"{db_name_read}2"

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -3,6 +3,7 @@ import pytest
 import os
 
 from basic_settings import get_settings_dict
+from linker_utils import _test_table_registration
 
 skip = False
 try:
@@ -155,6 +156,8 @@ def test_full_example_athena(tmp_path):
     )
 
     linker.unlinkables_chart(source_dataset="Testing")
+    
+    _test_table_registration(linker)
 
 
 @pytest.mark.skip(reason="AWS Connection Required")

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -91,7 +91,7 @@ def test_full_example_duckdb(tmp_path):
 
     linker.unlinkables_chart(source_dataset="Testing")
 
-    _test_table_registration(linker)
+    _test_table_registration(linker, ["arrow"])
 
     record = {
         "unique_id": 1,

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -106,7 +106,7 @@ def test_full_example_duckdb(tmp_path):
     linker.compute_tf_table("first_name")
     linker._initialise_df_concat_with_tf()
 
-    matches = linker.find_matches_to_new_records(
+    linker.find_matches_to_new_records(
         [record], blocking_rules=[], match_weight_threshold=-10000
     )
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -91,7 +91,7 @@ def test_full_example_duckdb(tmp_path):
 
     linker.unlinkables_chart(source_dataset="Testing")
 
-    _test_table_registration(linker, ["arrow"])
+    _test_table_registration(linker)
 
     record = {
         "unique_id": 1,

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -1,3 +1,4 @@
+from atexit import register
 import os
 
 from splink.spark.spark_linker import SparkLinker
@@ -10,6 +11,7 @@ from splink.spark.spark_comparison_level_library import (
 
 from pyspark.sql.functions import array
 from basic_settings import get_settings_dict
+from linker_utils import _test_table_registration, register_roc_data
 
 
 def test_full_example_spark(df_spark, tmp_path):
@@ -88,3 +90,24 @@ def test_full_example_spark(df_spark, tmp_path):
     )
 
     linker.unlinkables_chart(source_dataset="Testing")
+
+    _test_table_registration(linker)
+
+    register_roc_data(linker)
+    linker.roc_chart_from_labels_table("labels")
+
+    record = {
+        "unique_id": 1,
+        "first_name": "John",
+        "surname": "Smith",
+        "dob": "1971-05-24",
+        "city": "London",
+        "email": ["john@smith.net"],
+        "group": 10000,
+    }
+
+    linker.compute_tf_table("first_name")
+
+    matches = linker.find_matches_to_new_records(
+        [record], blocking_rules=[], match_weight_threshold=-10000
+    )

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -107,6 +107,6 @@ def test_full_example_spark(df_spark, tmp_path):
 
     linker.compute_tf_table("first_name")
 
-    matches = linker.find_matches_to_new_records(
+    linker.find_matches_to_new_records(
         [record], blocking_rules=[], match_weight_threshold=-10000
     )

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -90,7 +90,7 @@ def test_full_example_spark(df_spark, tmp_path):
 
     linker.unlinkables_chart(source_dataset="Testing")
 
-    _test_table_registration(linker, ["spark"])
+    _test_table_registration(linker)
 
     register_roc_data(linker)
     linker.roc_chart_from_labels_table("labels")

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -1,4 +1,3 @@
-from atexit import register
 import os
 
 from splink.spark.spark_linker import SparkLinker
@@ -91,7 +90,7 @@ def test_full_example_spark(df_spark, tmp_path):
 
     linker.unlinkables_chart(source_dataset="Testing")
 
-    _test_table_registration(linker)
+    _test_table_registration(linker, ["spark"])
 
     register_roc_data(linker)
     linker.roc_chart_from_labels_table("labels")

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -7,6 +7,7 @@ from splink.comparison_level_library import (
     _mutable_params,
 )
 from basic_settings import get_settings_dict
+from linker_utils import _test_table_registration, register_roc_data
 
 _mutable_params["dialect"] = "sqlite"
 _mutable_params["levenshtein"] = "levenshtein"
@@ -57,6 +58,11 @@ def test_full_example_sqlite(tmp_path):
     linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.5)
 
     linker.unlinkables_chart(source_dataset="Testing")
+
+    _test_table_registration(linker)
+
+    register_roc_data(linker)
+    linker.roc_chart_from_labels_table("labels")
 
 
 def test_small_link_example_sqlite():


### PR DESCRIPTION
Initial draft for table registration which addresses [issue #585](https://github.com/moj-analytical-services/splink/issues/585).
<br>

**This PR:**
* Add a table registration method to each linker.
* Adds a `query_sql` method for each linker, which allows users to easily query their database.
* Updates our tests to reflect this API change and add some new tests to check that table registration is working as intended.

<hr>

#### Table Registration

Fairly straightforward, but this grants users the ability to simply pass either: a dictionary, record level dictionary, pandas df or pyarrow in the duckdb case/spark df in the spark case.

This is done simply by calling:
`linker.register_table(<input>, <table_name>)`

**To note:** pyarrow is significantly quicker than pandas for this. From some quick benchmarks, I was finding that registering a record level dictionary of 3 million cells into duckdb took:
* 7 seconds with pandas
* 2 seconds with pyarrow.

If we're happy to let pyarrow become a dependency, I'll adjust this PR to use pyarrow instead.

### Query SQL

Not much to add - allows user to query their database as they please.
The syntax is simply: `linker.query_sql(sql)` and will output a pandas df.