### PR TITLE
Array intersection comparisons

### DIFF
--- a/docs/comparison_level_library.md
+++ b/docs/comparison_level_library.md
@@ -16,6 +16,7 @@ tags:
         - jaccard_level
         - else_level
         - columns_reversed_level
+        - array_intersect_level
     rendering:
       show_root_heading: false
       show_source: true

--- a/docs/comparison_library.md
+++ b/docs/comparison_library.md
@@ -13,6 +13,7 @@ tags:
         - distance_function_at_thresholds
         - levenshtein_at_thresholds
         - jaccard_at_thresholds
+        - array_intersect_at_sizes
     rendering:
       show_root_heading: false
       show_source: true

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -9,8 +9,10 @@ from ..comparison_level_library import (  # noqa: F401
     array_intersect_level,
 )
 
+
 def size_array_intersect_sql(col_name_l, col_name_r):
     return f"cardinality(array_intersect({col_name_l}, {col_name_r}))"
+
 
 _mutable_params["dialect"] = "presto"
 _mutable_params["levenshtein"] = "levenshtein_distance"

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -6,7 +6,12 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     columns_reversed_level,
     distance_in_km_level,
+    array_intersect_level,
 )
+
+def size_array_intersect_sql(col_name_l, col_name_r):
+    return f"cardinality(array_intersect({col_name_l}, {col_name_r}))"
 
 _mutable_params["dialect"] = "presto"
 _mutable_params["levenshtein"] = "levenshtein_distance"
+_mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -20,7 +20,7 @@ _mutable_params["levenshtein"] = "levenshtein_distance"
 
 class array_intersect_level(ArrayIntersectLevelBase):
     @property
-    def _sql_dialect_(self):
+    def _sql_dialect(self):
         return "presto"
 
     @property

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -6,7 +6,7 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     columns_reversed_level,
     distance_in_km_level,
-    array_intersect_level,
+    ArrayIntersectLevelBase,
 )
 
 
@@ -16,4 +16,13 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 
 _mutable_params["dialect"] = "presto"
 _mutable_params["levenshtein"] = "levenshtein_distance"
