### PR TITLE
Fix charts for training probability edge cases

### DIFF
--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -221,7 +221,8 @@ def predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename):
     sqls.append(sql)
 
     sqls_2 = predict_from_comparison_vectors_sqls(
-        linker._settings_obj, include_clerical_match_score=True,
+        linker._settings_obj,
+        include_clerical_match_score=True,
         sql_infinity_expression=linker._infinity_expression,
     )
 

--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -221,7 +221,8 @@ def predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename):
     sqls.append(sql)
 
     sqls_2 = predict_from_comparison_vectors_sqls(
-        linker._settings_obj, include_clerical_match_score=True
+        linker._settings_obj, include_clerical_match_score=True,
+        sql_infinity_expression=linker._infinity_expression,
     )
 
     sqls.extend(sqls_2)

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -363,6 +363,10 @@ class AthenaLinker(Linker):
         percent = proportion * 100
         return f" TABLESAMPLE BERNOULLI ({percent})"
 
+    @property
+    def _infinity_expression(self):
+        return "infinity()"
+
     def _table_exists_in_database(self, table_name):
         return wr.catalog.does_table_exist(
             database=self.output_schema,

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -235,8 +235,7 @@ class AthenaLinker(Linker):
             >>> )
         """
 
-        if settings_dict is not None and "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "presto"
+        self._sql_dialect_ = "presto"
 
         self.boto3_session = boto3_session
         self.output_schema = output_database

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -18,6 +18,7 @@ from .misc import (
     match_weight_to_bayes_factor,
 )
 from .parse_sql import get_columns_used_from_sql
+from .constants import LEVEL_NOT_OBSERVED_TEXT
 
 from .input_column import sqlglot_tree_signature
 
@@ -190,7 +191,7 @@ class ComparisonLevel:
     def m_probability(self):
         if self._is_null_level:
             return None
-        if self._m_probability == "level not observed in training dataset":
+        if self._m_probability == LEVEL_NOT_OBSERVED_TEXT:
             return 1e-6
         if self._m_probability is None and self._has_comparison:
             vals = _default_m_values(self.comparison._num_levels)
@@ -201,7 +202,7 @@ class ComparisonLevel:
     def m_probability(self, value):
         if self._is_null_level:
             raise AttributeError("Cannot set m_probability when is_null_level is true")
-        if value == "level not observed in training dataset":
+        if value == LEVEL_NOT_OBSERVED_TEXT:
             cc_n = self.comparison._output_column_name
             cl_n = self._label_for_charts
             logger.warning(
@@ -216,7 +217,7 @@ class ComparisonLevel:
     def u_probability(self):
         if self._is_null_level:
             return None
-        if self._u_probability == "level not observed in training dataset":
+        if self._u_probability == LEVEL_NOT_OBSERVED_TEXT:
             return 1e-6
         if self._u_probability is None:
             vals = _default_u_values(self.comparison._num_levels)
@@ -227,7 +228,7 @@ class ComparisonLevel:
     def u_probability(self, value):
         if self._is_null_level:
             raise AttributeError("Cannot set u_probability when is_null_level is true")
-        if value == "level not observed in training dataset":
+        if value == LEVEL_NOT_OBSERVED_TEXT:
             cc_n = self.comparison._output_column_name
             cl_n = self._label_for_charts
             logger.warning(

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -513,8 +513,6 @@ class ComparisonLevel:
         bayes_factor = (
             self._bayes_factor if self._bayes_factor != math.inf else "'Infinity'"
         )
-        # bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else 1e200
-        # bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else 10
         sql = f"""
         WHEN
         {self.comparison._gamma_column_name} = {self._comparison_vector_value}

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -664,7 +664,7 @@ class ComparisonLevel:
             p = trained_value["probability"]
             record["estimated_probability"] = p
             record["estimate_description"] = trained_value["description"]
-            if p is not None and p > 0.0 and p < 1.0:
+            if p is not None and p != LEVEL_NOT_OBSERVED_TEXT and p > 0.0 and p < 1.0:
                 record["estimated_probability_as_log_odds"] = math.log2(p / (1 - p))
             else:
                 record["estimated_probability_as_log_odds"] = None

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -333,6 +333,8 @@ class ComparisonLevel:
             return 1.0
         if self.m_probability is None or self.u_probability is None:
             return None
