### PR TITLE
change haversine test to use pandas instead of pyarrow (py3.6 compatibility)

### DIFF
--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -1,6 +1,4 @@
 import pandas as pd
-import pyarrow as pa
-
 from splink.comparison_level_library import (
     columns_reversed_level,
     else_level,

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -63,7 +63,7 @@ def test_haversine_level():
         d["lat_long"] = {"lat": d["lat"], "long": d["lon"]}
         d["lat_long_arr"] = [d["lat"], d["lon"]]
 
-    df = pa.Table.from_pylist(data)
+    df = pd.DataFrame(data)
 
     settings = {
         "unique_id_column_name": "id",


### PR DESCRIPTION
Context
While harmless this `from_pylist` method doesnt work in py3.6 (as it was added from pyarrow>=7.00 onwards
This is not a core splink functionality just a convenient way to load data for this test so the change is not affecting 
the testing coverage at all.


see
https://github.com/moj-analytical-services/splink/discussions/836#discussioncomment-3872555
