### PR TITLE
Fix total link calculation

### DIFF
--- a/splink/misc.py
+++ b/splink/misc.py
@@ -99,13 +99,12 @@ def calculate_cartesian(df_rows, link_type):
     if link_type == "link_only":
         if len(n) <= 1:
             raise ValueError(
-                "if 'link_type 'is 'link_only' should have "
-                "at least two input frames"
+                "if 'link_type 'is 'link_only' should have " "at least two input frames"
             )
         # sum of pairwise product can be found as
         # half of [(sum)-squared - (sum of squares)]
         return (
-            sum([m["count"] for m in n])**2 - sum([m["count"]**2 for m in n])
+            sum([m["count"] for m in n]) ** 2 - sum([m["count"] ** 2 for m in n])
         ) / 2
 
     if link_type == "dedupe_only":
@@ -119,7 +118,7 @@ def calculate_cartesian(df_rows, link_type):
     if link_type == "link_and_dedupe":
         total_rows = sum([m["count"] for m in n])
         return total_rows * (total_rows - 1) / 2
-    
+
     raise ValueError(
         "'link_type' should be either 'link_only', 'dedupe_only', "
         "or 'link_and_dedupe'"

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -97,19 +97,33 @@ def calculate_cartesian(df_rows, link_type):
     n = df_rows
 
     if link_type == "link_only":
-        return np.product([m["count"] for m in n])
+        if len(n) <= 1:
+            raise ValueError(
+                "if 'link_type 'is 'link_only' should have "
+                "at least two input frames"
+            )
+        # sum of pairwise product can be found as
+        # half of [(sum)-squared - (sum of squares)]
+        return (
+            sum([m["count"] for m in n])**2 - sum([m["count"]**2 for m in n])
+        ) / 2
 
     if link_type == "dedupe_only":
-        return sum([m["count"] * (m["count"] - 1) for m in n]) / 2
+        if len(n) > 1:
+            raise ValueError(
+                "if 'link_type' is 'dedupe_only' should have only "
+                "a single input frame"
+            )
+        return n[0]["count"] * (n[0]["count"] - 1) / 2
 
     if link_type == "link_and_dedupe":
-        if len(n) > 1:
-            prod = np.product([m["count"] for m in n])
-        else:
-            prod = 0
-
-        c = sum([m["count"] * (m["count"] - 1) for m in n]) / 2
-        return prod + c
+        total_rows = sum([m["count"] for m in n])
+        return total_rows * (total_rows - 1) / 2
+    
+    raise ValueError(
+        "'link_type' should be either 'link_only', 'dedupe_only', "
+        "or 'link_and_dedupe'"
+    )
 
 
 def calculate_reduction_ratio(N, cartesian):

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -170,8 +170,12 @@ def test_blocking_records_accuracy():
         linker_settings,
         expected_out={
             # number of links per block simply related to two-frame case
-            "row_count": [3*7257, 3*27190, 3*68640],
-            "cumulative_rows": [3*7257, 3*7257 + 3*27190, 3*7257 + 3*27190 + 3*68640],
+            "row_count": [3 * 7257, 3 * 27190, 3 * 68640],
+            "cumulative_rows": [
+                3 * 7257,
+                3 * 7257 + 3 * 27190,
+                3 * 7257 + 3 * 27190 + 3 * 68640,
+            ],
             "cartesian": 3_000_000,
         },
         blocking_rules=blocking_rules,
@@ -182,10 +186,10 @@ def test_blocking_records_accuracy():
     validate_blocking_output(
         linker_settings,
         expected_out={
-            # and as above, 
+            # and as above,
             "row_count": [31272, 120993, 308880],
             "cumulative_rows": [31272, 31272 + 120993, 31272 + 120993 + 308880],
-            "cartesian": (3000 * 2999)//2,
+            "cartesian": (3000 * 2999) // 2,
         },
         blocking_rules=blocking_rules,
     )

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -172,7 +172,7 @@ def test_blocking_records_accuracy():
             # number of links per block simply related to two-frame case
             "row_count": [3*7257, 3*27190, 3*68640],
             "cumulative_rows": [3*7257, 3*7257 + 3*27190, 3*7257 + 3*27190 + 3*68640],
-            "cartesian": 1_000_000_000 #3_000_000,
+            "cartesian": 3_000_000,
         },
         blocking_rules=blocking_rules,
     )