-_mutable_params["size_array_intersect_function"] = size_array_intersect_sql
+
+
+class array_intersect_level(ArrayIntersectLevelBase):
+    @property
+    def _sql_dialect_(self):
+        return "presto"
+
+    @property
+    def _size_array_intersect_function(self):
+        return size_array_intersect_sql

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -6,7 +6,13 @@ from ..comparison_level_library import (
 from ..comparison_library import (  # noqa: F401
     exact_match,
     levenshtein_at_thresholds,
+    array_intersect_at_sizes,
+)
+
+from .athena_comparison_level_library import (
+    size_array_intersect_sql,
 )
 
 _mutable_params["dialect"] = "presto"
 _mutable_params["levenshtein"] = "levenshtein_distance"
+_mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -6,13 +6,18 @@ from ..comparison_level_library import (
 from ..comparison_library import (  # noqa: F401
     exact_match,
     levenshtein_at_thresholds,
-    array_intersect_at_sizes,
+    ArrayIntersectAtSizesComparisonBase,
 )
 
 from .athena_comparison_level_library import (
-    size_array_intersect_sql,
+    array_intersect_level,
 )
 
 _mutable_params["dialect"] = "presto"
 _mutable_params["levenshtein"] = "levenshtein_distance"
-_mutable_params["size_array_intersect_function"] = size_array_intersect_sql
+
+
+class array_intersect_at_sizes(ArrayIntersectAtSizesComparisonBase):
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -133,7 +133,8 @@ class ComparisonLevel:
         self._level_dict = level_dict
 
         self.comparison: "Comparison" = comparison
-        self._sql_dialect = sql_dialect
+        if not hasattr(self, "_sql_dialect"):
+            self._sql_dialect = sql_dialect
 
         self._sql_condition = self._level_dict["sql_condition"]
         self._is_null_level = self._level_dict_val_else_default("is_null_level")

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -322,6 +322,24 @@ def array_intersect_level(
     col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1,
     include_colname_in_charts_label=False
 ) -> ComparisonLevel:
+    """Represents a comparison level based around the size of an intersection of
+    arrays
+
+    Args:
+        col_name (str): Input column name
+        m_probability (float, optional): Starting value for m probability. Defaults to
+            None.
+        tf_adjustment_column (str, optional): Column to use for term frequency
+            adjustments if an exact match is observed. Defaults to None.
+        min_intersection (int, optional): The minimum cardinality of the intersection
+            of arrays for this comparison level. Defaults to 1
+        include_colname_in_charts_label (bool, optional): Should the charts label
+            contain the column name? Defaults to False
+
+    Returns:
+        ComparisonLevel: A comparison level that evaluates the size of intersection
+            of arrays
+    """
 
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -12,6 +12,7 @@ _mutable_params = {
     "dialect": None,
     "levenshtein": "levenshtein",
     "jaro_winkler": "jaro_winkler",
+    "size_array_intersect_function": None,
 }
 
 
@@ -313,5 +314,34 @@ def percentage_difference_level(
     }
     if m_probability:
         level_dict["m_probability"] = m_probability
+
+    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+
+
+def array_intersect_level(
+    col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1,
+    include_colname_in_charts_label=False
+) -> ComparisonLevel:
+
+    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+
+    size_array_intersect_function = _mutable_params["size_array_intersect_function"]
+    if size_array_intersect_function is None:
+        pass # or better, raise an error!
+
+    size_array_intersection = f"{size_array_intersect_function(col.name_l(), col.name_r())}"
+    sql = f"{size_array_intersection} >= {min_intersection}"
+
+    label_prefix = f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"
+    if min_intersection == 1:
+        label = f"{label_prefix} intersect"
+    else:
+        label = f"{label_prefix} intersect size >= {min_intersection}"
+
+    level_dict = {"sql_condition": sql, "label_for_charts": label}
+    if m_probability:
+        level_dict["m_probability"] = m_probability
+    if term_frequency_adjustments:
+        level_dict["tf_adjustment_column"] = col_name
 
     return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -324,6 +324,7 @@ def array_intersect_level(
     term_frequency_adjustments=False,
     min_intersection=1,
     include_colname_in_charts_label=False,
+    size_array_intersect_function=None,
 ) -> ComparisonLevel:
     """Represents a comparison level based around the size of an intersection of
     arrays
@@ -346,9 +347,11 @@ def array_intersect_level(
 
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
 
-    size_array_intersect_function = _mutable_params["size_array_intersect_function"]
     if size_array_intersect_function is None:
-        pass  # or better, raise an error!
+        size_array_intersect_function = _mutable_params["size_array_intersect_function"]
+        # if it's still None, then we are not using a dialect properly
+        if size_array_intersect_function is None:
+            raise Exception("TODO")
 
     size_array_intersection = (
         f"{size_array_intersect_function(col.name_l(), col.name_r())}"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -345,7 +345,7 @@ class ArrayIntersectLevelBase(ComparisonLevel):
             ComparisonLevel: A comparison level that evaluates the size of intersection
                 of arrays
         """
-        col = InputColumn(col_name, sql_dialect=self._sql_dialect_)
+        col = InputColumn(col_name, sql_dialect=self._sql_dialect)
 
         size_array_intersection = (
             f"{self._size_array_intersect_function(col.name_l(), col.name_r())}"
@@ -366,11 +366,7 @@ class ArrayIntersectLevelBase(ComparisonLevel):
         if term_frequency_adjustments:
             level_dict["tf_adjustment_column"] = col_name
 
-        super().__init__(level_dict, sql_dialect=self._sql_dialect_)
-
-    @property
-    def _sql_dialect_(self):
-        raise NotImplementedError("Dialect not defined on base class")
+        super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
     @property
     def _size_array_intersect_function(self):

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -319,8 +319,11 @@ def percentage_difference_level(
 
 
 def array_intersect_level(
-    col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1,
-    include_colname_in_charts_label=False
+    col_name,
+    m_probability=None,
+    term_frequency_adjustments=False,
+    min_intersection=1,
+    include_colname_in_charts_label=False,
 ) -> ComparisonLevel:
     """Represents a comparison level based around the size of an intersection of
     arrays
@@ -345,9 +348,11 @@ def array_intersect_level(
 
     size_array_intersect_function = _mutable_params["size_array_intersect_function"]
     if size_array_intersect_function is None:
-        pass # or better, raise an error!
+        pass  # or better, raise an error!
 
-    size_array_intersection = f"{size_array_intersect_function(col.name_l(), col.name_r())}"
+    size_array_intersection = (
+        f"{size_array_intersect_function(col.name_l(), col.name_r())}"
+    )
     sql = f"{size_array_intersection} >= {min_intersection}"
 
     label_prefix = f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -318,56 +318,60 @@ def percentage_difference_level(
     return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
 
 
-def array_intersect_level(
-    col_name,
-    m_probability=None,
-    term_frequency_adjustments=False,
-    min_intersection=1,
-    include_colname_in_charts_label=False,
-    size_array_intersect_function=None,
-) -> ComparisonLevel:
-    """Represents a comparison level based around the size of an intersection of
-    arrays
+class ArrayIntersectLevelBase(ComparisonLevel):
+    def __init__(
+        self,
+        col_name,
+        m_probability=None,
+        term_frequency_adjustments=False,
+        min_intersection=1,
+        include_colname_in_charts_label=False,
+    ):
+        """Represents a comparison level based around the size of an intersection of
+        arrays
 
-    Args:
-        col_name (str): Input column name
-        m_probability (float, optional): Starting value for m probability. Defaults to
-            None.
-        tf_adjustment_column (str, optional): Column to use for term frequency
-            adjustments if an exact match is observed. Defaults to None.
-        min_intersection (int, optional): The minimum cardinality of the intersection
-            of arrays for this comparison level. Defaults to 1
-        include_colname_in_charts_label (bool, optional): Should the charts label
-            contain the column name? Defaults to False
+        Args:
+            col_name (str): Input column name
+            m_probability (float, optional): Starting value for m probability. Defaults
+                to None.
+            tf_adjustment_column (str, optional): Column to use for term frequency
+                adjustments if an exact match is observed. Defaults to None.
+            min_intersection (int, optional): The minimum cardinality of the
+                intersection of arrays for this comparison level. Defaults to 1
+            include_colname_in_charts_label (bool, optional): Should the charts label
+                contain the column name? Defaults to False
 
-    Returns:
-        ComparisonLevel: A comparison level that evaluates the size of intersection
-            of arrays
-    """
+        Returns:
+            ComparisonLevel: A comparison level that evaluates the size of intersection
+                of arrays
+        """
+        col = InputColumn(col_name, sql_dialect=self._sql_dialect_)
 
-    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+        size_array_intersection = (
+            f"{self._size_array_intersect_function(col.name_l(), col.name_r())}"
+        )
+        sql = f"{size_array_intersection} >= {min_intersection}"
 
-    if size_array_intersect_function is None:
-        size_array_intersect_function = _mutable_params["size_array_intersect_function"]
-        # if it's still None, then we are not using a dialect properly
-        if size_array_intersect_function is None:
-            raise Exception("TODO")
+        label_prefix = (
+            f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"
+        )
+        if min_intersection == 1:
+            label = f"{label_prefix} intersect"
+        else:
+            label = f"{label_prefix} intersect size >= {min_intersection}"
 
-    size_array_intersection = (
-        f"{size_array_intersect_function(col.name_l(), col.name_r())}"
-    )
-    sql = f"{size_array_intersection} >= {min_intersection}"
+        level_dict = {"sql_condition": sql, "label_for_charts": label}
+        if m_probability:
+            level_dict["m_probability"] = m_probability
+        if term_frequency_adjustments:
+            level_dict["tf_adjustment_column"] = col_name
 
-    label_prefix = f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"
-    if min_intersection == 1:
-        label = f"{label_prefix} intersect"
-    else:
-        label = f"{label_prefix} intersect size >= {min_intersection}"
+        super().__init__(level_dict, sql_dialect=self._sql_dialect_)
 
-    level_dict = {"sql_condition": sql, "label_for_charts": label}
-    if m_probability:
-        level_dict["m_probability"] = m_probability
-    if term_frequency_adjustments:
-        level_dict["tf_adjustment_column"] = col_name
+    @property
+    def _sql_dialect_(self):
+        raise NotImplementedError("Dialect not defined on base class")
 
-    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+    @property
+    def _size_array_intersect_function(self):
+        raise NotImplementedError("Intersect function not defined on base class")

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -343,7 +343,12 @@ def array_intersect_at_sizes(
 
     for size_intersect, m_prob in zip(sizes, m_probabilities):
         level = cl.array_intersect_level(
-            col_name, m_probability=m_prob, min_intersection=size_intersect
+            col_name,
+            m_probability=m_prob,
+            min_intersection=size_intersect,
+            size_array_intersect_function=cl._mutable_params[
+                "size_array_intersect_function"
+            ],
         )
         comparison_levels.append(level)
 

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -316,7 +316,8 @@ def array_intersect_at_sizes(
     Args:
         col_name (str): The name of the column to compare
         size_or_sizes (Union[int, list], optional): The size(s) of intersection
-            to use for the non-'else' similarity level(s). Defaults to [1].
+            to use for the non-'else' similarity level(s). Should be in
+            descending order. Defaults to [1].
         m_probability_or_probabilities_sizes (Union[float, list], optional):
             _description_. If provided, overrides the default m probabilities
             for the sizes specified. Defaults to None.

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -336,6 +336,10 @@ class ArrayIntersectAtSizesComparisonBase(Comparison):
                 "`size_or_sizes` must have at least one element, so that Comparison "
                 "has more than just an 'else' level"
             )
+        if any(size <= 0 for size in sizes):
+            raise ValueError(
+                "All entries of `size_or_sizes` must be postive"
+            )
 
         if m_probability_or_probabilities_sizes is None:
             m_probability_or_probabilities_sizes = [None] * len(sizes)

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -337,9 +337,7 @@ class ArrayIntersectAtSizesComparisonBase(Comparison):
                 "has more than just an 'else' level"
             )
         if any(size <= 0 for size in sizes):
-            raise ValueError(
-                "All entries of `size_or_sizes` must be postive"
-            )
+            raise ValueError("All entries of `size_or_sizes` must be postive")
 
         if m_probability_or_probabilities_sizes is None:
             m_probability_or_probabilities_sizes = [None] * len(sizes)

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -297,20 +297,21 @@ def jaro_winkler_at_thresholds(
         m_probability_else,
     )
 
+
 def array_intersect_at_sizes(
     col_name: str,
     size_or_sizes: Union[int, list] = [1],
     m_probability_or_probabilities_sizes: Union[float, list] = None,
     m_probability_else=None,
 ) -> Comparison:
-    """A comparison of the data in `col_name` with a user-provided distance function
-    used to assess middle similarity levels.
+    """A comparison of the data in array column `col_name` with various
+    intersection sizes to assess similarity levels.
 
     An example of the output with default arguments and setting
     `size_or_sizes = [3, 1]` would be
-    - Intersection has 3 elements
-    - Intersection has 1 element
-    - Anything else
+    - Intersection has at least 3 elements
+    - Intersection has at least 1 element (i.e. 1 or 2)
+    - Anything else (i.e. empty intersection)
 
     Args:
         col_name (str): The name of the column to compare
@@ -325,4 +326,40 @@ def array_intersect_at_sizes(
     Returns:
         Comparison:
     """
-    pass
+
+    sizes = ensure_is_iterable(size_or_sizes)
+    if len(sizes) == 0:
+        raise ValueError(
+            "`size_or_sizes` must have at least one element, so that Comparison "
+            "has more than just an 'else' level"
+        )
+
+    if m_probability_or_probabilities_sizes is None:
+        m_probability_or_probabilities_sizes = [None] * len(sizes)
+    m_probabilities = ensure_is_iterable(m_probability_or_probabilities_sizes)
+
+    comparison_levels = []
+    comparison_levels.append(cl.null_level(col_name))
+
+    for size_intersect, m_prob in zip(sizes, m_probabilities):
+        level = cl.array_intersect_level(
+            col_name, m_probability=m_prob, min_intersection=size_intersect
+        )
+        comparison_levels.append(level)
+
+    comparison_levels.append(
+        cl.else_level(m_probability=m_probability_else),
+    )
+
+    comparison_desc = ""
+
+    size_desc = ", ".join([str(s) for s in sizes])
+    plural = "" if len(sizes) == 1 else "s"
+    comparison_desc += f"Array intersection at minimum size{plural} {size_desc} vs. "
+    comparison_desc += "anything else"
+
+    comparison_dict = {
+        "comparison_description": comparison_desc,
+        "comparison_levels": comparison_levels,
+    }
+    return Comparison(comparison_dict)

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -298,74 +298,77 @@ def jaro_winkler_at_thresholds(
     )
 
 
-def array_intersect_at_sizes(
-    col_name: str,
-    size_or_sizes: Union[int, list] = [1],
-    m_probability_or_probabilities_sizes: Union[float, list] = None,
-    m_probability_else=None,
-) -> Comparison:
-    """A comparison of the data in array column `col_name` with various
-    intersection sizes to assess similarity levels.
+class ArrayIntersectAtSizesComparisonBase(Comparison):
+    def __init__(
+        self,
+        col_name: str,
+        size_or_sizes: Union[int, list] = [1],
+        m_probability_or_probabilities_sizes: Union[float, list] = None,
+        m_probability_else=None,
+    ) -> Comparison:
+        """A comparison of the data in array column `col_name` with various
+        intersection sizes to assess similarity levels.
 
-    An example of the output with default arguments and setting
-    `size_or_sizes = [3, 1]` would be
-    - Intersection has at least 3 elements
-    - Intersection has at least 1 element (i.e. 1 or 2)
-    - Anything else (i.e. empty intersection)
+        An example of the output with default arguments and setting
+        `size_or_sizes = [3, 1]` would be
+        - Intersection has at least 3 elements
+        - Intersection has at least 1 element (i.e. 1 or 2)
+        - Anything else (i.e. empty intersection)
 
-    Args:
-        col_name (str): The name of the column to compare
-        size_or_sizes (Union[int, list], optional): The size(s) of intersection
-            to use for the non-'else' similarity level(s). Should be in
-            descending order. Defaults to [1].
-        m_probability_or_probabilities_sizes (Union[float, list], optional):
-            _description_. If provided, overrides the default m probabilities
-            for the sizes specified. Defaults to None.
-        m_probability_else (_type_, optional): If provided, overrides the
-            default m probability for the 'anything else' level. Defaults to None.
+        Args:
+            col_name (str): The name of the column to compare
+            size_or_sizes (Union[int, list], optional): The size(s) of intersection
+                to use for the non-'else' similarity level(s). Should be in
+                descending order. Defaults to [1].
+            m_probability_or_probabilities_sizes (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the sizes specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
 
-    Returns:
-        Comparison:
-    """
+        Returns:
+            Comparison:
+        """
 
-    sizes = ensure_is_iterable(size_or_sizes)
-    if len(sizes) == 0:
-        raise ValueError(
-            "`size_or_sizes` must have at least one element, so that Comparison "
-            "has more than just an 'else' level"
+        sizes = ensure_is_iterable(size_or_sizes)
+        if len(sizes) == 0:
+            raise ValueError(
+                "`size_or_sizes` must have at least one element, so that Comparison "
+                "has more than just an 'else' level"
+            )
+
+        if m_probability_or_probabilities_sizes is None:
+            m_probability_or_probabilities_sizes = [None] * len(sizes)
+        m_probabilities = ensure_is_iterable(m_probability_or_probabilities_sizes)
+
+        comparison_levels = []
+        comparison_levels.append(cl.null_level(col_name))
+
+        for size_intersect, m_prob in zip(sizes, m_probabilities):
+            level = self._array_intersect_level(
+                col_name, m_probability=m_prob, min_intersection=size_intersect
+            )
+            comparison_levels.append(level)
+
+        comparison_levels.append(
+            cl.else_level(m_probability=m_probability_else),
         )
 
-    if m_probability_or_probabilities_sizes is None:
-        m_probability_or_probabilities_sizes = [None] * len(sizes)
-    m_probabilities = ensure_is_iterable(m_probability_or_probabilities_sizes)
+        comparison_desc = ""
 
-    comparison_levels = []
-    comparison_levels.append(cl.null_level(col_name))
-
-    for size_intersect, m_prob in zip(sizes, m_probabilities):
-        level = cl.array_intersect_level(
-            col_name,
-            m_probability=m_prob,
-            min_intersection=size_intersect,
-            size_array_intersect_function=cl._mutable_params[
-                "size_array_intersect_function"
-            ],
+        size_desc = ", ".join([str(s) for s in sizes])
+        plural = "" if len(sizes) == 1 else "s"
+        comparison_desc += (
+            f"Array intersection at minimum size{plural} {size_desc} vs. "
         )
-        comparison_levels.append(level)
+        comparison_desc += "anything else"
 
-    comparison_levels.append(
-        cl.else_level(m_probability=m_probability_else),
-    )
+        comparison_dict = {
+            "comparison_description": comparison_desc,
+            "comparison_levels": comparison_levels,
+        }
+        super().__init__(comparison_dict)
 
-    comparison_desc = ""
-
-    size_desc = ", ".join([str(s) for s in sizes])
-    plural = "" if len(sizes) == 1 else "s"
-    comparison_desc += f"Array intersection at minimum size{plural} {size_desc} vs. "
-    comparison_desc += "anything else"
-
-    comparison_dict = {
-        "comparison_description": comparison_desc,
-        "comparison_levels": comparison_levels,
-    }
-    return Comparison(comparison_dict)
+    @property
+    def _array_intersect_level(self):
+        raise NotImplementedError("Intersect level not defined on base class")

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -296,3 +296,33 @@ def jaro_winkler_at_thresholds(
         m_probability_or_probabilities_lev,
         m_probability_else,
     )
+
+def array_intersect_at_sizes(
+    col_name: str,
+    size_or_sizes: Union[int, list] = [1],
+    m_probability_or_probabilities_sizes: Union[float, list] = None,
+    m_probability_else=None,
+) -> Comparison:
+    """A comparison of the data in `col_name` with a user-provided distance function
+    used to assess middle similarity levels.
+
+    An example of the output with default arguments and setting
+    `size_or_sizes = [3, 1]` would be
+    - Intersection has 3 elements
+    - Intersection has 1 element
+    - Anything else
+
+    Args:
+        col_name (str): The name of the column to compare
+        size_or_sizes (Union[int, list], optional): The size(s) of intersection
+            to use for the non-'else' similarity level(s). Defaults to [1].
+        m_probability_or_probabilities_sizes (Union[float, list], optional):
+            _description_. If provided, overrides the default m probabilities
+            for the sizes specified. Defaults to None.
+        m_probability_else (_type_, optional): If provided, overrides the
+            default m probability for the 'anything else' level. Defaults to None.
+
+    Returns:
+        Comparison:
+    """
+    pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -10,7 +10,7 @@ from ..comparison_level_library import (  # noqa: F401
     columns_reversed_level,
     distance_in_km_level,
     percentage_difference_level,
-    array_intersect_level,
+    ArrayIntersectLevelBase,
 )
 
 
@@ -24,4 +24,13 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 
 _mutable_params["dialect"] = "duckdb"
 _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
-_mutable_params["size_array_intersect_function"] = size_array_intersect_sql
+
+
+class array_intersect_level(ArrayIntersectLevelBase):
+    @property
+    def _sql_dialect_(self):
+        return "duckdb"
+
+    @property
+    def _size_array_intersect_function(self):
+        return size_array_intersect_sql

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -13,12 +13,14 @@ from ..comparison_level_library import (  # noqa: F401
     array_intersect_level,
 )
 
+
 def size_array_intersect_sql(col_name_l, col_name_r):
     # sum of individual (unique) array sizes, minus the (unique) union
     return (
         f"list_unique({col_name_l}) + list_unique({col_name_r})"
         f" - list_unique(list_concat({col_name_l}, {col_name_r}))"
     )
+
 
 _mutable_params["dialect"] = "duckdb"
 _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -28,7 +28,7 @@ _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 
 class array_intersect_level(ArrayIntersectLevelBase):
     @property
-    def _sql_dialect_(self):
+    def _sql_dialect(self):
         return "duckdb"
 
     @property

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -10,7 +10,16 @@ from ..comparison_level_library import (  # noqa: F401
     columns_reversed_level,
     distance_in_km_level,
     percentage_difference_level,
+    array_intersect_level,
 )
+
+def size_array_intersect_sql(col_name_l, col_name_r):
+    # sum of individual (unique) array sizes, minus the (unique) union
+    return (
+        f"list_unique({col_name_l}) + list_unique({col_name_r})"
+        f" - list_unique(list_concat({col_name_l}, {col_name_r}))"
+    )
 
 _mutable_params["dialect"] = "duckdb"
 _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
+_mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -9,7 +9,12 @@ from ..comparison_library import (  # noqa: F401
     distance_function_at_thresholds,
     jaccard_at_thresholds,
     jaro_winkler_at_thresholds,
+    array_intersect_at_sizes,
+)
+from .duckdb_comparison_level_library import (
+    size_array_intersect_sql,
 )
 
 _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 _mutable_params["dialect"] = "duckdb"
+_mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -9,12 +9,17 @@ from ..comparison_library import (  # noqa: F401
     distance_function_at_thresholds,
     jaccard_at_thresholds,
     jaro_winkler_at_thresholds,
-    array_intersect_at_sizes,
+    ArrayIntersectAtSizesComparisonBase,
 )
 from .duckdb_comparison_level_library import (
-    size_array_intersect_sql,
+    array_intersect_level,
 )
 
 _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 _mutable_params["dialect"] = "duckdb"
-_mutable_params["size_array_intersect_function"] = size_array_intersect_sql
+
+
+class array_intersect_at_sizes(ArrayIntersectAtSizesComparisonBase):
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -9,7 +9,7 @@ from ..comparison_level_library import (  # noqa: F401
     jaccard_level,
     jaro_winkler_level,
     distance_in_km_level,
-    array_intersect_level,
+    ArrayIntersectLevelBase,
 )
 
 
@@ -18,4 +18,13 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 
 
 _mutable_params["dialect"] = "spark"
-_mutable_params["size_array_intersect_function"] = size_array_intersect_sql
+
+
+class array_intersect_level(ArrayIntersectLevelBase):
+    @property
+    def _sql_dialect_(self):
+        return "spark"
+
+    @property
+    def _size_array_intersect_function(self):
+        return size_array_intersect_sql

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -17,17 +17,19 @@ _mutable_params["dialect"] = "spark"
 
 
 def array_intersect_level(
-    col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1
+    col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1,
+    include_colname_in_charts_label=False
 ) -> ComparisonLevel:
 
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
 
     sql = f"size(array_intersect({col.name_l()}, {col.name_r()})) >= {min_intersection}"
 
+    label_prefix = f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"
     if min_intersection == 1:
-        label = "Arrays intersect"
+        label = f"{label_prefix} intersect"
     else:
-        label = f"Array intersect size >= {min_intersection}"
+        label = f"{label_prefix} intersect size >= {min_intersection}"
 
     level_dict = {"sql_condition": sql, "label_for_charts": label}
     if m_probability:

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -11,11 +11,11 @@ from ..comparison_level_library import (  # noqa: F401
     distance_in_km_level,
     array_intersect_level,
 )
-from ..input_column import InputColumn
-from ..comparison_level import ComparisonLevel
+
 
 def size_array_intersect_sql(col_name_l, col_name_r):
     return f"size(array_intersect({col_name_l}, {col_name_r}))"
+
 
 _mutable_params["dialect"] = "spark"
 _mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -22,7 +22,7 @@ _mutable_params["dialect"] = "spark"
 
 class array_intersect_level(ArrayIntersectLevelBase):
     @property
-    def _sql_dialect_(self):
+    def _sql_dialect(self):
         return "spark"
 
     @property

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -9,37 +9,13 @@ from ..comparison_level_library import (  # noqa: F401
     jaccard_level,
     jaro_winkler_level,
     distance_in_km_level,
+    array_intersect_level,
 )
 from ..input_column import InputColumn
 from ..comparison_level import ComparisonLevel
 
-_mutable_params["dialect"] = "spark"
-
-
 def size_array_intersect_sql(col_name_l, col_name_r):
     return f"size(array_intersect({col_name_l}, {col_name_r}))"
 
-
-def array_intersect_level(
-    col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1,
-    include_colname_in_charts_label=False
-) -> ComparisonLevel:
-
-    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
-
-    size_array_intersection = f"{size_array_intersect_sql(col.name_l(), col.name_r())}"
-    sql = f"{size_array_intersection} >= {min_intersection}"
-
-    label_prefix = f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"
-    if min_intersection == 1:
-        label = f"{label_prefix} intersect"
-    else:
-        label = f"{label_prefix} intersect size >= {min_intersection}"
-
-    level_dict = {"sql_condition": sql, "label_for_charts": label}
-    if m_probability:
-        level_dict["m_probability"] = m_probability
-    if term_frequency_adjustments:
-        level_dict["tf_adjustment_column"] = col_name
-
-    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+_mutable_params["dialect"] = "spark"
+_mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -16,6 +16,10 @@ from ..comparison_level import ComparisonLevel
 _mutable_params["dialect"] = "spark"
 
 
+def size_array_intersect_sql(col_name_l, col_name_r):
+    return f"size(array_intersect({col_name_l}, {col_name_r}))"
+
+
 def array_intersect_level(
     col_name, m_probability=None, term_frequency_adjustments=False, min_intersection=1,
     include_colname_in_charts_label=False
@@ -23,7 +27,8 @@ def array_intersect_level(
 
     col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
 
-    sql = f"size(array_intersect({col.name_l()}, {col.name_r()})) >= {min_intersection}"
+    size_array_intersection = f"{size_array_intersect_sql(col.name_l(), col.name_r())}"
+    sql = f"{size_array_intersection} >= {min_intersection}"
 
     label_prefix = f"{col_name} arrays" if include_colname_in_charts_label else "Arrays"
     if min_intersection == 1:

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -9,6 +9,13 @@ from ..comparison_library import (  # noqa: F401
     distance_function_at_thresholds,
     jaccard_at_thresholds,
     jaro_winkler_at_thresholds,
+    array_intersect_at_sizes,
 )
 
+from .spark_comparison_level_library import (
+    size_array_intersect_sql,
+)
+
+
 _mutable_params["dialect"] = "spark"
+_mutable_params["size_array_intersect_function"] = size_array_intersect_sql

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -9,13 +9,18 @@ from ..comparison_library import (  # noqa: F401
     distance_function_at_thresholds,
     jaccard_at_thresholds,
     jaro_winkler_at_thresholds,
-    array_intersect_at_sizes,
+    ArrayIntersectAtSizesComparisonBase,
 )
 
 from .spark_comparison_level_library import (
-    size_array_intersect_sql,
+    array_intersect_level,
 )
 
 
 _mutable_params["dialect"] = "spark"
-_mutable_params["size_array_intersect_function"] = size_array_intersect_sql
+
+
+class array_intersect_at_sizes(ArrayIntersectAtSizesComparisonBase):
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level

--- a/tests/test_array_columns.py
+++ b/tests/test_array_columns.py
@@ -1,16 +1,7 @@
-<<<<<<< HEAD
-=======
-import importlib
-
->>>>>>> 1e7631a16ac4feffc8450db518830bb05777ae63
 import pandas as pd
 
 from splink.duckdb.duckdb_linker import DuckDBLinker
 import splink.duckdb.duckdb_comparison_library as cl
-<<<<<<< HEAD
-=======
-importlib.reload(cl)
->>>>>>> 1e7631a16ac4feffc8450db518830bb05777ae63
 
 
 def postcode(num):
@@ -110,11 +101,7 @@ def test_array_comparisons():
     # now levels encompass multiple size intersections
     intersection_size_ids = {
         3: intersection_size_ids[3].union(intersection_size_ids[4]),
-<<<<<<< HEAD
         1: intersection_size_ids[1].union(intersection_size_ids[2]),
-=======
-        1: intersection_size_ids[1].union(intersection_size_ids[2])
->>>>>>> 1e7631a16ac4feffc8450db518830bb05777ae63
     }
     postcode_comparison = linker._settings_obj.comparisons[0]
     # size: gamma_level value

--- a/tests/test_array_columns.py
+++ b/tests/test_array_columns.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+import pytest
+
 from splink.duckdb.duckdb_linker import DuckDBLinker
 import splink.duckdb.duckdb_comparison_library as cl
 
@@ -123,3 +125,13 @@ def test_array_comparisons():
             )
             print(id_pair)
             assert row["gamma_postcode"] == gamma_val
+
+    # check we get an error if we try to pass -ve sizes
+    with pytest.raises(ValueError):
+        settings = {
+            "link_type": "dedupe_only",
+            "comparisons": [
+                cl.array_intersect_at_sizes("postcode", [-1, 2]),
+                cl.exact_match("first_name"),
+            ],
+        }

--- a/tests/test_array_columns.py
+++ b/tests/test_array_columns.py
@@ -1,0 +1,125 @@
+import pandas as pd
+
+from splink.duckdb.duckdb_linker import DuckDBLinker
+import splink.duckdb.duckdb_comparison_library as cl
+
+
+def postcode(num):
+    return f"XX{num} {num}YZ"
+
+
+def test_array_comparisons():
+    df = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "first_name": "Isabella",
+                "postcode": [postcode(1), postcode(2)],
+            },
+            {
+                "unique_id": 2,
+                "first_name": "Mary",
+                "postcode": [postcode(1), postcode(3), postcode(7)],
+            },
+            {
+                "unique_id": 3,
+                "first_name": "Hannah",
+                "postcode": [postcode(1), postcode(2), postcode(4)],
+            },
+            {
+                "unique_id": 4,
+                "first_name": "Jane",
+                "postcode": [postcode(1), postcode(2), postcode(4)],
+            },
+            {
+                "unique_id": 5,
+                "first_name": "Isabella",
+                "postcode": [postcode(5), postcode(6)],
+            },
+            {
+                "unique_id": 6,
+                "first_name": "Graham",
+                "postcode": [postcode(7), postcode(8), postcode(9), postcode(10)],
+            },
+            {
+                "unique_id": 7,
+                "first_name": "Mark",
+                "postcode": [postcode(7), postcode(8), postcode(9), postcode(10)],
+            },
+        ]
+    )
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.array_intersect_at_sizes("postcode", [4, 3, 2, 1]),
+            cl.exact_match("first_name"),
+        ],
+    }
+    linker = DuckDBLinker(df, settings)
+    df_e = linker.predict().as_pandas_dataframe()
+
+    # ID pairs with various sizes of intersections
+    intersection_size_ids = {
+        4: {(6, 7)},
+        3: {(3, 4)},
+        2: {(1, 3), (1, 4)},
+        1: {(1, 2), (2, 3), (2, 4), (2, 6), (2, 7)},
+    }
+    postcode_comparison = linker._settings_obj.comparisons[0]
+    # size: gamma_level value
+    size_gamma_lookup = {1: 1, 2: 2, 3: 3, 4: 4}
+
+    for size, id_comb in intersection_size_ids.items():
+        gamma_val = size_gamma_lookup[size]
+        print(f"Size {size}")
+        print(
+            postcode_comparison._get_comparison_level_by_comparison_vector_value(
+                gamma_val
+            ).as_dict()
+        )
+        for id_pair in id_comb:
+            row = dict(
+                df_e.query(
+                    "unique_id_l == {} and unique_id_r == {}".format(*id_pair)
+                ).iloc[0]
+            )
+            print(id_pair)
+            assert row["gamma_postcode"] == gamma_val
+
+    # and again but with coarser levels
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.array_intersect_at_sizes("postcode", [3, 1]),
+            cl.exact_match("first_name"),
+        ],
+    }
+    linker = DuckDBLinker(df, settings)
+    df_e = linker.predict().as_pandas_dataframe()
+
+    # now levels encompass multiple size intersections
+    intersection_size_ids = {
+        3: intersection_size_ids[3].union(intersection_size_ids[4]),
+        1: intersection_size_ids[1].union(intersection_size_ids[2]),
+    }
+    postcode_comparison = linker._settings_obj.comparisons[0]
+    # size: gamma_level value
+    size_gamma_lookup = {1: 1, 3: 2}
+
+    for size, id_comb in intersection_size_ids.items():
+        gamma_val = size_gamma_lookup[size]
+        print(f"Size {size}")
+        print(
+            postcode_comparison._get_comparison_level_by_comparison_vector_value(
+                gamma_val
+            ).as_dict()
+        )
+        for id_pair in id_comb:
+            row = dict(
+                df_e.query(
+                    "unique_id_l == {} and unique_id_r == {}".format(*id_pair)
+                ).iloc[0]
+            )
+            print(id_pair)
+            assert row["gamma_postcode"] == gamma_val


### PR DESCRIPTION
This introduces simple array comparisons (i.e. size of intersection of two arrays) to DuckDB and Athena backends.

It also allows the column name to be inserted into the chart label, which may be useful in comparisons including multiple arrays (and which currently breaks the `match_weights_chart`.

Additionally, to give a common interface, as it stands there is a new approach to dialect-dependent levels, based on subclassing rather than using `_mutable_params`. This is because:
* the form of the sql expression is different, so in this case just changing the name of the function is not enough (due to duckdb's lack of a direct array intersect)
* using a `_mutable_params` approach lead to coupling between tests, where tests would fail due to the presence of test scripts which are run _afterwards_, which made things hard to reason about
* possibly a little simpler to understand?

As the dialect-dependent subclasses do not have an `__init__` method, the docstring is inherited, meaning that it is still available for hinting. It is currently in the `__init__` rather than on the class directly as this allows it to be picked up in vscode, although as a consequence it is lower down within jupyter.

Currently also the subclasses are named in snake-case rather than the conventional camel-case, so as to not break the existing interface, and be consistent with the API for other comparison/comparison-levels.
