### PR TITLE
Compound sql parse error

### DIFF
--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -68,6 +68,8 @@ def _exact_match_colname(sql_syntax_tree):
 
 
 def _get_sub_expressions(expr):
+    # get list of subclauses joined together by 'AND' at top-level
+    # e.g. 'A AND B AND C' -> ['A', 'B', 'C']
     if isinstance(expr, sqlglot.exp.And):
         return [*_get_sub_expressions(expr.left), *_get_sub_expressions(expr.right)]
     return [expr]

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -69,7 +69,7 @@ def _exact_match_colname(sql_syntax_tree):
     return cols[0]
 
 
-def _get_and_subclauses(expr):
+def _get_and_subclauses(expr: sqlglot.Expression):
     # get list of subclauses joined together by 'AND' at top-level
     # e.g. 'A AND B AND C' -> ['A', 'B', 'C']
     # or if no AND, return expression as a list, e.g. 'A' -> ['A']

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -29,8 +29,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _is_exact_match(sql, sql_dialect=None):
-    sql_syntax_tree = sqlglot.parse_one(sql, read=sql_dialect)
+def _is_exact_match(sql_syntax_tree):
 
     signature = sqlglot_tree_signature(sql_syntax_tree)
     if signature != "eq column column identifier identifier":
@@ -47,14 +46,13 @@ def _is_exact_match(sql, sql_dialect=None):
         return False
 
 
-def _exact_match_colname(sql, sql_dialect=None):
+def _exact_match_colname(sql_syntax_tree):
     cols = []
-    syntax_tree = sqlglot.parse_one(sql.lower(), read=sql_dialect)
 
-    for identifier in syntax_tree.find_all(Identifier):
+    for identifier in sql_syntax_tree.find_all(Identifier):
         identifier.args["quoted"] = False
 
-    for tup in syntax_tree.walk():
+    for tup in sql_syntax_tree.walk():
         subtree = tup[0]
         depth = getattr(subtree, "depth", None)
         if depth == 2:
@@ -67,6 +65,12 @@ def _exact_match_colname(sql, sql_dialect=None):
             f"Expected sql condition to refer to one column but got {cols}"
         )
     return cols[0]
+
+
+def _get_sub_expressions(expr):
+    if isinstance(expr, sqlglot.exp.And):
+        return [*_get_sub_expressions(expr.left), *_get_sub_expressions(expr.right)]
+    return [expr]
 
 
 def _default_m_values(num_levels):
@@ -458,28 +462,32 @@ class ComparisonLevel:
         if self._is_else_level:
             return False
 
-        sql_syntax_tree = sqlglot.parse_one(self._sql_condition, read=self._sql_dialect)
-        # better to use the tree directly, but for now:
-        sql_cnf = normalize(sql_syntax_tree).sql()
-        sqls = re.split(r" and ", sql_cnf, flags=re.IGNORECASE)
-        for sql in sqls:
-            if not _is_exact_match(sql, self._sql_dialect):
+        sql_syntax_tree = sqlglot.parse_one(self._sql_condition.lower(), read=self._sql_dialect)
+        sql_cnf = normalize(sql_syntax_tree)
+
+        exprs = _get_sub_expressions(sql_cnf)
+        for expr in exprs:
+            print(f"\tprocessing {expr}")
+            if not _is_exact_match(expr):
                 return False
         return True
 
     @property
     def _exact_match_colnames(self):
 
-        sqls = re.split(r" and ", self._sql_condition, flags=re.IGNORECASE)
-        for sql in sqls:
-            if not _is_exact_match(sql):
+        sql_syntax_tree = sqlglot.parse_one(self._sql_condition.lower(), read=self._sql_dialect)
+        sql_cnf = normalize(sql_syntax_tree)
+
+        exprs = _get_sub_expressions(sql_cnf)
+        for expr in exprs:
+            if not _is_exact_match(expr):
                 raise ValueError(
                     "sql_cond not an exact match so can't get exact match column name"
                 )
 
         cols = []
-        for sql in sqls:
-            col = _exact_match_colname(sql, sql_dialect=self._sql_dialect)
+        for expr in exprs:
+            col = _exact_match_colname(expr)
             cols.append(col)
         return cols
 

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -462,12 +462,13 @@ class ComparisonLevel:
         if self._is_else_level:
             return False
 
-        sql_syntax_tree = sqlglot.parse_one(self._sql_condition.lower(), read=self._sql_dialect)
+        sql_syntax_tree = sqlglot.parse_one(
+            self._sql_condition.lower(), read=self._sql_dialect
+        )
         sql_cnf = normalize(sql_syntax_tree)
 
         exprs = _get_sub_expressions(sql_cnf)
         for expr in exprs:
-            print(f"\tprocessing {expr}")
             if not _is_exact_match(expr):
                 return False
         return True
@@ -475,7 +476,9 @@ class ComparisonLevel:
     @property
     def _exact_match_colnames(self):
 