@@ -185,7 +185,7 @@ def test_blocking_records_accuracy():
             # and as above, 
             "row_count": [31272, 120993, 308880],
             "cumulative_rows": [31272, 31272 + 120993, 31272 + 120993 + 308880],
-            "cartesian": 1_000_000_000 + 3*1000*999//2 #(3000 * 2999)//2,
+            "cartesian": (3000 * 2999)//2,
         },
         blocking_rules=blocking_rules,
     )

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -181,9 +181,7 @@ def test_prob_rr_match_link_only_multitable():
     prob = linker._settings_obj._probability_two_random_records_match
     # 6 matches (1 John, 3 Mary, 1 Jones (ignoring already matched Mary), 1 Taylor)
     # 4*3 + 4*5 + 4*7 + 3*5 + 3*7 + 5*7 = 131 comparisons
-    # assert pytest.approx(prob) == 6 / 131
-    # existing miscounting:
-    assert pytest.approx(prob) == 6 / 420
+    assert pytest.approx(prob) == 6 / 131
 
 
 def test_prob_rr_match_link_and_dedupe_multitable():
@@ -242,6 +240,4 @@ def test_prob_rr_match_link_and_dedupe_multitable():
     prob = linker._settings_obj._probability_two_random_records_match
     # 10 matches (1 John, 3 Mary, 2 Jones (ignoring already matched Mary), 1 Taylor, 3 Graham, 0 Roberts (ignoring already counted Graham))
     # (3 + 4 + 5 + 7)(3 + 4 + 5 + 7 - 1)/2 = 171 comparisons
-    # assert pytest.approx(prob) == 10 / 171
-    # existing miscounting:
-    assert pytest.approx(prob) == 10 / 460
+    assert pytest.approx(prob) == 10 / 171

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -185,7 +185,7 @@ def test_prob_rr_match_link_only_multitable():
     assert pytest.approx(prob) == 6 / 131
 
     # if we define all record pairs to be a match match, then the probability should be 1
