### PR TITLE
Return settings dict from save_settings_to_json()

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import List, Union
 from copy import Error, copy, deepcopy
@@ -2188,31 +2190,35 @@ class Linker:
         if return_html_as_string:
             return rendered
 
-    def save_settings_to_json(self, out_path: str, overwrite=False) -> dict:
-        """Save the configuration and parameters the linkage model to a `.json` file.
+    def save_settings_to_json(
+        self, out_path: str | None = None, overwrite: bool = False
+    ) -> dict:
+        """Save the configuration and parameters of the linkage model to a `.json` file.
 
-        The model can later be loaded back in using `linker.load_settings_from_json()`
+        The model can later be loaded back in using `linker.load_settings_from_json()`.
+        The settings dict is also returned in case you want to save it a different way.
 
         Examples:
             >>> linker.save_settings_to_json("my_settings.json", overwrite=True)
 
         Args:
-            out_path (str): File path for json file
+            out_path (str, optional): File path for json file. If None, don't save to
+                file. Defaults to None.
             overwrite (bool, optional): Overwrite if already exists? Defaults to False.
+
+        Returns:
+            dict: The settings as a dictionary.
         """
-
         model_dict = self._settings_obj.as_dict()
-
         if out_path:
-
             if os.path.isfile(out_path) and not overwrite:
                 raise ValueError(
                     f"The path {out_path} already exists. Please provide a different "
                     "path or set overwrite=True"
                 )
-
             with open(out_path, "w", encoding="utf-8") as f:
                 json.dump(model_dict, f, indent=4)
+        return model_dict
 
     def load_settings_from_json(self, in_path: str):
         """Load settings from a `.json` file.


### PR DESCRIPTION
This allows
- modifying the settings before storing
- storing the settings in a different format,
  eg yaml on a remote machine.

This also makes the function actually follow its type hint.

In an ideal world the function might want to get renamed to
simply `save_settings()` but I didn't want to make that
assumption/break anyone.