+        elif self.u_probability == 0:
+            return math.inf
         else:
             return self.m_probability / self.u_probability
 
@@ -349,6 +351,7 @@ class ComparisonLevel:
             f"If comparison level is `{self._label_for_charts.lower()}` "
             "then comparison is"
         )
+        # TODO: bf in case of Inf
         if self._bayes_factor >= 1.0:
             return f"{text} {self._bayes_factor:,.2f} times more likely to be a match"
         else:
@@ -503,10 +506,13 @@ class ComparisonLevel:
 
     @property
     def _bayes_factor_sql(self):
+        bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else "\'Infinity\'"
+        # bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else 1e200
+        # bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else 10
         sql = f"""
         WHEN
         {self.comparison._gamma_column_name} = {self._comparison_vector_value}
-        THEN cast({self._bayes_factor} as double)
+        THEN cast({bayes_factor} as double)
         """
         return dedent(sql)
 

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -351,8 +351,11 @@ class ComparisonLevel:
             f"If comparison level is `{self._label_for_charts.lower()}` "
             "then comparison is"
         )
-        # TODO: bf in case of Inf
-        if self._bayes_factor >= 1.0:
+        if self._bayes_factor == math.inf:
+            return f"{text} certain to be a match"
+        elif self._bayes_factor == 0.0:
+            return f"{text} impossible to be a match"
+        elif self._bayes_factor >= 1.0:
             return f"{text} {self._bayes_factor:,.2f} times more likely to be a match"
         else:
             mult = 1 / self._bayes_factor
@@ -506,7 +509,9 @@ class ComparisonLevel:
 
     @property
     def _bayes_factor_sql(self):
-        bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else "\'Infinity\'"
+        bayes_factor = (
+            self._bayes_factor if self._bayes_factor != math.inf else "'Infinity'"
+        )
         # bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else 1e200
         # bayes_factor = self._bayes_factor if self._bayes_factor != math.inf else 10
         sql = f"""

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -652,7 +652,7 @@ class ComparisonLevel:
             p = trained_value["probability"]
             record["estimated_probability"] = p
             record["estimate_description"] = trained_value["description"]
-            if p is not None and p > 0.0:
+            if p is not None and p > 0.0 and p < 1.0:
                 record["estimated_probability_as_log_odds"] = math.log2(p / (1 - p))
             else:
                 record["estimated_probability_as_log_odds"] = None

--- a/splink/constants.py
+++ b/splink/constants.py
@@ -1,0 +1,1 @@
+LEVEL_NOT_OBSERVED_TEXT = "level not observed in training dataset"

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -101,8 +101,7 @@ class DuckDBLinker(Linker):
                 to attach more easily readable/interpretable names. Defaults to None.
         """
 
-        if settings_dict is not None and "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "duckdb"
+        self._sql_dialect_ = "duckdb"
 
         validate_duckdb_connection(connection, logger)
 

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -220,6 +220,10 @@ class DuckDBLinker(Linker):
         percent = proportion * 100
         return f"USING SAMPLE {percent}% (bernoulli)"
 
+    @property
+    def _infinity_expression(self):
+        return "cast('infinity' as double)"
+
     def _table_exists_in_database(self, table_name):
         sql = f"PRAGMA table_info('{table_name}');"
 

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -14,6 +14,7 @@ from .charts import (
 )
 from .comparison_level import ComparisonLevel
 from .comparison import Comparison
+from .constants import LEVEL_NOT_OBSERVED_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +185,7 @@ class EMTrainingSession:
                 )
 
                 if not self._training_fix_m_probabilities:
-                    not_observed = "level not observed in training dataset"
+                    not_observed = LEVEL_NOT_OBSERVED_TEXT
                     if cl._m_probability == not_observed:
                         orig_cl._add_trained_m_probability(not_observed, training_desc)
                         logger.info(
@@ -199,7 +200,7 @@ class EMTrainingSession:
                         )
 
                 if not self._training_fix_u_probabilities:
