### PR TITLE
Fix width per bar rather than per facet in charts

### DIFF
--- a/splink/files/chart_defs/m_u_parameters_interactive_history.json
+++ b/splink/files/chart_defs/m_u_parameters_interactive_history.json
@@ -125,7 +125,7 @@
         }
       ],
       "width": 150,
-      "height": 50
+      "height": {"step": 12} 
     },
     {
       "mark": "bar",
@@ -224,7 +224,7 @@
         }
       ],
       "width": 150,
-      "height": 50
+      "height": {"step": 12} 
     }
   ],
   "data": {

--- a/splink/files/chart_defs/match_weights_interactive_history.json
+++ b/splink/files/chart_defs/match_weights_interactive_history.json
@@ -37,8 +37,8 @@
   ],
   "vconcat": [
     {
-      "height": 30,
-      "mark": { "type": "bar", "clip": true, "height": 20 },
+      "height": 20,
+      "mark": { "type": "bar", "clip": true, "height": 15 },
       "selection": {
         "zoom_selector": {
           "type": "interval",
@@ -110,6 +110,7 @@
       }
     },
     {
+      "height": {"step": 12},
       "mark": { "type": "bar", "clip": true },
       "selection": {
         "zoom_selector": {


### PR DESCRIPTION
Width per facet is currently fixed so many levels result in thin bars and overlapping labels while few levels result in unnecessarily large bars.

# Before
<img width="1155" alt="Screenshot 2022-11-21 at 18 07 19" src="https://user-images.githubusercontent.com/7570107/203129310-17575af0-341d-496a-9de7-26692fac1774.png">


# After
<img width="1000" alt="Screenshot 2022-11-21 at 18 07 41" src="https://user-images.githubusercontent.com/7570107/203130134-cfda44ba-74e8-4adc-8a3a-3c6ccc483354.png">

(same change made to m_u_parameters chart)
