### PR TITLE
Splink databricks

### DIFF
--- a/databricks-notebooks/splink notebook - databricks-splink.py
+++ b/databricks-notebooks/splink notebook - databricks-splink.py
@@ -1,0 +1,91 @@
+# Databricks notebook source
+user_name = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()
+
+# COMMAND ----------
+
+import splink.spark.spark_comparison_library as cl
+import pandas as pd 
+from splink.databricks.enable_splink import enable_splink
+
+# COMMAND ----------
+
+# this attachs the splink JAR to the cluster
+enable_splink(spark)
+
+# COMMAND ----------
+
+df = spark.read.csv(
+  "file:/Workspace/Repos/robert.whiffin@databricks.com/splink/tests/datasets/fake_1000_from_splink_demos.csv"
+  , header=True
+)
+
+# COMMAND ----------
+
+settings = {
+    "link_type": "dedupe_only",
+    "comparisons": [
+        cl.jaro_winkler_at_thresholds("first_name", 0.8),
+        cl.jaro_winkler_at_thresholds("surname", 0.8),
+        cl.levenshtein_at_thresholds("dob"),
+        cl.exact_match("city", term_frequency_adjustments=True),
+        cl.levenshtein_at_thresholds("email"),
+    ],
+    "blocking_rules_to_generate_predictions": [
+        "l.first_name = r.first_name",
+        "l.surname = r.surname",
+    ],
+    "retain_matching_columns": True,
+    "retain_intermediate_calculation_columns": True,
+    "em_convergence": 0.01
+}
+
+# COMMAND ----------
+
+# this defines where we are going to store the splink tables
+catalog_name = "splink"
+database_name = user_name
+spark.sql(f"create catalog if not exists {catalog_name};")
+spark.sql(f"use catalog {catalog_name};")
+spark.sql(f"create database if not exists {database_name};")
+spark.sql(f"use database {database_name};")
+
+# COMMAND ----------
+
+from splink.databricks.spark_linker import SparkLinker
+linker = SparkLinker(df, catalog = "splink", schema = "robert_whiffin", settings_dict=settings, spark=spark)
+deterministic_rules = [
+    "l.first_name = r.first_name and levenshtein(r.dob, l.dob) <= 1",
+    "l.surname = r.surname and levenshtein(r.dob, l.dob) <= 1",
+    "l.first_name = r.first_name and levenshtein(r.surname, l.surname) <= 2",
+    "l.email = r.email"
+]
+
+# COMMAND ----------
+
+linker.estimate_probability_two_random_records_match(deterministic_rules, recall=0.6)
+
+# COMMAND ----------
+
+linker.estimate_u_using_random_sampling(target_rows=5e5)
+
+# COMMAND ----------
+
+spark.udf.registerJavaFunction(
+    "jaro_winkler", "uk.gov.moj.dash.linkage.JaroWinklerSimilarity", types.DoubleType()
+)
+
+# COMMAND ----------
+
+training_blocking_rule = "l.first_name = r.first_name and l.surname = r.surname"
+training_session_fname_sname = linker.estimate_parameters_using_expectation_maximisation(training_blocking_rule)
+
+training_blocking_rule = "l.dob = r.dob"
+training_session_dob = linker.estimate_parameters_using_expectation_maximisation(training_blocking_rule)
+
+# COMMAND ----------
+
+results = linker.predict(threshold_match_probability=0.9)
+
+# COMMAND ----------
+
+results.as_pandas_dataframe(limit=5)

--- a/splink/databricks/custom_spark_dialect.py
+++ b/splink/databricks/custom_spark_dialect.py
@@ -1,0 +1,42 @@
+from sqlglot import exp
+
+from sqlglot.dialects import Dialect, Spark
+from sqlglot.generator import Generator
+
+
+def cast_as_double_edit(self, expression):
+    """
+    Forces floating point numbers to the double class in spark,
+    instead of casting them to decimals.
+    This resolves the spark issue where decimals only support precision
+    up to 38 digits.
+    More info: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
+    """
+    datatype = self.sql(expression, "to")
+    if datatype.lower() == "double":
+        if expression.this.key == "literal":
+            return f"{expression.name}D"
+
+    return expression.sql(dialect="spark")
+
+
+class CustomSpark(Spark):
+    class Parser(Spark.Parser):
+        FUNCTIONS = {
+            **Spark.Parser.FUNCTIONS,
+        }
+
+    class Generator(Generator):
+
+        TYPE_MAPPING = {
+            **Spark.Generator.TYPE_MAPPING,
+        }
+
+        TRANSFORMS = {
+            **Spark.Generator.TRANSFORMS,
+            exp.Cast: cast_as_double_edit,
+            exp.TryCast: cast_as_double_edit,
+        }
+
+
+Dialect["customspark"]