-                    not_observed = "level not observed in training dataset"
+                    not_observed = LEVEL_NOT_OBSERVED_TEXT
                     if cl._u_probability == not_observed:
                         orig_cl._add_trained_u_probability(not_observed, training_desc)
                         logger.info(

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -158,7 +158,10 @@ def expectation_maximisation(
         start_time = time.time()
 
         # Expectation step
-        sqls = predict_from_comparison_vectors_sqls(settings_obj)
+        sqls = predict_from_comparison_vectors_sqls(
+            settings_obj,
+            sql_infinity_expression=linker._infinity_expression,
+        )
         for sql in sqls:
             linker._enqueue_sql(sql["sql"], sql["output_table_name"])
 

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -8,6 +8,7 @@ from .settings import Settings
 from .m_u_records_to_parameters import m_u_records_to_lookup_dict
 from .splink_dataframe import SplinkDataFrame
 from .comparison_level import ComparisonLevel
+from .constants import LEVEL_NOT_OBSERVED_TEXT
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:
@@ -96,7 +97,7 @@ def populate_m_u_from_lookup(
             ]["m_probability"]
 
         except KeyError:
-            m_probability = "level not observed in training dataset"
+            m_probability = LEVEL_NOT_OBSERVED_TEXT
         cl.m_probability = m_probability
 
     if not em_training_session._training_fix_u_probabilities:
@@ -106,7 +107,7 @@ def populate_m_u_from_lookup(
             ]["u_probability"]
 
         except KeyError:
-            u_probability = "level not observed in training dataset"
+            u_probability = LEVEL_NOT_OBSERVED_TEXT
 
         cl.u_probability = u_probability
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -146,6 +146,7 @@ class Linker:
 
         self._pipeline = SQLPipeline()
 
+        settings_dict = deepcopy(settings_dict)
         # if settings_dict is passed, set sql_dialect on it if missing, and make sure
         # incompatible dialect not passed
         if settings_dict is not None and settings_dict.get("sql_dialect", None) is None:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -259,6 +259,12 @@ class Linker:
             )
         return self._sql_dialect_
 
+    @property
+    def _infinity_expression(self):
+        raise NotImplementedError(
+            f"infinity sql expression not available for {type(self)}"
+        )
+
     def _prepend_schema_to_table_name(self, table_name):
         if self._output_schema:
             return f"{self._output_schema}.{table_name}"
@@ -1095,7 +1101,8 @@ class Linker:
         self._enqueue_sql(sql, "__splink__df_comparison_vectors")
 
         sqls = predict_from_comparison_vectors_sqls(
-            self._settings_obj, threshold_match_probability, threshold_match_weight
+            self._settings_obj, threshold_match_probability, threshold_match_weight,
+            sql_infinity_expression=self._infinity_expression,
         )
         for sql in sqls:
             self._enqueue_sql(sql["sql"], sql["output_table_name"])
@@ -1179,7 +1186,10 @@ class Linker:
         sql = compute_comparison_vector_values_sql(self._settings_obj)
         self._enqueue_sql(sql, "__splink__df_comparison_vectors")
 
-        sqls = predict_from_comparison_vectors_sqls(self._settings_obj)
+        sqls = predict_from_comparison_vectors_sqls(
+            self._settings_obj,
+            sql_infinity_expression=self._infinity_expression,
+        )
         for sql in sqls:
             self._enqueue_sql(sql["sql"], sql["output_table_name"])
 
@@ -1248,7 +1258,10 @@ class Linker:
         sql = compute_comparison_vector_values_sql(self._settings_obj)
         self._enqueue_sql(sql, "__splink__df_comparison_vectors")
 
-        sqls = predict_from_comparison_vectors_sqls(self._settings_obj)
+        sqls = predict_from_comparison_vectors_sqls(
+            self._settings_obj,
+            sql_infinity_expression=self._infinity_expression,
+        )
         for sql in sqls:
             self._enqueue_sql(sql["sql"], sql["output_table_name"])
 
@@ -1301,7 +1314,10 @@ class Linker:
 
         self._enqueue_sql(sql, "__splink__df_comparison_vectors")
 
-        sqls = predict_from_comparison_vectors_sqls(self._settings_obj)
+        sqls = predict_from_comparison_vectors_sqls(
+            self._settings_obj,
+            sql_infinity_expression=self._infinity_expression,
+        )
         for sql in sqls:
             self._enqueue_sql(sql["sql"], sql["output_table_name"])
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1101,7 +1101,9 @@ class Linker:
         self._enqueue_sql(sql, "__splink__df_comparison_vectors")
 
         sqls = predict_from_comparison_vectors_sqls(
-            self._settings_obj, threshold_match_probability, threshold_match_weight,
+            self._settings_obj,
+            threshold_match_probability,
+            threshold_match_weight,
             sql_infinity_expression=self._infinity_expression,
         )
         for sql in sqls:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -146,6 +146,17 @@ class Linker:
 
         self._pipeline = SQLPipeline()
 
+        # if settings_dict is passed, set sql_dialect on it if missing, and make sure
+        # incompatible dialect not passed
+        if settings_dict is not None:
+            if settings_dict.get("sql_dialect", None) is None:
+                settings_dict["sql_dialect"] = self._sql_dialect
+            elif settings_dict["sql_dialect"] != self._sql_dialect:
+                raise ValueError(
+                    f"Incompatible SQL dialect! `settings` dictionary uses "
+                    f"dialect {settings_dict['sql_dialect']}, but expecting "
+                    f"'{self._sql_dialect}' for Linker of type {type(self)}"
+                )
         self._settings_dict = settings_dict
         if settings_dict is None:
             self._settings_obj_ = None
@@ -243,6 +254,15 @@ class Linker:
             return True
         else:
             return False
+
+    @property
+    def _sql_dialect(self):
+        if self._sql_dialect_ is None:
+            raise NotImplementedError(
+                f"No SQL dialect set on object of type {type(self)}. "
+                "Did you make sure to create a dialect-specific Linker?"
+            )
+        return self._sql_dialect_
 
     def _prepend_schema_to_table_name(self, table_name):
         if self._output_schema:

--- a/splink/m_u_records_to_parameters.py
+++ b/splink/m_u_records_to_parameters.py
@@ -1,6 +1,7 @@
 import logging
 
 from .comparison_level import ComparisonLevel
+from .constants import LEVEL_NOT_OBSERVED_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def append_u_probability_to_comparison_level_trained_probabilities(
         ]["u_probability"]
 
     except KeyError:
-        u_probability = "level not observed in training dataset"
+        u_probability = LEVEL_NOT_OBSERVED_TEXT
 
         logger.info(f"u probability {not_trained_message(cl)}")
     cl._add_trained_u_probability(
@@ -72,7 +73,7 @@ def append_m_probability_to_comparison_level_trained_probabilities(
         ]["m_probability"]
 
     except KeyError:
-        m_probability = "level not observed in training dataset"
+        m_probability = LEVEL_NOT_OBSERVED_TEXT
 
         logger.info(f"m probability {not_trained_message(cl)}")
     cl._add_trained_m_probability(

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -1,4 +1,4 @@
-from math import log2
+from math import log2, inf
 from typing import Iterable
 import numpy as np
 import json
@@ -12,7 +12,7 @@ def dedupe_preserving_order(list_of_items):
 
 
 def prob_to_bayes_factor(prob):
-    return prob / (1 - prob)
+    return prob / (1 - prob) if prob != 1 else inf
 
 
 def prob_to_match_weight(prob):

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -13,7 +13,7 @@ def predict_from_comparison_vectors_sqls(
     threshold_match_probability=None,
     threshold_match_weight=None,
     include_clerical_match_score=False,
-    sql_infinity_expression="\'infinity\'",
+    sql_infinity_expression="'infinity'",
 ) -> List[dict]:
 
     sqls = []
@@ -58,7 +58,9 @@ def predict_from_comparison_vectors_sqls(
 
         # if any BF is Infinity then we need to adjust expression,
         # as arithmetic won't go through directly
-        any_bf_inf = " OR ".join(map(lambda col: f"{col} = {sql_infinity_expression}", mult))
+        any_bf_inf = " OR ".join(
+            map(lambda col: f"{col} = {sql_infinity_expression}", mult)
+        )
         bayes_factor_expr = f"""
         CASE WHEN {any_bf_inf} THEN {sql_infinity_expression} ELSE {bayes_factor_expr} END
         """

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -61,12 +61,14 @@ def predict_from_comparison_vectors_sqls(
         any_bf_inf = " OR ".join(
             map(lambda col: f"{col} = {sql_infinity_expression}", mult)
         )
-        bayes_factor_expr = f"""
-        CASE WHEN {any_bf_inf} THEN {sql_infinity_expression} ELSE {bayes_factor_expr} END
-        """
-        match_prob_expr = f"""
-        CASE WHEN {any_bf_inf} THEN 1.0 ELSE (({bayes_factor_expr})/(1+({bayes_factor_expr}))) END
-        """
+        bayes_factor_expr = (
+            f"CASE WHEN {any_bf_inf} THEN {sql_infinity_expression} "
+            f"ELSE {bayes_factor_expr} END"
+        )
+        match_prob_expr = (
+            f"CASE WHEN {any_bf_inf} THEN 1.0 "
+            f"ELSE (({bayes_factor_expr})/(1+({bayes_factor_expr}))) END"
+        )
 
     # In case user provided both, take the minimum of the two thresholds
     if threshold_match_probability is not None:

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -113,8 +113,7 @@ class SparkLinker(Linker):
 
         """
 
-        if settings_dict is not None and "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "spark"
+        self._sql_dialect_ = "spark"
 
         self.break_lineage_method = break_lineage_method
 

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -273,6 +273,10 @@ class SparkLinker(Linker):
         output_df = self._table_to_splink_dataframe(templated_name, physical_name)
         return output_df
 
+    @property
+    def _infinity_expression(self):
+        return "'infinity'"
+
     def register_table(self, input, table_name, overwrite=False):
         """
         Register a table to your backend database, to be used in one of the

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -155,6 +155,10 @@ class SQLiteLinker(Linker):
             f" ORDER BY RANDOM() LIMIT {sample_size})"
         )
 
+    @property
+    def _infinity_expression(self):
+        return "'infinity'"
+
     def _table_exists_in_database(self, table_name):
         sql = f"PRAGMA table_info('{table_name}');"
 

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -88,8 +88,7 @@ class SQLiteLinker(Linker):
         input_table_aliases: Union[str, list] = None,
     ):
 
-        if settings_dict is not None and "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "sqlite"
+        self._sql_dialect_ = "sqlite"
 
         self.con = connection
         self.con.row_factory = dict_factory

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -140,7 +140,7 @@ def test_m_u_charts():
     )
 
     print(linker._settings_obj.as_dict())
-    assert linker._settings_obj.comparisons[1].comparison_levels[2].u_probability == 1.0
+    assert linker._settings_obj.comparisons[1].comparison_levels[1].u_probability == 0.0
 
     linker.match_weights_chart()
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import numpy as np
+
+from splink.duckdb.duckdb_linker import DuckDBLinker
+import splink.duckdb.duckdb_comparison_library as cl
+
+
+# ground truth:
+# true matches ALWAYS match on gender
+# first_name is at most one edit away
+# surname can be any match level
+df = pd.DataFrame(
+    [
+        {"unique_id": 1, "true_match_id": 1, "first_name": "John", "surname": "Smith", "gender": "m", "tm_partial": 1},
+        {"unique_id": 2, "true_match_id": 1, "first_name": "Jon", "surname": "Smith", "gender": "m", "tm_partial": 1},
+        {"unique_id": 3, "true_match_id": 2, "first_name": "Mary", "surname": "Jones", "gender": "f", "tm_partial": None},
+        {"unique_id": 4, "true_match_id": 2, "first_name": "May", "surname": "Jones", "gender": "f", "tm_partial": 2},
+        {"unique_id": 5, "true_match_id": 2, "first_name": "Mary", "surname": "J", "gender": "f", "tm_partial": 2},
+        {"unique_id": 6, "true_match_id": 3, "first_name": "David", "surname": "Greene", "gender": "m", "tm_partial": 3},
+        {"unique_id": 7, "true_match_id": 3, "first_name": "David", "surname": "Green", "gender": "m", "tm_partial": None},
+        {"unique_id": 8, "true_match_id": 4, "first_name": "Sara", "surname": "Smith", "gender": "f", "tm_partial": 4},
+        {"unique_id": 9, "true_match_id": 4, "first_name": "Sarah", "surname": "Smith", "gender": "f", "tm_partial": 4},
+        {"unique_id": 10, "true_match_id": 4, "first_name": "Sarah", "surname": "Smt", "gender": "f", "tm_partial": 4},
+        {"unique_id": 11, "true_match_id": 5, "first_name": "Joan", "surname": "Smith", "gender": "f", "tm_partial": None},
+        {"unique_id": 12, "true_match_id": 6, "first_name": "Kim", "surname": "Greene", "gender": "f", "tm_partial": None},
+        {"unique_id": 13, "true_match_id": 7, "first_name": "Kim", "surname": "Greene", "gender": "m", "tm_partial": 7},
+    ]
+)
+
+def test_m_u_charts():
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.exact_match("gender"),
+            cl.exact_match("tm_partial"),
+            cl.levenshtein_at_thresholds("first_name", [1]),
+            cl.levenshtein_at_thresholds("surname", [1]),
+        ],
+    }
+    linker = DuckDBLinker(df, settings)
+
+    linker.estimate_probability_two_random_records_match(
+        "l.true_match_id = r.true_match_id", recall=1.0
+    )
+
+    # linker.estimate_u_using_random_sampling(1e6)
+    linker.estimate_parameters_using_expectation_maximisation(
+        "l.surname = r.surname",
+        fix_u_probabilities=False,
+        fix_probability_two_random_records_match=True
+    )
+    # linker.estimate_parameters_using_expectation_maximisation("l.first_name = r.first_name", fix_u_probabilities=False, fix_probability_two_random_records_match=True)
+
+    print(linker._settings_obj.as_dict())
+
+    linker.match_weights_chart()
+
+
+def test_parameter_estimate_charts():
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.exact_match("gender"),
+            cl.levenshtein_at_thresholds("first_name", [1]),
+            cl.levenshtein_at_thresholds("surname", [1]),
+        ],
+    }
+    linker = DuckDBLinker(df, settings)
+
+    linker.estimate_probability_two_random_records_match(
+        "l.true_match_id = r.true_match_id", recall=1.0
+    )
+
+    # linker.estimate_u_using_random_sampling(1e6)
+    linker.estimate_parameters_using_expectation_maximisation("l.surname = r.surname", fix_u_probabilities=False, fix_probability_two_random_records_match=True)
+    linker.estimate_parameters_using_expectation_maximisation("l.first_name = r.first_name", fix_u_probabilities=False, fix_probability_two_random_records_match=True)
+
+    print(linker._settings_obj.as_dict())
+
+    linker.parameter_estimate_comparisons_chart()

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,8 +1,8 @@
 import pandas as pd
