### PR TITLE
github action for testing py3.6 compatibility

### DIFF
--- a/.github/workflows/pytest_36_compatibility.yml
+++ b/.github/workflows/pytest_36_compatibility.yml
@@ -1,0 +1,34 @@
+name: Run tests on a py 3.6 env
+on:
+  release:
+    types: [published,unpublished]
+     
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python 3.6.2 and necessary dependencies 
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: setup pyenv  / install suitable deps for py 3.6 / test
+        uses: "gabrielfalcao/pyenv-action@v9"
+        with:
+          default: 3.6.2
+          command: |
+           pip install --upgrade pip
+           pip install pybind11==2.10.0 certifi==2021.5.30 dataclasses==0.8 attrs==22.1.0  decorator==4.4.2 networkx==2.5.1 numpy==1.19.5 
+           pip install setuptools==59.6.0 setuptools-scm==6.4.2
+           pip install -v duckdb==0.5.1 
+           pip install importlib-metadata==4.8.3 iniconfig==1.1.1 Jinja2==3.0.3 jsonschema==3.2.0 MarkupSafe==2.0.1  packaging==21.3 pandas==1.1.5 pluggy==1.0.0 py==1.11.0 py4j==0.10.9.5 pyarrow==6.0.1 pyparsing==3.0.7 pyrsistent==0.18.0 pyspark==3.2.2 pytest==7.0.1 python-dateutil==2.8.2 pytz==2022.4 six==1.16.0 sqlglot==5.3.1 tomli==1.2.3 typing_extensions==4.1.1 zipp==3.6.0 rapidfuzz
+           
+      #----------------------------------------------
+      # install splink and run tests 
+      #----------------------------------------------
+      - name: Install project
+        run: pip install --no-dependencies .
+
+      - name: Run tests
+        run: |
+          python3 -m pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/moj-analytical-services/splink"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.6"
 jsonschema = "^3.2"
 pandas = "^1.0.0"
 duckdb = "^0.5.0"


### PR DESCRIPTION
Some context: 
it has been tested on a macbook that all tests pass on a python 3.6.2 environment after the 3.4.1 splink release.

However there was initially some difficulty testing methodically this via a GitHub action : 
here are some notes on process for making the 3.6 env testing to work.

https://github.com/moj-analytical-services/splink/discussions/836


Now that this action exists on every (minor, major) release we can test if the tests work on a py3.6 environment.

Next step within this PR after discussion is to add a documentation sub-note somewhere on what needs to be done in order to install the latest splink versions on a Python 3.6.2 environment.

a proposed solution would be to install splink via the `--no-dependencies` flag after installing certain prerequisite modules
(or installing these via a dependencies3_6.txt file ).

Opinions?