--- a/splink/databricks/enable_splink.py
+++ b/splink/databricks/enable_splink.py
@@ -1,0 +1,31 @@
+from splink.spark.jar_location import similarity_jar_location
+
+def enable_splink():
+    sc = spark.sparkContext
+    _jar_path = similarity_jar_location()
+    JavaURI = getattr(sc._jvm.java.net, "URI")
+    JavaJarId = getattr(sc._jvm.com.databricks.libraries, "JavaJarId")
+    ManagedLibraryId = getattr(
+        sc._jvm.com.databricks.libraries, "ManagedLibraryId"
+    )
+    ManagedLibraryVersions = getattr(
+        sc._jvm.com.databricks.libraries, "ManagedLibraryVersions"
+    )
+    NoVersion = getattr(ManagedLibraryVersions, "NoVersion$")
+    NoVersionModule = getattr(NoVersion, "MODULE$")
+    DatabricksILoop = getattr(
+        sc._jvm.com.databricks.backend.daemon.driver, "DatabricksILoop"
+    )
+    converters = sc._jvm.scala.collection.JavaConverters
+
+    JarURI = JavaURI.create("file:" + _jar_path)
+    lib = JavaJarId(
+        JarURI,
+        ManagedLibraryId.defaultOrganization(),
+        NoVersionModule.simpleString(),
+    )
+    libSeq = converters.asScalaBufferConverter((lib,)).asScala().toSeq()
+
+    context = DatabricksILoop.getSharedDriverContextIfExists().get()
+    context.registerNewLibraries(libSeq)
+    context.attachLibrariesToSpark(libSeq)

--- a/splink/databricks/enable_splink.py
+++ b/splink/databricks/enable_splink.py
@@ -1,6 +1,6 @@
 from splink.spark.jar_location import similarity_jar_location
 
-def enable_splink():
+def enable_splink(spark):
     sc = spark.sparkContext
     _jar_path = similarity_jar_location()
     JavaURI = getattr(sc._jvm.java.net, "URI")

--- a/splink/databricks/enable_splink.py
+++ b/splink/databricks/enable_splink.py
@@ -1,4 +1,4 @@
-from splink.spark.jar_location import similarity_jar_location
+from splink.databricks.jar_location import similarity_jar_location
 
 def enable_splink(spark):
     sc = spark.sparkContext

--- a/splink/databricks/jar_location.py
+++ b/splink/databricks/jar_location.py
@@ -1,0 +1,5 @@
+def similarity_jar_location():
+    import splink
+
+    path = splink.__file__[0:-11] + "files/spark_jars/scala-udf-similarity-0.0.9.jar"
+    return path

--- a/splink/databricks/spark_comparison_level_library.py
+++ b/splink/databricks/spark_comparison_level_library.py
@@ -1,0 +1,38 @@
+from ..comparison_level_library import (  # noqa: F401
+    _mutable_params,
+    exact_match_level,
+    levenshtein_level,
+    else_level,
+    null_level,
+    distance_function_level,
+    columns_reversed_level,
+    jaccard_level,
+    jaro_winkler_level,
+    distance_in_km_level,
+)
+from ..input_column import InputColumn
+from ..comparison_level import ComparisonLevel
+
+_mutable_params["dialect"] = "spark"
+
+
+def array_intersect_level(
+    col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1
+) -> ComparisonLevel:
+
+    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+
+    sql = f"size(array_intersect({col.name_l()}, {col.name_r()})) >= {min_intersection}"
+
+    if min_intersection == 1:
+        label = "Arrays intersect"
+    else:
+        label = f"Array intersect size >= {min_intersection}"
+
+    level_dict = {"sql_condition": sql, "label_for_charts": label}
+    if m_probability:
+        level_dict["m_probability"] = m_probability
+    if term_frequency_adjustments:
+        level_dict["tf_adjustment_column"] = col_name
+
+    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])