-import numpy as np
 
 from splink.duckdb.duckdb_linker import DuckDBLinker
 import splink.duckdb.duckdb_comparison_library as cl
+from splink.charts import save_offline_chart
 
 
 # ground truth:
@@ -11,21 +11,113 @@ import splink.duckdb.duckdb_comparison_library as cl
 # surname can be any match level
 df = pd.DataFrame(
     [
-        {"unique_id": 1, "true_match_id": 1, "first_name": "John", "surname": "Smith", "gender": "m", "tm_partial": 1},
-        {"unique_id": 2, "true_match_id": 1, "first_name": "Jon", "surname": "Smith", "gender": "m", "tm_partial": 1},
-        {"unique_id": 3, "true_match_id": 2, "first_name": "Mary", "surname": "Jones", "gender": "f", "tm_partial": None},
-        {"unique_id": 4, "true_match_id": 2, "first_name": "May", "surname": "Jones", "gender": "f", "tm_partial": 2},
-        {"unique_id": 5, "true_match_id": 2, "first_name": "Mary", "surname": "J", "gender": "f", "tm_partial": 2},
-        {"unique_id": 6, "true_match_id": 3, "first_name": "David", "surname": "Greene", "gender": "m", "tm_partial": 3},
-        {"unique_id": 7, "true_match_id": 3, "first_name": "David", "surname": "Green", "gender": "m", "tm_partial": None},
-        {"unique_id": 8, "true_match_id": 4, "first_name": "Sara", "surname": "Smith", "gender": "f", "tm_partial": 4},
-        {"unique_id": 9, "true_match_id": 4, "first_name": "Sarah", "surname": "Smith", "gender": "f", "tm_partial": 4},
-        {"unique_id": 10, "true_match_id": 4, "first_name": "Sarah", "surname": "Smt", "gender": "f", "tm_partial": 4},
-        {"unique_id": 11, "true_match_id": 5, "first_name": "Joan", "surname": "Smith", "gender": "f", "tm_partial": None},
-        {"unique_id": 12, "true_match_id": 6, "first_name": "Kim", "surname": "Greene", "gender": "f", "tm_partial": None},
-        {"unique_id": 13, "true_match_id": 7, "first_name": "Kim", "surname": "Greene", "gender": "m", "tm_partial": 7},
+        {
+            "unique_id": 1,
+            "true_match_id": 1,
+            "first_name": "John",
+            "surname": "Smith",
+            "gender": "m",
+            "tm_partial": 1,
+        },
+        {
+            "unique_id": 2,
+            "true_match_id": 1,
+            "first_name": "Jon",
+            "surname": "Smith",
+            "gender": "m",
+            "tm_partial": 1,
+        },
+        {
+            "unique_id": 3,
+            "true_match_id": 2,
+            "first_name": "Mary",
+            "surname": "Jones",
+            "gender": "f",
+            "tm_partial": None,
+        },
+        {
+            "unique_id": 4,
+            "true_match_id": 2,
+            "first_name": "May",
+            "surname": "Jones",
+            "gender": "f",
+            "tm_partial": 2,
+        },
+        {
+            "unique_id": 5,
+            "true_match_id": 2,
+            "first_name": "Mary",
+            "surname": "J",
+            "gender": "f",
+            "tm_partial": 2,
+        },
+        {
+            "unique_id": 6,
+            "true_match_id": 3,
+            "first_name": "David",
+            "surname": "Greene",
+            "gender": "m",
+            "tm_partial": 3,
+        },
+        {
+            "unique_id": 7,
+            "true_match_id": 3,
+            "first_name": "David",
+            "surname": "Green",
+            "gender": "m",
+            "tm_partial": None,
+        },
+        {
+            "unique_id": 8,
+            "true_match_id": 4,
+            "first_name": "Sara",
+            "surname": "Smith",
+            "gender": "f",
+            "tm_partial": 4,
+        },
+        {
+            "unique_id": 9,
+            "true_match_id": 4,
+            "first_name": "Sarah",
+            "surname": "Smith",
+            "gender": "f",
+            "tm_partial": 4,
+        },
+        {
+            "unique_id": 10,
+            "true_match_id": 4,
+            "first_name": "Sarah",
+            "surname": "Smt",
+            "gender": "f",
+            "tm_partial": 4,
+        },
+        {
+            "unique_id": 11,
+            "true_match_id": 5,
+            "first_name": "Joan",
+            "surname": "Smith",
+            "gender": "f",
+            "tm_partial": None,
+        },
+        {
+            "unique_id": 12,
+            "true_match_id": 6,
+            "first_name": "Kim",
+            "surname": "Greene",
+            "gender": "f",
+            "tm_partial": None,
+        },
+        {
+            "unique_id": 13,
+            "true_match_id": 7,
+            "first_name": "Kim",
+            "surname": "Greene",
+            "gender": "m",
+            "tm_partial": 7,
+        },
     ]
 )