-    dfs = list(map(lambda df: df.assign(city = "Brighton"), dfs))
+    dfs = list(map(lambda df: df.assign(city="Brighton"), dfs))
     linker = DuckDBLinker(dfs, settings)
     linker.estimate_probability_two_random_records_match(
         ["l.city = r.city"], recall=1.0
@@ -253,7 +253,7 @@ def test_prob_rr_match_link_and_dedupe_multitable():
     # (3 + 4 + 5 + 7)(3 + 4 + 5 + 7 - 1)/2 = 171 comparisons
     assert pytest.approx(prob) == 10 / 171
 
-    dfs = list(map(lambda df: df.assign(city = "Brighton"), dfs))
+    dfs = list(map(lambda df: df.assign(city="Brighton"), dfs))
     linker = DuckDBLinker(dfs, settings)
     linker.estimate_probability_two_random_records_match(
         ["l.city = r.city"], recall=1.0

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -123,3 +123,125 @@ def test_prob_rr_match_link_and_dedupe():
     prob = linker._settings_obj._probability_two_random_records_match
     # 3 matches and 15 comparisons
     assert pytest.approx(prob) == 3 / 15
+
+
+def test_prob_rr_match_link_only_multitable():
+    df_1 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "John", "surname": "Smith"},
+            {"unique_id": 2, "first_name": "Mary", "surname": "Jones"},
+            {"unique_id": 3, "first_name": "Hannah", "surname": "Jones"},
+        ]
+    )
+
+    df_2 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "John", "surname": "Smyth"},
+            {"unique_id": 2, "first_name": "Mary", "surname": "Jones"},
+            {"unique_id": 3, "first_name": "Jane", "surname": "Taylor"},
+            {"unique_id": 4, "first_name": "Alice", "surname": "Williams"},
+        ]
+    )
+
+    df_3 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "Graham", "surname": "Roberts"},
+            {"unique_id": 2, "first_name": "Graham", "surname": "Robinson"},
+            {"unique_id": 3, "first_name": "Mary", "surname": "Taylor"},
+            {"unique_id": 4, "first_name": "Graham", "surname": "Roberts"},
+            {"unique_id": 5, "first_name": "Sarah", "surname": "Thompson"},
+        ]
+    )
+
+    df_4 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "Johnny", "surname": "Brown"},
+            {"unique_id": 2, "first_name": "Ben", "surname": "Davies"},
+            {"unique_id": 3, "first_name": "Felicity", "surname": "Wright"},
+            {"unique_id": 4, "first_name": "Kelly", "surname": "Evans"},
+            {"unique_id": 5, "first_name": "David", "surname": "Thomas"},
+            {"unique_id": 6, "first_name": "Bryan", "surname": "Wilson"},
+            {"unique_id": 7, "first_name": "Brian", "surname": "Johnson"},
+        ]
+    )
+
+    settings = {
+        "link_type": "link_only",
+        "blocking_rules_to_generate_predictions": [],
+        "comparisons": [],
+    }
+
+    deterministic_rules = ["l.first_name = r.first_name", "l.surname = r.surname"]
+
+    linker = DuckDBLinker([df_1, df_2, df_3, df_4], settings)
+    linker.estimate_probability_two_random_records_match(
+        deterministic_rules, recall=1.0
+    )
+
+    prob = linker._settings_obj._probability_two_random_records_match
+    # 6 matches (1 John, 3 Mary, 1 Jones (ignoring already matched Mary), 1 Taylor)
+    # 4*3 + 4*5 + 4*7 + 3*5 + 3*7 + 5*7 = 131 comparisons
+    # assert pytest.approx(prob) == 6 / 131
+    # existing miscounting:
+    assert pytest.approx(prob) == 6 / 420
+
+
+def test_prob_rr_match_link_and_dedupe_multitable():
+    df_1 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "John", "surname": "Smith"},
+            {"unique_id": 2, "first_name": "Mary", "surname": "Jones"},
+            {"unique_id": 3, "first_name": "Hannah", "surname": "Jones"},
+        ]
+    )
+
+    df_2 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "John", "surname": "Smyth"},
+            {"unique_id": 2, "first_name": "Mary", "surname": "Jones"},
+            {"unique_id": 3, "first_name": "Jane", "surname": "Taylor"},
+            {"unique_id": 4, "first_name": "Alice", "surname": "Williams"},
+        ]
+    )
+
+    df_3 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "Graham", "surname": "Roberts"},
+            {"unique_id": 2, "first_name": "Graham", "surname": "Robinson"},
+            {"unique_id": 3, "first_name": "Mary", "surname": "Taylor"},
+            {"unique_id": 4, "first_name": "Graham", "surname": "Roberts"},
+            {"unique_id": 5, "first_name": "Sarah", "surname": "Thompson"},
+        ]
+    )
+
+    df_4 = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "Johnny", "surname": "Brown"},
+            {"unique_id": 2, "first_name": "Ben", "surname": "Davies"},
+            {"unique_id": 3, "first_name": "Felicity", "surname": "Wright"},
+            {"unique_id": 4, "first_name": "Kelly", "surname": "Evans"},
+            {"unique_id": 5, "first_name": "David", "surname": "Thomas"},
+            {"unique_id": 6, "first_name": "Bryan", "surname": "Wilson"},
+            {"unique_id": 7, "first_name": "Brian", "surname": "Johnson"},
+        ]
+    )
+
+    settings = {
+        "link_type": "link_and_dedupe",
+        "blocking_rules_to_generate_predictions": [],
+        "comparisons": [],
+    }
+
+    deterministic_rules = ["l.first_name = r.first_name", "l.surname = r.surname"]
+
+    linker = DuckDBLinker([df_1, df_2, df_3, df_4], settings)
+    linker.estimate_probability_two_random_records_match(
+        deterministic_rules, recall=1.0
+    )
+
+    prob = linker._settings_obj._probability_two_random_records_match
+    # 10 matches (1 John, 3 Mary, 2 Jones (ignoring already matched Mary), 1 Taylor, 3 Graham, 0 Roberts (ignoring already counted Graham))
+    # (3 + 4 + 5 + 7)(3 + 4 + 5 + 7 - 1)/2 = 171 comparisons
+    # assert pytest.approx(prob) == 10 / 171
+    # existing miscounting:
+    assert pytest.approx(prob) == 10 / 460

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -173,7 +173,8 @@ def test_prob_rr_match_link_only_multitable():
 
     deterministic_rules = ["l.first_name = r.first_name", "l.surname = r.surname"]
 