--- a/splink/databricks/spark_comparison_library.py
+++ b/splink/databricks/spark_comparison_library.py
@@ -1,0 +1,14 @@
+from ..comparison_level_library import (
+    _mutable_params,
+)
+
+
+from ..comparison_library import (  # noqa: F401
+    exact_match,
+    levenshtein_at_thresholds,
+    distance_function_at_thresholds,
+    jaccard_at_thresholds,
+    jaro_winkler_at_thresholds,
+)
+
+_mutable_params["dialect"] = "spark"

--- a/splink/databricks/spark_linker.py
+++ b/splink/databricks/spark_linker.py
@@ -1,0 +1,331 @@
+import logging
+import sqlglot
+from typing import Union, List
+import re
+import os
+import math
+
+import pandas as pd
+
+from pyspark.sql import Row
+
+from ..linker import Linker
+from ..splink_dataframe import SplinkDataFrame
+from ..term_frequencies import colname_to_tf_tablename
+from ..logging_messages import execute_sql_logging_message_info, log_sql
+from ..misc import ensure_is_list
+from ..input_column import InputColumn
+from .custom_spark_dialect import Dialect
+
+logger = logging.getLogger(__name__)
+
+Dialect["customspark"]
+
+
+class SparkDataframe(SplinkDataFrame):
+    def __init__(self, templated_name, physical_name, spark_linker):
+        super().__init__(templated_name, physical_name)
+        self.spark_linker = spark_linker
+
+    @property
+    def columns(self) -> List[InputColumn]:
+        sql = f"select * from {self.physical_name} limit 1"
+        spark_df = self.spark_linker.spark.sql(sql)
+
+        col_strings = list(spark_df.columns)
+        return [InputColumn(c, sql_dialect="spark") for c in col_strings]
+
+    def validate(self):
+        pass
+
+    def as_record_dict(self, limit=None):
+
+        sql = f"select * from {self.physical_name}"
+        if limit:
+            sql += f" limit {limit}"
+
+        return self.spark_linker.spark.sql(sql).toPandas().to_dict(orient="records")
+
+    def drop_table_from_database(self, force_non_splink_table=False):
+
+        # Spark, in general, does not persist its results to disk
+        # There is a whitelist of dataframes to either perist() or checkpoint()
+        # But there's no real need to clean these up, so we'll just do nothing
+        pass
+
+    def as_pandas_dataframe(self, limit=None):
+
+        sql = f"select * from {self.physical_name}"
+        if limit:
+            sql += f" limit {limit}"
+
+        return self.spark_linker.spark.sql(sql).toPandas()
+
+    def as_spark_dataframe(self):
+        return self.spark_linker.spark.table(self.physical_name)
+
+
+class SparkLinker(Linker):
+
+    # flake8: noqa: C901
+    def __init__(
+        self,
+        input_table_or_tables,
+        settings_dict=None,
+        break_lineage_method="delta",
+        set_up_basic_logging=True,
+        input_table_aliases: Union[str, list] = None,
+        spark=None,
+        repartition_after_blocking=False,
+        num_partitions_on_repartition=100,
+    ):
+        """Initialise the linker object, which manages the data linkage process and
+                holds the data linkage model.
+
+        Args:
+            input_table_or_tables: Input data into the linkage model.  Either a
+                single table or a list of tables.  Tables can be provided either as
+                a Spark DataFrame, or as the name of the table as a string, as
+                registered in the Spark catalog
+            settings_dict (dict, optional): A Splink settings dictionary. If not
+                provided when the object is created, can later be added using
+                `linker.initialise_settings()` Defaults to None.
+            break_lineage_method (str, optional): Method to use to cache intermediate
+                results.  Can be "checkpoint", "persist" or "delta".  Defaults to
+                "delta".
+            set_up_basic_logging (bool, optional): If true, sets ups up basic logging
+                so that Splink sends messages at INFO level to stdout. Defaults to True.
+            input_table_aliases (Union[str, list], optional): Labels assigned to
+                input tables in Splink outputs.  If the names of the tables in the
+                input database are long or unspecific, this argument can be used
+                to attach more easily readable/interpretable names. Defaults to None.
+            spark: The SparkSession. Required only if `input_table_or_tables` are
+                provided as string - otherwise will be inferred from the provided
+                Spark Dataframes.
+            repartition_after_blocking (bool, optional): In some cases, especially when
+                the comparisons are very computationally intensive, performance may be
+                improved by repartitioning after blocking to distribute the workload of
+                computing the comparison vectors more evenly and reduce the number of
+                tasks. Defaults to False.
+            num_partitions_on_repartition (int, optional): When saving out intermediate
+                results, how many partitions to use?  This should be set so that
+                partitions are roughly 100Mb. Defaults to 100.
+
+        """
+
+        if settings_dict is not None and "sql_dialect" not in settings_dict:
+            settings_dict["sql_dialect"] = "spark"
+
+        self.break_lineage_method = break_lineage_method
+
+        self.repartition_after_blocking = repartition_after_blocking
+        self.num_partitions_on_repartition = num_partitions_on_repartition
+
+        input_tables = ensure_is_list(input_table_or_tables)
+
+        input_aliases = self._ensure_aliases_populated_and_is_list(
+            input_table_or_tables, input_table_aliases
+        )
+
+        self.spark = spark
+        if spark is None:
+            for t in input_tables:
+                if type(t).__name__ == "DataFrame":
+                    self.spark = t.sql_ctx.sparkSession
+                    break
+        if self.spark is None:
+            raise ValueError(
+                "If input_table_or_tables are strings rather than "
+                "Spark dataframes, you must pass in the spark session using the spark="
+                " argument when you initialise the linker"
+            )
+
+        for table in self.spark.catalog.listTables():
+            if table.isTemporary:
+                if "__splink__" in table.name:
+                    self.spark.catalog.dropTempView(table.name)
+
+        homogenised_tables = []
+        homogenised_aliases = []
+
+        for i, (table, alias) in enumerate(zip(input_tables, input_aliases)):
+
+            if type(alias).__name__ == "DataFrame":
+                alias = f"__splink__input_table_{i}"
+
+            if type(table).__name__ == "DataFrame":
+                table.createOrReplaceTempView(alias)
+                table = alias
+
+            homogenised_tables.append(table)
+            homogenised_aliases.append(alias)
+
+        super().__init__(
+            homogenised_tables,
+            settings_dict,
+            set_up_basic_logging,
+            input_table_aliases=homogenised_aliases,
+        )
+
+    def _table_to_splink_dataframe(self, templated_name, physical_name):
+        return SparkDataframe(templated_name, physical_name, self)
+
+    def initialise_settings(self, settings_dict: dict):
+        if "sql_dialect" not in settings_dict:
+            settings_dict["sql_dialect"] = "spark"
+        super().initialise_settings(settings_dict)
+
+    def _repartition_if_needed(self, spark_df, templated_name):
+        # Repartitioning has two effects:
+        # 1. When we persist out results to disk, it results in a predictable
+        #    number of output files.  Some splink operations result in a very large
+        #    number of output files, so this reduces the number of files and therefore
+        #    avoids slow reads and writes
+        # 2. When we repartition, it results in a more evenly distributed workload
+        #    across the cluster, which is useful for large datasets.
+
+        names_to_repartition = [
+            r"__splink__df_comparison_vectors",
+            r"__splink__df_blocked",
+            r"__splink__df_neighbours",
+            r"__splink__df_representatives",
+            r"__splink__df_concat_with_tf_sample",
+            r"__splink__df_concat_with_tf",
+        ]
+
+        num_partitions = self.num_partitions_on_repartition
+
+        if re.fullmatch(r"__splink__df_representatives", templated_name):
+            num_partitions = math.ceil(self.num_partitions_on_repartition / 6)
+
+        if re.fullmatch(r"__splink__df_neighbours", templated_name):
+            num_partitions = math.ceil(self.num_partitions_on_repartition / 4)
+
+        if re.fullmatch(r"__splink__df_concat_with_tf_sample", templated_name):
+            num_partitions = math.ceil(self.num_partitions_on_repartition / 4)
+
+        if re.fullmatch(r"__splink__df_concat_with_tf", templated_name):
+            num_partitions = math.ceil(self.num_partitions_on_repartition / 4)
+
+        if re.fullmatch(r"|".join(names_to_repartition), templated_name):
+            spark_df = spark_df.repartition(num_partitions)
+
+        return spark_df
+
+    def _get_checkpoint_dir_path(self, spark_df):
+        # https://github.com/apache/spark/blob/301a13963808d1ad44be5cacf0a20f65b853d5a2/python/pyspark/context.py#L1323 # noqa
+        # getCheckpointDir method exists only in Spark 3.1+, use implementation
+        # from above link
+        if not self.spark._jsc.sc().getCheckpointDir().isEmpty():
+            return self.spark._jsc.sc().getCheckpointDir().get()
+        else:
+            # Raise checkpointing error
+            spark_df.limit(1).checkpoint()
+
+    def _break_lineage_and_repartition(self, spark_df, templated_name, physical_name):
+
+        spark_df = self._repartition_if_needed(spark_df, templated_name)
+
+        regex_to_persist = [
+            r"__splink__df_comparison_vectors",
+            r"__splink__df_concat_with_tf",
+            r"__splink__df_predict",
+            r"__splink__df_tf_.+",
+            r"__splink__df_representatives",
+            r"__splink__df_neighbours",
+            r"__splink__df_connected_components_df",
+        ]
+
+        if re.fullmatch(r"|".join(regex_to_persist), templated_name):
+            if self.break_lineage_method == "persist":
+                spark_df = spark_df.persist()
+                logger.debug(f"persisted {templated_name}")
+            elif self.break_lineage_method == "checkpoint":
+                spark_df = spark_df.checkpoint()
+                logger.debug(f"Checkpointed {templated_name}")
+            elif self.break_lineage_method == "delta":
+                checkpoint_dir = self._get_checkpoint_dir_path(spark_df)
+                write_path = os.path.join(checkpoint_dir, physical_name)
+                spark_df.write.mode("overwrite").delta(write_path)
+                spark_df = self.spark.read.delta(write_path)
+                logger.debug(f"Wrote {templated_name} to delta")
+            else:
+                raise ValueError(
+                    f"Unknown break_lineage_method: {self.break_lineage_method}"
+                )
+        return spark_df
+
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
+
+        sql = sqlglot.transpile(sql, read="spark", write="customspark", pretty=True)[0]
+
+        logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
+        logger.log(5, log_sql(sql))
+        spark_df = self.spark.sql(sql)
+
+        spark_df = self._break_lineage_and_repartition(
+            spark_df, templated_name, physical_name
+        )
+
+        # After blocking, want to repartition
+        # if templated
+        spark_df.createOrReplaceTempView(physical_name)
+
+        output_df = self._table_to_splink_dataframe(templated_name, physical_name)
+        return output_df
+
+    def register_table(self, input, table_name, overwrite=False):
+        """
+        Register a table to your backend database, to be used in one of the
+        splink methods, or simply to allow querying.
+
+        Tables can be of type: dictionary, record level dictionary,
+        pandas dataframe, pyarrow table and in the spark case, a spark df.
+
+        Examples:
+            >>> test_dict = {"a": [666,777,888],"b": [4,5,6]}
+            >>> linker.register_table(test_dict, "test_dict")
+            >>> linker.query_sql("select * from test_dict")
+
+        Args:
+            input: The data you wish to register. This can be either a dictionary,
+                pandas dataframe, pyarrow table or a spark dataframe.
+            table_name (str): The name you wish to assign to the table.
+
+        Returns:
+            SplinkDataFrame: An abstraction representing the table created by the sql
+                pipeline
+        """
+        # Check if table name is already in use
+        exists = self._table_exists_in_database(table_name)
+        if exists:
+            if not overwrite:
+                raise ValueError(f"Table '{table_name}' already exists in database.")
+
+        if isinstance(input, dict):
+            input = pd.DataFrame(input)
+            input = self.spark.createDataFrame(input)
+        elif isinstance(input, list):
+            input = pd.DataFrame.from_records(input)
+            input = self.spark.createDataFrame(input)
+        elif type(input).__name__ in ["DataFrame", "Table"]:
+            input = self.spark.createDataFrame(input)
+
+        input.createOrReplaceTempView(table_name)
+        return self._table_to_splink_dataframe(table_name, table_name)
+
+    def _random_sample_sql(self, proportion, sample_size):
+        if proportion == 1.0:
+            return ""
+        percent = proportion * 100
+        return f" TABLESAMPLE ({percent} PERCENT) "
+
+    def _table_exists_in_database(self, table_name):
+        tables = self.spark.catalog.listTables()
+        for t in tables:
+            if t.name == table_name:
+                return True
+        return False
+
+    def register_tf_table(self, df, col_name, overwrite=False):
+        self.register_table(df, colname_to_tf_tablename(col_name), overwrite)