+
 
 def test_m_u_charts():
     settings = {
@@ -33,11 +125,12 @@ def test_m_u_charts():
         "comparisons": [
             cl.exact_match("gender"),
             cl.exact_match("tm_partial"),
-            cl.levenshtein_at_thresholds("first_name", [1]),
+            # cl.levenshtein_at_thresholds("first_name", [1]),
             cl.levenshtein_at_thresholds("surname", [1]),
         ],
     }
     linker = DuckDBLinker(df, settings)
+    linker.debug_mode = True
 
     linker.estimate_probability_two_random_records_match(
         "l.true_match_id = r.true_match_id", recall=1.0
@@ -47,13 +140,14 @@ def test_m_u_charts():
     linker.estimate_parameters_using_expectation_maximisation(
         "l.surname = r.surname",
         fix_u_probabilities=False,
-        fix_probability_two_random_records_match=True
+        fix_probability_two_random_records_match=True,
     )
     # linker.estimate_parameters_using_expectation_maximisation("l.first_name = r.first_name", fix_u_probabilities=False, fix_probability_two_random_records_match=True)
 
     print(linker._settings_obj.as_dict())
 
-    linker.match_weights_chart()
+    chart = linker.match_weights_chart()
+    save_offline_chart(chart, "tmp_test_mw.html", overwrite=True)
 
 
 def test_parameter_estimate_charts():
@@ -66,15 +160,25 @@ def test_parameter_estimate_charts():
         ],
     }
     linker = DuckDBLinker(df, settings)