-    linker = DuckDBLinker([df_1, df_2, df_3, df_4], settings)
+    dfs = [df_1, df_2, df_3, df_4]
+    linker = DuckDBLinker(dfs, settings)
     linker.estimate_probability_two_random_records_match(
         deterministic_rules, recall=1.0
     )
@@ -182,6 +183,15 @@ def test_prob_rr_match_link_only_multitable():
     # 6 matches (1 John, 3 Mary, 1 Jones (ignoring already matched Mary), 1 Taylor)
     # 4*3 + 4*5 + 4*7 + 3*5 + 3*7 + 5*7 = 131 comparisons
     assert pytest.approx(prob) == 6 / 131
+
+    # if we define all record pairs to be a match match, then the probability should be 1
+    dfs = list(map(lambda df: df.assign(city = "Brighton"), dfs))
+    linker = DuckDBLinker(dfs, settings)
+    linker.estimate_probability_two_random_records_match(
+        ["l.city = r.city"], recall=1.0
+    )
+    prob = linker._settings_obj._probability_two_random_records_match
+    assert prob == 1
 
 
 def test_prob_rr_match_link_and_dedupe_multitable():
@@ -232,7 +242,8 @@ def test_prob_rr_match_link_and_dedupe_multitable():
 
     deterministic_rules = ["l.first_name = r.first_name", "l.surname = r.surname"]
 
-    linker = DuckDBLinker([df_1, df_2, df_3, df_4], settings)
+    dfs = [df_1, df_2, df_3, df_4]
+    linker = DuckDBLinker(dfs, settings)
     linker.estimate_probability_two_random_records_match(
         deterministic_rules, recall=1.0
     )
@@ -241,3 +252,11 @@ def test_prob_rr_match_link_and_dedupe_multitable():
     # 10 matches (1 John, 3 Mary, 2 Jones (ignoring already matched Mary), 1 Taylor, 3 Graham, 0 Roberts (ignoring already counted Graham))
     # (3 + 4 + 5 + 7)(3 + 4 + 5 + 7 - 1)/2 = 171 comparisons
     assert pytest.approx(prob) == 10 / 171
+
+    dfs = list(map(lambda df: df.assign(city = "Brighton"), dfs))
+    linker = DuckDBLinker(dfs, settings)
+    linker.estimate_probability_two_random_records_match(
+        ["l.city = r.city"], recall=1.0
+    )
+    prob = linker._settings_obj._probability_two_random_records_match
+    assert prob == 1