--- a/splink/databricks/spark_linker.py
+++ b/splink/databricks/spark_linker.py
@@ -71,6 +71,7 @@ class SparkLinker(Linker):
     def __init__(
         self,
         input_table_or_tables,
+        dbfs_checkpoint_dir,
         settings_dict=None,
         break_lineage_method="delta",
         set_up_basic_logging=True,
@@ -87,6 +88,7 @@ class SparkLinker(Linker):
                 single table or a list of tables.  Tables can be provided either as
                 a Spark DataFrame, or as the name of the table as a string, as
                 registered in the Spark catalog
+            dbfs_checkpoint_dir (str): Location on the Databricks File System to write out working files
             settings_dict (dict, optional): A Splink settings dictionary. If not
                 provided when the object is created, can later be added using
                 `linker.initialise_settings()` Defaults to None.
@@ -213,14 +215,7 @@ class SparkLinker(Linker):
         return spark_df
 
     def _get_checkpoint_dir_path(self, spark_df):
-        # https://github.com/apache/spark/blob/301a13963808d1ad44be5cacf0a20f65b853d5a2/python/pyspark/context.py#L1323 # noqa
-        # getCheckpointDir method exists only in Spark 3.1+, use implementation
-        # from above link
-        if not self.spark._jsc.sc().getCheckpointDir().isEmpty():
-            return self.spark._jsc.sc().getCheckpointDir().get()
-        else:
-            # Raise checkpointing error
-            spark_df.limit(1).checkpoint()
+        return self.dbfs_checkpoint_dir
 
     def _break_lineage_and_repartition(self, spark_df, templated_name, physical_name):
 

--- a/splink/databricks/spark_linker.py
+++ b/splink/databricks/spark_linker.py
@@ -246,8 +246,8 @@ class SparkLinker(Linker):
             elif self.break_lineage_method == "delta":
                 checkpoint_dir = self._get_checkpoint_dir_path(spark_df)
                 write_path = os.path.join(checkpoint_dir, physical_name)
-                spark_df.write.mode("overwrite").delta(write_path)
-                spark_df = self.spark.read.delta(write_path)
+                spark_df.write.mode("overwrite").format("delta").save(write_path)
+                spark_df = self.spark.read.format("delta").load(write_path)
                 logger.debug(f"Wrote {templated_name} to delta")
             else:
                 raise ValueError(


### PR DESCRIPTION
This PR makes some changes to the spark implementation of splink;

- introduces an `enable_splink()` function which attaches the splink JAR to a running Spark cluster (no need to attach JAR at start up)
- reworks some of the spark drop table code to make it more performant on large systems. Previously the code called `spark.catalog.listTables()` which is an expensive way of doing it - it lists every table in the Catalog. It is better to instead call `spark.sql("show tables like '*__splink__*'")` to let spark handle the filtering of table names. 
- updates Spark Linker to accept a catalog and schema as location to store the Splink tables
- updates Spark Linker to use Delta instead of Parquet. This ought to give a speed improvement due to Delta caching, and opens up the possibility of further improvements through Z-ordering
- Adds an example notebook for Databricks showing how to use enable_splink() in conjunction with existing example from docs. FYI, notebook doesn't include a pip-install command as the databricks-splink is not available in pip 