### PR TITLE
Fix cumulative br bug

### DIFF
--- a/splink/analyse_blocking.py
+++ b/splink/analyse_blocking.py
@@ -93,7 +93,7 @@ def cumulative_comparisons_generated_by_blocking_rules(
     cumulative_blocking_rule_count = linker._execute_sql_pipeline()
     br_n = cumulative_blocking_rule_count.as_pandas_dataframe()
     cumulative_blocking_rule_count.drop_table_from_database()
-    br_count, br_keys = list(br_n.row_count), list(br_n['match_key'].astype('int'))
+    br_count, br_keys = list(br_n.row_count), list(br_n["match_key"].astype("int"))
 
     if len(br_count) != len(brs_as_objs):
         missing_br = [x for x in range(len(brs_as_objs)) if x not in br_keys]

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -148,7 +148,4 @@ def block_using_rules_sql(linker: "Linker"):
 
     sql = "union all".join(sqls)
 
-    if not settings_obj._needs_matchkey_column:
-        sql = sql.replace(", '0' as match_key", "")
-
     return sql

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -116,6 +116,22 @@ def test_blocking_records_accuracy():
         blocking_rules=blocking_rules,
     )
 
+    blocking_rules = [
+        "l.first_name = r.first_name",
+        "l.first_name = r.first_name and l.surname = r.surname",
+        "l.dob = r.dob",
+    ]
+
+    validate_blocking_output(
+        linker_settings,
+        expected_out={
+            "row_count": [2253, 0, 1244],
+            "cumulative_rows": [2253, 2253, 3497],
+            "cartesian": 499500,
+        },
+        blocking_rules=blocking_rules,
+    )
+
     # link and dedupe + link only without settings
     blocking_rules = [
         "l.surname = r.surname",

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -63,7 +63,7 @@ def test_splink_converges_to_known_params():
     linker = DuckDBLinker(df, settings)
 
     # need to register df_blocked and go from there
-    linker._con.register("__splink__df_comparison_vectors_2fc9d5a", df)
+    linker._con.register("__splink__df_comparison_vectors_0de5e3a", df)
 
     em_training_session = EMTrainingSession(
         linker,
@@ -83,7 +83,7 @@ def test_splink_converges_to_known_params():
 
     cv = DuckDBLinkerDataFrame(
         "__splink__df_comparison_vectors",
-        "__splink__df_comparison_vectors_2fc9d5a",
+        "__splink__df_comparison_vectors_0de5e3a",
         linker,
     )
 


### PR DESCRIPTION
Fixes [issue #812](https://github.com/moj-analytical-services/splink/issues/812).

All I've changed is how we utilise the match_key field produced by splink. Where we have a missing blocking rule, we work out which is missing using the match_key and set it to a value of 0.

This results in charts that look like so:
![Screenshot 2022-09-28 at 13 31 20](https://user-images.githubusercontent.com/45356472/192779038-e8c531e4-13d4-42da-a884-3a34d91ca8a9.png)


The graph axis could probably do with some manual intervention too, but that's one for a later date.