+    linker.debug_mode = True
 
     linker.estimate_probability_two_random_records_match(
         "l.true_match_id = r.true_match_id", recall=1.0
     )
 
     # linker.estimate_u_using_random_sampling(1e6)
-    linker.estimate_parameters_using_expectation_maximisation("l.surname = r.surname", fix_u_probabilities=False, fix_probability_two_random_records_match=True)
-    linker.estimate_parameters_using_expectation_maximisation("l.first_name = r.first_name", fix_u_probabilities=False, fix_probability_two_random_records_match=True)
+    linker.estimate_parameters_using_expectation_maximisation(
+        "l.surname = r.surname",
+        fix_u_probabilities=False,
+        fix_probability_two_random_records_match=True,
+    )
+    linker.estimate_parameters_using_expectation_maximisation(
+        "l.first_name = r.first_name",
+        fix_u_probabilities=False,
+        fix_probability_two_random_records_match=True,
+    )
 
     print(linker._settings_obj.as_dict())
 
-    linker.parameter_estimate_comparisons_chart()
+    chart = linker.parameter_estimate_comparisons_chart()
+    save_offline_chart(chart, "tmp_test_pe.html", overwrite=True)

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -128,7 +128,6 @@ def test_m_u_charts():
         ],
     }
     linker = DuckDBLinker(df, settings)