--- a/tests/test_total_comparison_count.py
+++ b/tests/test_total_comparison_count.py
@@ -1,0 +1,42 @@
+from splink.duckdb.duckdb_linker import DuckDBLinker
+from splink.misc import calculate_cartesian
+
+import pandas as pd
+
+
+# TODO: (somwehere, maybe not here) cross-check calculation with the blocked frame we get using rule 1=1
+
+# convenience to get list into format as though it was result of a count query
+def list_to_row_count(l):
+    return [{"count": el} for el in l]
+
+
+def test_calculate_cartesian_dedupe_only():
+    # dedupe_only - have n(n-1)/2 comparisons, only a single frame
+    assert calculate_cartesian(list_to_row_count([5]), "dedupe_only") == 10
+    assert calculate_cartesian(list_to_row_count([8]), "dedupe_only") == 28
+    assert calculate_cartesian(list_to_row_count([10]), "dedupe_only") == 45
+    # TODO: define behaviour for n > 1 tables? error? would also need to think about n = 1 for link_only
+
+
+def test_calculate_cartesian_link_only():
+    # link_only - sum of all pairwise comparisons - i.e. sum of all pairwise products
+    assert calculate_cartesian(list_to_row_count([2, 3]), "link_only") == 6
+    assert calculate_cartesian(list_to_row_count([7, 11]), "link_only") == 77
+    assert calculate_cartesian(list_to_row_count([2, 2, 2]), "link_only") == 12
+    assert calculate_cartesian(list_to_row_count([2, 3, 5]), "link_only") == 31
+    assert calculate_cartesian(list_to_row_count([1, 1, 1]), "link_only") == 3
+    assert calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_only") == 40
+    assert calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_only") == 150
+
+
+def test_calculate_cartesian_link_and_dedupe():
+    # link_and_dedupe - much like dedupe, N(N - 1)/2 comparisons with N = sum of rows of all frames
+    # alternatively can think of this as 'link only' links + dedupe links for each frame in list
+    assert calculate_cartesian(list_to_row_count([8]), "link_and_dedupe") == 28
+    assert calculate_cartesian(list_to_row_count([2, 3]), "link_and_dedupe") == 10
+    assert calculate_cartesian(list_to_row_count([7, 11]), "link_and_dedupe") == 77 + 21 + 55
+    assert calculate_cartesian(list_to_row_count([2, 2, 2]), "link_and_dedupe") == 15
+    assert calculate_cartesian(list_to_row_count([1, 1, 1]), "link_and_dedupe") == 3
+    assert calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_only") == 45
+    assert calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_only") == 190

--- a/tests/test_total_comparison_count.py
+++ b/tests/test_total_comparison_count.py
@@ -18,7 +18,8 @@ def test_calculate_cartesian_dedupe_only():
     assert calculate_cartesian(list_to_row_count([5]), "dedupe_only") == 10
     assert calculate_cartesian(list_to_row_count([8]), "dedupe_only") == 28
     assert calculate_cartesian(list_to_row_count([10]), "dedupe_only") == 45
-    # TODO: define behaviour for n > 1 tables? error? would also need to think about n = 1 for link_only
+    with pytest.raises(ValueError):
+        calculate_cartesian(list_to_row_count([10, 20]), "dedupe_only")
 
 
 def test_calculate_cartesian_link_only():
@@ -30,6 +31,8 @@ def test_calculate_cartesian_link_only():
     assert calculate_cartesian(list_to_row_count([1, 1, 1]), "link_only") == 3
     assert calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_only") == 40
     assert calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_only") == 150
+    with pytest.raises(ValueError):
+        calculate_cartesian(list_to_row_count([12]), "link_only")
 
 
 def test_calculate_cartesian_link_and_dedupe():

--- a/tests/test_total_comparison_count.py
+++ b/tests/test_total_comparison_count.py
@@ -40,11 +40,18 @@ def test_calculate_cartesian_link_and_dedupe():
     # alternatively can think of this as 'link only' links + dedupe links for each frame in list
     assert calculate_cartesian(list_to_row_count([8]), "link_and_dedupe") == 28
     assert calculate_cartesian(list_to_row_count([2, 3]), "link_and_dedupe") == 10
