### PR TITLE
Changed distance function name in jaro_winkler_level to mutable_params

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -145,9 +145,10 @@ def jaro_winkler_level(
     Returns:
         ComparisonLevel: A comparison level that evaluates the jaro winkler similarity
     """
+    jaro_name = _mutable_params["jaro_winkler"]
     return distance_function_level(
         col_name,
-        "jaro_winkler",
+        jaro_name,
         distance_threshold,
         True,
         m_probability=m_probability,


### PR DESCRIPTION
Distance function name in `jaro_winkler_level()` which gets passed to `distance_function_level()` now provided by `_mutable_params` so that comparison level works with DuckDB