-    linker.debug_mode = True
 
     linker.estimate_probability_two_random_records_match(
         "l.true_match_id = r.true_match_id", recall=1.0
@@ -143,7 +142,7 @@ def test_m_u_charts():
     print(linker._settings_obj.as_dict())
     assert linker._settings_obj.comparisons[1].comparison_levels[2].u_probability == 1.0
 
-    chart = linker.match_weights_chart()
+    linker.match_weights_chart()
 
 
 def test_parameter_estimate_charts():
@@ -156,7 +155,6 @@ def test_parameter_estimate_charts():
         ],
     }
     linker = DuckDBLinker(df, settings)
-    linker.debug_mode = True
 
     linker.estimate_probability_two_random_records_match(
         "l.true_match_id = r.true_match_id", recall=1.0
@@ -182,7 +180,7 @@ def test_parameter_estimate_charts():
     ]
     assert 1.0 in exact_gender_m_estimates
 
-    chart = linker.parameter_estimate_comparisons_chart()
+    linker.parameter_estimate_comparisons_chart()
 
     settings = {
         "link_type": "dedupe_only",
@@ -193,7 +191,6 @@ def test_parameter_estimate_charts():
         ],
     }
     linker = DuckDBLinker(df, settings)
-    linker.debug_mode = True
     linker.estimate_u_using_random_sampling(1e6)
 
