### PR TITLE
Unlinkables logic tweak

### DIFF
--- a/splink/charts.py
+++ b/splink/charts.py
@@ -295,6 +295,12 @@ def unlinkables_chart(
     source_dataset=None,
     as_dict=False,
 ):
+
+    if x_col not in ["match_weight", "match_probability"]:
+        raise ValueError(
+            f"{x_col} must be 'match_weight' (default) or 'match_probability'."
+        )
+
     chart_path = "unlinkables_chart_def.json"
     unlinkables_chart_def = load_chart_definition(chart_path)
     unlinkables_chart_def["data"]["values"] = records

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1718,7 +1718,7 @@ class Linker:
         """
 
         # Link our initial df on itself and calculate the % of unlinkable entries
-        records = unlinkables_data(self, x_col)
+        records = unlinkables_data(self)
         return unlinkables_chart(records, x_col, source_dataset, as_dict)
 
     def comparison_viewer_dashboard(

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1719,7 +1719,7 @@ class Linker:
 
         # Link our initial df on itself and calculate the % of unlinkable entries
         records = unlinkables_data(self, x_col)
-        return unlinkables_chart(records, x_col, source_dataset)
+        return unlinkables_chart(records, x_col, source_dataset, as_dict)
 
     def comparison_viewer_dashboard(
         self,

--- a/splink/unlinkables.py
+++ b/splink/unlinkables.py
@@ -1,4 +1,4 @@
-def unlinkables_data(linker, x_col="match_weight"):
+def unlinkables_data(linker):
     """Generate data displaying the proportion of records that are "unlinkable"
     for a given splink score threshold and model parameters. These are records that,
     even when compared with themselves, do not contain enough information to confirm
@@ -6,19 +6,9 @@ def unlinkables_data(linker, x_col="match_weight"):
 
     Args:
         linker (Splink): A Splink data linker
-        x_col (str, optional): The column name to use as the x-axis in the chart.
-            This can be either the "match_weight" or "match_probability" columns.
-            Defaults to "match_weight".
-        source_dataset (str, optional): Name of the source dataset (used in chart
-            title). Defaults to None.
     """
 
     self_link = linker._self_link()
-
-    if x_col not in ["match_weight", "match_probability"]:
-        raise ValueError(
-            f"{x_col} must be 'match_weight' (default) or 'match_probability'."
-        )
 
     sql = f"""
         select


### PR DESCRIPTION
Argument `as_dict` now correctly passed through to the chart creation function, moved the column check to the chart function (as it is not needed by the data creation function) and trimmed unnecessary args from docstring.