### PR TITLE
Update readme to color format example code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The specification of the Fellegi Sunter statistical model behind `splink` is sim
 
 Splink supports python 3.7+. To obtain the latest released version of splink:
 
-```
+```sh
 pip install splink
 ```
 
@@ -76,7 +76,7 @@ The following code demonstrates how to estimate the parameters of a deduplicatio
 
 For more detailed tutorials, please see [here](https://moj-analytical-services.github.io/splink/demos/00_Tutorial_Introduction.html).
 
-```
+```py
 from splink.duckdb.duckdb_linker import DuckDBLinker
 from splink.duckdb.duckdb_comparison_library import (
     exact_match,


### PR DESCRIPTION
The example code block on the README was not color formatted (for python). The change makes color formatted code block(s) available.