-    chart = linker.parameter_estimate_comparisons_chart()
+    linker.parameter_estimate_comparisons_chart()

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -87,7 +87,10 @@ def test_splink_converges_to_known_params():
         linker,
     )
 
-    sqls = predict_from_comparison_vectors_sqls(linker._settings_obj)
+    sqls = predict_from_comparison_vectors_sqls(
+        linker._settings_obj,
+        sql_infinity_expression=linker._infinity_expression,
+    )
 
     for sql in sqls:
         linker._enqueue_sql(sql["sql"], sql["output_table_name"])


### PR DESCRIPTION
The main part of this handles:
* unobserved levels in training dataset, which broke parameter-estimate chart
* levels where `m = 1` in individual EM-runs estimates, which broke parameter-estimate chart 
* levels where `u = 0` (either truly so, or in individual EM-runs estimates), which broke parameter-estimate chart and potentially match-weights chart
The latter entails dealing with Bayes factors which are effectively infinite, which required adjusting the prediction sql.

Additionally, I have stopped the linker from directly mutating the passed `settings` dict, and allowed a method for `Linker`s to consistently know what dialect they are (`linker._sql_dialect`), as well as to throw an error if, say a `DuckDBLinker` is passed a `settings` dict with a `sql_dialect` specified as `spark`, and moving some of this logic to the base class. This did not turn out to be necessary to fix the above handling of cases, but have left it in as it seems like it might be a useful error-check.