### PR TITLE
Checking returned range in `estimate_probability_two_random_records_match`

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2204,6 +2204,12 @@ class Linker:
                 by these deterministic rules
         """
 
+        if (recall > 1) or (recall <= 0):
+            raise ValueError(
+                f"Estimated recall must be greater than 0 "
+                f"and no more than 1. Supplied value {recall}."
+            )
+
         # If user, by error, provides a single rule as a string
         if isinstance(deterministic_matching_rules, str):
             deterministic_matching_rules = [deterministic_matching_rules]

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2220,22 +2220,22 @@ class Linker:
         )
 
         summary_record = records[-1]
-        observed_matches = summary_record["cumulative_rows"]
-        cartesian = summary_record["cartesian"]
+        num_observed_matches = summary_record["cumulative_rows"]
+        num_total_comparisons = summary_record["cartesian"]
 
-        if observed_matches > cartesian * recall:
+        if num_observed_matches > num_total_comparisons * recall:
             raise ValueError(
                 f"Deterministic matching rules led to more "
                 f"observed matches than is consistent with supplied recall. "
                 f"With these rules, recall must be at least "
-                f"{observed_matches/cartesian:,.2f}."
+                f"{num_observed_matches/num_total_comparisons:,.2f}."
             )
 
-        num_rows = observed_matches / recall
-        prob = num_rows / cartesian
+        num_expected_matches = num_observed_matches / recall
+        prob = num_expected_matches / num_total_comparisons
 
         # warn about boundary values, as these will usually be in error
-        if observed_matches == 0:
+        if num_observed_matches == 0:
             logger.warning(
                 f"WARNING: Deterministic matching rules led to no observed matches! "
                 f"This means that no possible record pairs are matches, "
@@ -2264,7 +2264,8 @@ class Linker:
         logger.info(
             f"Probability two random records match is estimated to be  {prob:.3g}.\n"
             f"This means that amongst all possible pairwise record comparisons, one in "
-            f"{reciprocal_prob} are expected to match.  With {cartesian:,.0f} total"
+            f"{reciprocal_prob} are expected to match.  "
+            f"With {num_total_comparisons:,.0f} total"
             " possible comparisons, we expect a total of around "
-            f"{num_rows:,.2f} matching pairs"
+            f"{num_expected_matches:,.2f} matching pairs"
         )

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2242,14 +2242,14 @@ class Linker:
             )
         if prob == 1:
             logger.warning(
-                f"WARNING: Probability two random records match is estimated to be 1.\n"
-                f"This means that all possible record pairs are matches, "
-                f"and all records are linked to one another.\n"
-                f"If this is truly the case then you do not need "
-                f"to run the linkage model.\n"
-                f"However, it is more likely that this estimate is faulty. "
-                f"Perhaps your deterministic matching rules include "
-                f"too many false positives?"
+                "WARNING: Probability two random records match is estimated to be 1.\n"
+                "This means that all possible record pairs are matches, "
+                "and all records are linked to one another.\n"
+                "If this is truly the case then you do not need "
+                "to run the linkage model.\n"
+                "However, it is more likely that this estimate is faulty. "
+                "Perhaps your deterministic matching rules include "
+                "too many false positives?"
             )
 
         self._settings_obj._probability_two_random_records_match = prob

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -261,3 +261,46 @@ def test_prob_rr_match_link_and_dedupe_multitable():
     )
     prob = linker._settings_obj._probability_two_random_records_match
     assert prob == 1
+
+
+def test_prob_rr_valid_range():
+
+    def check_range(p):
+        # boundaries are degenerate cases where we don't need a linkage model
+        # (if we believe those values to be accurate)
+        assert p < 1
+        assert p > 0
+
+    df = pd.DataFrame(
+        [
+            {"unique_id": 1, "first_name": "John", "surname": "Smith"},
+            {"unique_id": 2, "first_name": "John", "surname": "Williams"},
+            {"unique_id": 3, "first_name": "John", "surname": "Jones"},
+            {"unique_id": 4, "first_name": "John", "surname": "Davis"},
+            {"unique_id": 5, "first_name": "John", "surname": "Evans"},
+        ]
+    )
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [],
+    }
+
+    # Test dedupe only
+    linker = DuckDBLinker(df, settings)
+    with pytest.raises(ValueError):
+        # all comparisons matches using this rule, so we must have perfect recall
+        # using recall = 80% is inconsistent, so should get an error
+        linker.estimate_probability_two_random_records_match(
+            "l.first_name = r.first_name", recall=0.8
+        )
+    check_range(linker._settings_obj._probability_two_random_records_match)
+
+    # no comparisons matches using this rule, so we will estimate value as 0
+    # this gives a linkage model that always predicts match_probability as 0,
+    # so should give an error at this stage
+    with pytest.raises(ValueError):
+        linker.estimate_probability_two_random_records_match(
+            "l.surname = r.surname", recall=0.7
+        )
+    check_range(linker._settings_obj._probability_two_random_records_match)

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -354,3 +354,17 @@ def test_prob_rr_valid_range(caplog):
         )
         assert "WARNING:" in caplog.text
     check_range(linker._settings_obj._probability_two_random_records_match)
+
+    # check we get errors if we pass bogus values for recall
+    with pytest.raises(ValueError):
+        linker.estimate_probability_two_random_records_match(
+            "l.first_name = r.first_name", recall=0.0
+        )
+    with pytest.raises(ValueError):
+        linker.estimate_probability_two_random_records_match(
+            "l.first_name = r.first_name", recall=1.2
+        )
+    with pytest.raises(ValueError):
+        linker.estimate_probability_two_random_records_match(
+            "l.first_name = r.first_name", recall=-0.4
+        )


### PR DESCRIPTION
Checking that the estimated `probability_two_random_records_match` is a valid probability, with error if it would be estimated as greater than 1 (due to incompatible estimated recall).

Will give warnings if it is estimated to be 1 exactly, or 0 (i.e. if the deterministic rules generate no matches), as in these cases the linkage model becomes trivial, and is _probably_ more likely to be the case of a mistake rather than actually being the true situation for the data.

Also catches if the user mistakenly gives an invalid value of `recall`.

Fixes #870 and #876.