-        sql_syntax_tree = sqlglot.parse_one(self._sql_condition.lower(), read=self._sql_dialect)
+        sql_syntax_tree = sqlglot.parse_one(
+            self._sql_condition.lower(), read=self._sql_dialect
+        )
         sql_cnf = normalize(sql_syntax_tree)
 
         exprs = _get_sub_expressions(sql_cnf)

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -74,7 +74,7 @@ def test_compound_comparison_level():
     def col_is_null(col):
         return f"({col}_l IS NULL OR {col}_r IS NULL)"
 
-    sql_two_out_of_three_match = (
+    sql_and_clauses_joined_with_ors = (
         f"(({col_is_match('first_name')} AND {col_is_match('middle_name')}) OR "
         f"({col_is_match('middle_name')} AND {col_is_match('surname')}) OR "
         f"({col_is_match('surname')} AND {col_is_match('first_name')}))"
@@ -106,8 +106,8 @@ def test_compound_comparison_level():
                         "label_for_charts": "All three match",
                     },
                     {
-                        "sql_condition": sql_two_out_of_three_match,
-                        "label_for_charts": "2/3 match",
+                        "sql_condition": sql_and_clauses_joined_with_ors,
+                        "label_for_charts": "2 out of 3 columns match",
                     },
                     cll.exact_match_level("first_name"),
                     cll.exact_match_level("middle_name"),

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from sqlglot import parse_one
+from sqlglot.optimizer.normalize import normalize
 
 from splink.duckdb.duckdb_linker import DuckDBLinker
 import splink.duckdb.duckdb_comparison_library as cl
@@ -216,3 +218,52 @@ def test_complex_compound_comparison_level():
     linker = DuckDBLinker(df, settings)
 
     linker.estimate_parameters_using_expectation_maximisation("1=1")
+
+
+def test_normalise():
+    # check that the sqlglot normaliser is doing what we think
+    # try to not impose specific form too strongly, so we aren't too tightly
+    # coupled to the implementationß
+    sql_syntax_tree = parse_one("a or (b and c)")
+    sql_cnf = normalize(sql_syntax_tree).sql().lower()
+
+    subclauses_expected = [
+        ["a or c", "c or a"],
+        ["a or b", "b or a"],
+    ]
+
+    # get subclauses and remove outer parens
+    subclauses_found = map(lambda s: s.strip("()"), sql_cnf.split(" and "))
+
+    # loop through subclauses, make sure that we have exactly one of each
+    for found in subclauses_found:
+        term_found = False
+        for i, expected in enumerate(subclauses_expected):
+            if found in expected:
+                del subclauses_expected[i]
+                term_found = True
+                break
+        assert term_found, f"CNF contains unexpected clause '{found}'"
+    assert not subclauses_expected
+
+    # and a slightly more complex statement
+    sql_syntax_tree = parse_one("(a and b) or (a and c) or (c and d) or (d and b)")
+    sql_cnf = normalize(sql_syntax_tree).sql().lower()
+
+    subclauses_expected = [
+        ["b or c", "c or b"],
+        ["a or d", "d or a"],
+    ]
+
+    subclauses_found = map(lambda s: s.strip("()"), sql_cnf.split(" and "))
+
+    # loop through subclauses, make sure that we have exactly one of each
+    for found in subclauses_found:
+        term_found = False
+        for i, expected in enumerate(subclauses_expected):
+            if found in expected:
+                del subclauses_expected[i]
+                term_found = True
+                break
+        assert term_found, f"CNF contains unexpected clause '{found}'"
+    assert not subclauses_expected

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -121,3 +121,91 @@ def test_compound_comparison_level():
     linker = DuckDBLinker(df, settings)
 
     linker.estimate_parameters_using_expectation_maximisation("l.city = r.city")
+
+
+def test_complex_compound_comparison_level():
+
+    # non-realistic example
+    df = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "col_1": "a",
+                "col_2": "b",
+                "col_3": "c",
+                "col_4": "d",
+                "col_5": "e",
+                "col_6": "f",
+                "col_7": "g",
+            },
+            {
+                "unique_id": 2,
+                "col_1": "aa",
+                "col_2": "b",
+                "col_3": "cc",
+                "col_4": "d",
+                "col_5": "ee",
+                "col_6": "f",
+                "col_7": "gg",
+            },
+            {
+                "unique_id": 3,
+                "col_1": "a",
+                "col_2": "bb",
+                "col_3": "c",
+                "col_4": "dd",
+                "col_5": "e",
+                "col_6": "ff",
+                "col_7": "g",
+            },
+            {
+                "unique_id": 4,
+                "col_1": "aa",
+                "col_2": "bb",
+                "col_3": "cc",
+                "col_4": "d",
+                "col_5": "ee",
+                "col_6": "ff",
+                "col_7": "gg",
+            },
+        ]
+    )
+    A, B, C, D, E, F, G = (
+        "col_1_l = col_1_r",
+        "col_2_l = col_2_r",
+        "col_3_l = col_3_r",
+        "col_4_l = col_4_r",
+        "col_5_l = col_5_r",
+        "col_6_l = col_6_r",
+        "col_7_l = col_7_r",
+    )
+
+    complex_condition_sql = " OR ".join(
+        [
+            f"({A} AND {B})",
+            f"NOT ({C} AND {D})",
+            f"({B} AND NOT {E})",
+            f"({F} AND (NOT {A} AND {G}))",
+        ]
+    )
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            {
+                "output_column_name": "my_comparison",
+                "comparison_levels": [
+                    cll.null_level("col_1"),
+                    cll.exact_match_level("col_7"),
+                    cll.exact_match_level("col_3"),
+                    {
+                        "sql_condition": complex_condition_sql,
+                        "label_for_charts": "complex condition",
+                    },
+                    cll.else_level(),
+                ],
+            }
+        ],
+    }
+    linker = DuckDBLinker(df, settings)
+
+    linker.estimate_parameters_using_expectation_maximisation("1=1")

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -1,0 +1,123 @@
+import pandas as pd
+
+from splink.duckdb.duckdb_linker import DuckDBLinker
+import splink.duckdb.duckdb_comparison_library as cl
+import splink.duckdb.duckdb_comparison_level_library as cll
+
+
+def test_compound_comparison_level():
+
+    df = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "first_name": "John",
+                "middle_name": "James",
+                "surname": "Smith",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 2,
+                "first_name": "Mary",
+                "middle_name": "Harriet",
+                "surname": "Jones",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 3,
+                "first_name": "Jane",
+                "middle_name": "Joan",
+                "surname": "Taylor",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 4,
+                "first_name": "John",
+                "middle_name": "Blake",
+                "surname": "Jones",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 5,
+                "first_name": "Jane",
+                "middle_name": "Joan",
+                "surname": "Taylor",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 6,
+                "first_name": "Gill",
+                "middle_name": "Harriet",
+                "surname": "Greene",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 7,
+                "first_name": "Owen",
+                "middle_name": "James",
+                "surname": "Smith",
+                "city": "Brighton",
+            },
+            {
+                "unique_id": 8,
+                "first_name": "Sarah",
+                "middle_name": "Simone",
+                "surname": "Williams",
+                "city": "Brighton",
+            },
+        ]
+    )
+
+    def col_is_match(col):
+        return f"({col}_l = {col}_r)"
+
+    def col_is_null(col):
+        return f"({col}_l IS NULL OR {col}_r IS NULL)"
+
+    sql_two_out_of_three_match = (
+        f"(({col_is_match('first_name')} AND {col_is_match('middle_name')}) OR "
+        f"({col_is_match('middle_name')} AND {col_is_match('surname')}) OR "
+        f"({col_is_match('surname')} AND {col_is_match('first_name')}))"
+    )
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.exact_match("city"),
+            {
+                "output_column_name": "company_comparison",
+                "comparison_levels": [
+                    {
+                        "sql_condition": (
+                            f"{col_is_null('first_name')} AND "
+                            f"{col_is_null('middle_name')} AND "
+                            f"{col_is_null('surname')}"
+                        ),
+                        "label_for_charts": "NULL",
+                        "is_null_level": True,
+                    },
+                    # ignoring other permutations of NULL
+                    {
+                        "sql_condition": (
+                            f"{col_is_match('first_name')} AND "
+                            f"{col_is_match('middle_name')} AND "
+                            f"{col_is_match('surname')}"
+                        ),
+                        "label_for_charts": "All three match",
+                    },
+                    {
+                        "sql_condition": sql_two_out_of_three_match,
+                        "label_for_charts": "2/3 match",
+                    },
+                    cll.exact_match_level("first_name"),
+                    cll.exact_match_level("middle_name"),
+                    cll.exact_match_level("surname"),
+                    cll.else_level(),
+                ],
+            },
+        ],
+    }
+
+    linker = DuckDBLinker(df, settings)
+
+    linker.estimate_parameters_using_expectation_maximisation("l.city = r.city")

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -119,6 +119,13 @@ def test_compound_comparison_level():
     }
 
     linker = DuckDBLinker(df, settings)
+    all_cols_match_level = linker._settings_obj.comparisons[1].comparison_levels[1]
+    assert all_cols_match_level._is_exact_match
+    assert set(all_cols_match_level._exact_match_colnames) == {
+        "first_name",
+        "middle_name",
+        "surname",
+    }
 
     linker.estimate_parameters_using_expectation_maximisation("l.city = r.city")
 


### PR DESCRIPTION
Solves issue where compound expressions in comparison levels could break EM-training, by transforming SQL to [conjunctive normal form](https://en.wikipedia.org/wiki/Conjunctive_normal_form). Internal functions that determine exact-match status now work with `sqlglot` ASTs directly rather than raw SQL, to avoid having to parse multiple times.

Big thanks to @tobymao for pointing me in the direction of `sqlglot`'s `normalise` function to transform SQL into conjunctive normal form, which is doing the heavy lifting here.

Fixes #894.