### PR TITLE
docs: Fix link to settings_jsonschema.json

### DIFF
--- a/docs/topic_guides/customising_comparisons.ipynb
+++ b/docs/topic_guides/customising_comparisons.ipynb
@@ -295,7 +295,7 @@
    "source": [
     "## Method 3: Providing the spec as a dictionary\n",
     "\n",
-    "Ultimately, comparisons are specified as a dictionary which conforms to the formal `jsonschema` specification of the settings dictionary - see [here]https://github.com/moj-analytical-services/splink/blob/master/splink/files/settings_jsonschema.json) and [here](https://moj-analytical-services.github.io/splink/).\n",
+    "Ultimately, comparisons are specified as a dictionary which conforms to [the formal `jsonschema` specification of the settings dictionary](https://github.com/moj-analytical-services/splink/blob/master/splink/files/settings_jsonschema.json) and [here](https://moj-analytical-services.github.io/splink/).\n",
     "\n",
     "The library functions described above are convenience functions that provide a shorthand way to produce valid dictionaries.\n",
     "\n",


### PR DESCRIPTION
first, the link wasn't rendering because of a missing `(`

second, using "click here" as link text is not very usable for people with screen readers, this change improves accessibility.