-    assert calculate_cartesian(list_to_row_count([7, 11]), "link_and_dedupe") == 77 + 21 + 55
+    assert (
+        calculate_cartesian(list_to_row_count([7, 11]), "link_and_dedupe")
+        == 77 + 21 + 55
+    )
     assert calculate_cartesian(list_to_row_count([2, 2, 2]), "link_and_dedupe") == 15
     assert calculate_cartesian(list_to_row_count([1, 1, 1]), "link_and_dedupe") == 3
-    assert calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_and_dedupe") == 45
-    assert calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_and_dedupe") == 190
+    assert (
+        calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_and_dedupe") == 45
+    )
+    assert (
+        calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_and_dedupe") == 190
+    )
 
 
 @pytest.mark.parametrize(
@@ -52,10 +59,12 @@ def test_calculate_cartesian_link_and_dedupe():
     [
         ("dedupe_only", [97], ""),
         ("link_only", [97, 209, 104, 2], "group by source_dataset"),
-        ("link_and_dedupe", [97, 209, 104, 2], "group by source_dataset")
-    ]
+        ("link_and_dedupe", [97, 209, 104, 2], "group by source_dataset"),
+    ],
 )
-def test_calculate_cartesian_equals_total_number_of_links(link_type, frame_sizes, group_by):
+def test_calculate_cartesian_equals_total_number_of_links(
+    link_type, frame_sizes, group_by
+):
     # test that the count we get from calculate_cartesian
     # is the same as the actual number we get if we generate _all_ links
     # (i.e. using dummy blocking rule "1=1")
@@ -63,10 +72,10 @@ def test_calculate_cartesian_equals_total_number_of_links(link_type, frame_sizes
     def make_dummy_frame(row_count):
         # don't need meaningful differences as only interested in total countdf = pd.DataFrame(
         return pd.DataFrame(
-            data = {
+            data={
                 "unique_id": range(0, row_count),
                 "forename": "Claire",
-                "surname": "Brown"
+                "surname": "Brown",
             },
         )
 
@@ -80,7 +89,7 @@ def test_calculate_cartesian_equals_total_number_of_links(link_type, frame_sizes
 
     # calculate full number of comparisons
     full_count_sql = number_of_comparisons_generated_by_blocking_rule_sql(linker, "1=1")
-    linker._enqueue_sql(full_count_sql , "__splink__analyse_blocking_rule")
+    linker._enqueue_sql(full_count_sql, "__splink__analyse_blocking_rule")
     res = linker._execute_sql_pipeline().as_record_dict()[0]
 
     # compare with count from each frame

--- a/tests/test_total_comparison_count.py
+++ b/tests/test_total_comparison_count.py
@@ -43,8 +43,8 @@ def test_calculate_cartesian_link_and_dedupe():
     assert calculate_cartesian(list_to_row_count([7, 11]), "link_and_dedupe") == 77 + 21 + 55
     assert calculate_cartesian(list_to_row_count([2, 2, 2]), "link_and_dedupe") == 15
     assert calculate_cartesian(list_to_row_count([1, 1, 1]), "link_and_dedupe") == 3
-    assert calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_only") == 45
-    assert calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_only") == 190
+    assert calculate_cartesian(list_to_row_count([2, 2, 2, 2, 2]), "link_and_dedupe") == 45
+    assert calculate_cartesian(list_to_row_count([5, 5, 5, 5]), "link_and_dedupe") == 190
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #858.

Only direct change is to `calculate_cartesian` - the rest of the changes are tests for that, and for the functions which depend on the result of that calculation, for the case of `n > 2` input tables, including one that compares directly with the count of the blocked table.

Also includes some validation on the `df_rows` parameter, depending on link type. This behaviour seemed sensible to me (and checked the calling of this function to ensure this doesn't break anything upstream), but happy for any other opinions on that.