### PR TITLE
Remove mutable params

### DIFF
--- a/splink/athena/athena_base.py
+++ b/splink/athena/athena_base.py
@@ -1,0 +1,21 @@
+from ..dialect_base import (
+    DialectBase,
+)
+
+
+def size_array_intersect_sql(col_name_l, col_name_r):
+    return f"cardinality(array_intersect({col_name_l}, {col_name_r}))"
+
+
+class AthenaBase(DialectBase):
+    @property
+    def _sql_dialect(self):
+        return "presto"
+
+    @property
+    def _levenshtein_name(self):
+        return "levenshtein_distance"
+
+    @property
+    def _size_array_intersect_function(self):
+        return size_array_intersect_sql

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -1,10 +1,10 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    exact_match_level,
+    ExactMatchLevelBase,
     LevenshteinLevelBase,
     DistanceFunctionLevelBase,
     ElseLevelBase,
-    null_level,
+    NullLevelBase,
     ColumnsReversedLevelBase,
     DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
@@ -14,6 +14,14 @@ from .athena_base import (
 )
 
 _mutable_params["dialect"] = "presto"
+
+
+class null_level(AthenaBase, NullLevelBase):
+    pass
+
+
+class exact_match_level(AthenaBase, ExactMatchLevelBase):
+    pass
 
 
 class else_level(AthenaBase, ElseLevelBase):

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -3,7 +3,6 @@ from ..comparison_level_library import (  # noqa: F401
     DialectLevel,
     exact_match_level,
     LevenshteinLevelBase,
-    levenshtein_level,
     DistanceFunctionLevelBase,
     else_level,
     null_level,
@@ -33,11 +32,14 @@ class AthenaLevel(DialectLevel):
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
 
+
 class distance_function_level(AthenaLevel, DistanceFunctionLevelBase):
     pass
 
+
 class levenshtein_level(AthenaLevel, LevenshteinLevelBase):
     pass
+
 
 class array_intersect_level(ArrayIntersectLevelBase):
     pass

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -1,5 +1,4 @@
-from ..comparison_level_library import (  # noqa: F401
-    _mutable_params,
+from ..comparison_level_library import (
     ExactMatchLevelBase,
     LevenshteinLevelBase,
     DistanceFunctionLevelBase,
@@ -12,8 +11,6 @@ from ..comparison_level_library import (  # noqa: F401
 from .athena_base import (
     AthenaBase,
 )
-
-_mutable_params["dialect"] = "presto"
 
 
 class null_level(AthenaBase, NullLevelBase):

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -5,6 +5,7 @@ from ..comparison_level_library import (
     ElseLevelBase,
     NullLevelBase,
     ColumnsReversedLevelBase,
+    PercentageDifferenceLevelBase,
     DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
 )
@@ -38,6 +39,10 @@ class levenshtein_level(AthenaBase, LevenshteinLevelBase):
 
 
 class array_intersect_level(AthenaBase, ArrayIntersectLevelBase):
+    pass
+
+
+class percentage_difference_level(AthenaBase, PercentageDifferenceLevelBase):
     pass
 
 

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -3,9 +3,9 @@ from ..comparison_level_library import (  # noqa: F401
     exact_match_level,
     LevenshteinLevelBase,
     DistanceFunctionLevelBase,
-    else_level,
+    ElseLevelBase,
     null_level,
-    columns_reversed_level,
+    ColumnsReversedLevelBase,
     DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
 )
@@ -14,6 +14,14 @@ from .athena_base import (
 )
 
 _mutable_params["dialect"] = "presto"
+
+
+class else_level(AthenaBase, ElseLevelBase):
+    pass
+
+
+class columns_reversed_level(AthenaBase, ColumnsReversedLevelBase):
+    pass
 
 
 class distance_function_level(AthenaBase, DistanceFunctionLevelBase):

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -2,6 +2,7 @@ from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
     DialectLevel,
     exact_match_level,
+    LevenshteinLevelBase,
     levenshtein_level,
     DistanceFunctionLevelBase,
     else_level,
@@ -17,7 +18,6 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 
 
 _mutable_params["dialect"] = "presto"
-_mutable_params["levenshtein"] = "levenshtein_distance"
 
 
 class AthenaLevel(DialectLevel):
@@ -26,12 +26,18 @@ class AthenaLevel(DialectLevel):
         return "presto"
 
     @property
+    def _levenshtein_name(self):
+        return "levenshtein_distance"
+
+    @property
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
 
 class distance_function_level(AthenaLevel, DistanceFunctionLevelBase):
     pass
 
+class levenshtein_level(AthenaLevel, LevenshteinLevelBase):
+    pass
 
 class array_intersect_level(ArrayIntersectLevelBase):
     pass

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -1,6 +1,5 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    DialectLevel,
     exact_match_level,
     LevenshteinLevelBase,
     DistanceFunctionLevelBase,
@@ -10,34 +9,18 @@ from ..comparison_level_library import (  # noqa: F401
     distance_in_km_level,
     ArrayIntersectLevelBase,
 )
-
-
-def size_array_intersect_sql(col_name_l, col_name_r):
-    return f"cardinality(array_intersect({col_name_l}, {col_name_r}))"
-
+from .athena_base import (
+    AthenaBase,
+)
 
 _mutable_params["dialect"] = "presto"
 
 
-class AthenaLevel(DialectLevel):
-    @property
-    def _sql_dialect(self):
-        return "presto"
-
-    @property
-    def _levenshtein_name(self):
-        return "levenshtein_distance"
-
-    @property
-    def _size_array_intersect_function(self):
-        return size_array_intersect_sql
-
-
-class distance_function_level(AthenaLevel, DistanceFunctionLevelBase):
+class distance_function_level(AthenaBase, DistanceFunctionLevelBase):
     pass
 
 
-class levenshtein_level(AthenaLevel, LevenshteinLevelBase):
+class levenshtein_level(AthenaBase, LevenshteinLevelBase):
     pass
 
 

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -1,7 +1,9 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
+    DialectLevel,
     exact_match_level,
     levenshtein_level,
+    DistanceFunctionLevelBase,
     else_level,
     null_level,
     columns_reversed_level,
@@ -18,7 +20,7 @@ _mutable_params["dialect"] = "presto"
 _mutable_params["levenshtein"] = "levenshtein_distance"
 
 
-class array_intersect_level(ArrayIntersectLevelBase):
+class AthenaLevel(DialectLevel):
     @property
     def _sql_dialect(self):
         return "presto"
@@ -26,3 +28,10 @@ class array_intersect_level(ArrayIntersectLevelBase):
     @property
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
+
+class distance_function_level(AthenaLevel, DistanceFunctionLevelBase):
+    pass
+
+
+class array_intersect_level(ArrayIntersectLevelBase):
+    pass

--- a/splink/athena/athena_comparison_level_library.py
+++ b/splink/athena/athena_comparison_level_library.py
@@ -6,7 +6,7 @@ from ..comparison_level_library import (  # noqa: F401
     else_level,
     null_level,
     columns_reversed_level,
-    distance_in_km_level,
+    DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
 )
 from .athena_base import (
@@ -24,5 +24,9 @@ class levenshtein_level(AthenaBase, LevenshteinLevelBase):
     pass
 
 
-class array_intersect_level(ArrayIntersectLevelBase):
+class array_intersect_level(AthenaBase, ArrayIntersectLevelBase):
+    pass
+
+
+class distance_in_km_level(AthenaBase, DistanceInKMLevelBase):
     pass

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -5,19 +5,29 @@ from ..comparison_level_library import (
 
 from ..comparison_library import (  # noqa: F401
     exact_match,
-    levenshtein_at_thresholds,
+    DistanceFunctionAtThresholdsComparisonBase,
+    LevenshteinAtThresholdsComparisonBase,
     ArrayIntersectAtSizesComparisonBase,
 )
 
-from .athena_comparison_level_library import (
-    array_intersect_level,
+from .athena_base import (
+    AthenaBase,
 )
 
 _mutable_params["dialect"] = "presto"
-_mutable_params["levenshtein"] = "levenshtein_distance"
 
 
-class array_intersect_at_sizes(ArrayIntersectAtSizesComparisonBase):
-    @property
-    def _array_intersect_level(self):
-        return array_intersect_level
+class distance_function_at_thresholds(
+    AthenaBase, DistanceFunctionAtThresholdsComparisonBase
+):
+    pass
+
+
+class levenshtein_at_thresholds(
+    AthenaBase, LevenshteinAtThresholdsComparisonBase
+):
+    pass
+
+
+class array_intersect_at_sizes(AthenaBase, ArrayIntersectAtSizesComparisonBase):
+    pass

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -16,6 +16,7 @@ from .athena_base import (
 from .athena_comparison_level_library import (
     distance_function_level,
     levenshtein_level,
+    array_intersect_level,
 )
 
 _mutable_params["dialect"] = "presto"
@@ -38,4 +39,6 @@ class levenshtein_at_thresholds(
 
 
 class array_intersect_at_sizes(AthenaBase, ArrayIntersectAtSizesComparisonBase):
-    pass
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -4,7 +4,7 @@ from ..comparison_level_library import (
 
 
 from ..comparison_library import (  # noqa: F401
-    exact_match,
+    ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
     ArrayIntersectAtSizesComparisonBase,
@@ -14,6 +14,7 @@ from .athena_base import (
     AthenaBase,
 )
 from .athena_comparison_level_library import (
+    else_level,
     distance_function_level,
     levenshtein_level,
     array_intersect_level,
@@ -22,21 +23,33 @@ from .athena_comparison_level_library import (
 _mutable_params["dialect"] = "presto"
 
 
+class AthenaComparison(AthenaBase):
+    @property
+    def _else_level(self):
+        return else_level
+
+
+class exact_match(AthenaComparison, ExactMatchBase):
+    pass
+
+
 class distance_function_at_thresholds(
-    AthenaBase, DistanceFunctionAtThresholdsComparisonBase
+    AthenaComparison, DistanceFunctionAtThresholdsComparisonBase
 ):
     @property
     def _distance_level(self):
         return distance_function_level
 
 
-class levenshtein_at_thresholds(AthenaBase, LevenshteinAtThresholdsComparisonBase):
+class levenshtein_at_thresholds(
+    AthenaComparison, LevenshteinAtThresholdsComparisonBase
+):
     @property
     def _distance_level(self):
         return levenshtein_level
 
 
-class array_intersect_at_sizes(AthenaBase, ArrayIntersectAtSizesComparisonBase):
+class array_intersect_at_sizes(AthenaComparison, ArrayIntersectAtSizesComparisonBase):
     @property
     def _array_intersect_level(self):
         return array_intersect_level

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -14,6 +14,8 @@ from .athena_base import (
     AthenaBase,
 )
 from .athena_comparison_level_library import (
+    exact_match_level,
+    null_level,
     else_level,
     distance_function_level,
     levenshtein_level,
@@ -24,6 +26,14 @@ _mutable_params["dialect"] = "presto"
 
 
 class AthenaComparison(AthenaBase):
+    @property
+    def _exact_match_level(self):
+        return exact_match_level
+
+    @property
+    def _null_level(self):
+        return null_level
+
     @property
     def _else_level(self):
         return else_level

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -13,6 +13,10 @@ from ..comparison_library import (  # noqa: F401
 from .athena_base import (
     AthenaBase,
 )
+from .athena_comparison_level_library import (
+    distance_function_level,
+    levenshtein_level,
+)
 
 _mutable_params["dialect"] = "presto"
 
@@ -20,13 +24,17 @@ _mutable_params["dialect"] = "presto"
 class distance_function_at_thresholds(
     AthenaBase, DistanceFunctionAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return distance_function_level
 
 
 class levenshtein_at_thresholds(
     AthenaBase, LevenshteinAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return levenshtein_level
 
 
 class array_intersect_at_sizes(AthenaBase, ArrayIntersectAtSizesComparisonBase):

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -30,9 +30,7 @@ class distance_function_at_thresholds(
         return distance_function_level
 
 
-class levenshtein_at_thresholds(
-    AthenaBase, LevenshteinAtThresholdsComparisonBase
-):
+class levenshtein_at_thresholds(AthenaBase, LevenshteinAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return levenshtein_level

--- a/splink/athena/athena_comparison_library.py
+++ b/splink/athena/athena_comparison_library.py
@@ -1,9 +1,4 @@
-from ..comparison_level_library import (
-    _mutable_params,
-)
-
-
-from ..comparison_library import (  # noqa: F401
+from ..comparison_library import (
     ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
@@ -21,8 +16,6 @@ from .athena_comparison_level_library import (
     levenshtein_level,
     array_intersect_level,
 )
-
-_mutable_params["dialect"] = "presto"
 
 
 class AthenaComparison(AthenaBase):

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -10,9 +10,9 @@ from .comparison_level_sql import great_circle_distance_km_sql
 # DuckDBComparisonLevel etc.
 _mutable_params = {
     "dialect": None,
-    "levenshtein": "levenshtein",
-    "jaro_winkler": "jaro_winkler",
-    "size_array_intersect_function": None,
+    # "levenshtein": "levenshtein",
+    # "jaro_winkler": "jaro_winkler",
+    # "size_array_intersect_function": None,
 }
 # defines default values for dialect-dependent properties
 class DialectLevel():
@@ -20,6 +20,10 @@ class DialectLevel():
     @property
     def _sql_dialect(self):
         raise NotImplementedError("No SQL dialect specified")
+
+    @property
+    def _levenshtein_name(self):
+        return "levenshtein"
 
     @property
     def _jaro_winkler_name(self):
@@ -114,31 +118,32 @@ def exact_match_level(
     return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
 
 
-def levenshtein_level(
-    col_name: str,
-    distance_threshold: int,
-    m_probability=None,
-) -> ComparisonLevel:
-    """Represents a comparison using a levenshtein distance function,
+class LevenshteinLevelBase(DistanceFunctionLevelBase):
+    def __init__(
+        self,
+        col_name: str,
+        distance_threshold: int,
+        m_probability=None,
+    ) -> ComparisonLevel:
+        """Represents a comparison using a levenshtein distance function,
 
-    Args:
-        col_name (str): Input column name
-        distance_threshold (Union[int, float]): The threshold to use to assess
-            similarity
-        m_probability (float, optional): Starting value for m probability. Defaults to
-            None.
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+            m_probability (float, optional): Starting value for m probability. Defaults to
+                None.
 
-    Returns:
-        ComparisonLevel: A comparison level that evaluates the levenshtein similarity
-    """
-    lev_name = _mutable_params["levenshtein"]
-    return distance_function_level(
-        col_name,
-        lev_name,
-        distance_threshold,
-        False,
-        m_probability=m_probability,
-    )
+        Returns:
+            ComparisonLevel: A comparison level that evaluates the levenshtein similarity
+        """
+        super.__init__(
+            col_name,
+            self._levenshtein_name,
+            distance_threshold,
+            False,
+            m_probability=m_probability,
+        )
 
 
 class JaroWinklerLevelBase(DistanceFunctionLevelBase):

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -315,29 +315,31 @@ class DistanceInKMLevelBase(ComparisonLevel):
         super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
 
-def percentage_difference_level(
-    col_name: str,
-    percentage_distance_threshold: float,
-    m_probability=None,
-):
-    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+class PercentageDifferenceLevelBase(ComparisonLevel):
+    def __init__(
+        self,
+        col_name: str,
+        percentage_distance_threshold: float,
+        m_probability=None,
+    ):
+        col = InputColumn(col_name, sql_dialect=self._sql_dialect)
 
-    s = f"""(abs({col.name_l()} - {col.name_r()})/
-        (case
-            when {col.name_r()} > {col.name_l()}
-            then {col.name_r()}
-            else {col.name_l()}
-        end))
-        < {percentage_distance_threshold}"""
+        s = f"""(abs({col.name_l()} - {col.name_r()})/
+            (case
+                when {col.name_r()} > {col.name_l()}
+                then {col.name_r()}
+                else {col.name_l()}
+            end))
+            < {percentage_distance_threshold}"""
 
-    level_dict = {
-        "sql_condition": s,
-        "label_for_charts": f"< {percentage_distance_threshold:,.2%} diff",
-    }
-    if m_probability:
-        level_dict["m_probability"] = m_probability
+        level_dict = {
+            "sql_condition": s,
+            "label_for_charts": f"< {percentage_distance_threshold:,.2%} diff",
+        }
+        if m_probability:
+            level_dict["m_probability"] = m_probability
 
-    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+        super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
 
 class ArrayIntersectLevelBase(ComparisonLevel):

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -69,45 +69,49 @@ class DistanceFunctionLevelBase(ComparisonLevel):
         raise NotImplementedError("Distance function not supported in this dialect")
 
 
-def null_level(col_name) -> ComparisonLevel:
-    """Represents comparisons where one or both sides of the comparison
-    contains null values so the similarity cannot be evaluated.
-    Assumed to have a partial match weight of zero (null effect on overall match weight)
-    Args:
-        col_name (str): Input column name
-    Returns:
-        ComparisonLevel: Comparison level
-    """
+class NullLevelBase(ComparisonLevel):
+    def __init__(self, col_name) -> ComparisonLevel:
+        """Represents comparisons where one or both sides of the comparison
+        contains null values so the similarity cannot be evaluated.
+        Assumed to have a partial match weight of zero (null effect
+        on overall match weight)
+        Args:
+            col_name (str): Input column name
+        Returns:
+            ComparisonLevel: Comparison level
+        """
 
-    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
-    level_dict = {
-        "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
-        "label_for_charts": "Null",
-        "is_null_level": True,
-    }
-    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+        col = InputColumn(col_name, sql_dialect=self._sql_dialect)
+        level_dict = {
+            "sql_condition": f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL",
+            "label_for_charts": "Null",
+            "is_null_level": True,
+        }
+        super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
 
-def exact_match_level(
-    col_name,
-    m_probability=None,
-    term_frequency_adjustments=False,
-    include_colname_in_charts_label=False,
-) -> ComparisonLevel:
+class ExactMatchLevelBase(ComparisonLevel):
+    def __init__(
+        self,
+        col_name,
+        m_probability=None,
+        term_frequency_adjustments=False,
+        include_colname_in_charts_label=False,
+    ) -> ComparisonLevel:
 
-    col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+        col = InputColumn(col_name, sql_dialect=self._sql_dialect)
 
-    label_suffix = f" {col_name}" if include_colname_in_charts_label else ""
-    level_dict = {
-        "sql_condition": f"{col.name_l()} = {col.name_r()}",
-        "label_for_charts": f"Exact match{label_suffix}",
-    }
-    if m_probability:
-        level_dict["m_probability"] = m_probability
-    if term_frequency_adjustments:
-        level_dict["tf_adjustment_column"] = col_name
+        label_suffix = f" {col_name}" if include_colname_in_charts_label else ""
+        level_dict = {
+            "sql_condition": f"{col.name_l()} = {col.name_r()}",
+            "label_for_charts": f"Exact match{label_suffix}",
+        }
+        if m_probability:
+            level_dict["m_probability"] = m_probability
+        if term_frequency_adjustments:
+            level_dict["tf_adjustment_column"] = col_name
 
-    return ComparisonLevel(level_dict, sql_dialect=_mutable_params["dialect"])
+        super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
 
 class LevenshteinLevelBase(DistanceFunctionLevelBase):

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -15,6 +15,7 @@ _mutable_params = {
     # "size_array_intersect_function": None,
 }
 
+
 class DistanceFunctionLevelBase(ComparisonLevel):
     def __init__(
         self,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -5,17 +5,6 @@ from .comparison_level import ComparisonLevel
 from .comparison_level_sql import great_circle_distance_km_sql
 
 
-# So that we can pass in a sql_dialect to the comparison levels
-# that is different depending on whether we're in a SparkComparionLevel,
-# DuckDBComparisonLevel etc.
-_mutable_params = {
-    "dialect": None,
-    # "levenshtein": "levenshtein",
-    # "jaro_winkler": "jaro_winkler",
-    # "size_array_intersect_function": None,
-}
-
-
 class DistanceFunctionLevelBase(ComparisonLevel):
     def __init__(
         self,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -15,26 +15,6 @@ _mutable_params = {
     # "size_array_intersect_function": None,
 }
 
-
-# defines default values for dialect-dependent properties
-class DialectLevel:
-    @property
-    def _sql_dialect(self):
-        raise NotImplementedError("No SQL dialect specified")
-
-    @property
-    def _levenshtein_name(self):
-        return "levenshtein"
-
-    @property
-    def _jaro_winkler_name(self):
-        return "jaro_winkler"
-
-    @property
-    def _jaccard_name(self):
-        return "jaccard"
-
-
 class DistanceFunctionLevelBase(ComparisonLevel):
     def __init__(
         self,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -26,7 +26,7 @@ class DialectLevel():
         return "jaro_winkler"
 
 
-class distance_function_level(ComparisonLevel):
+class DistanceFunctionLevelBase(ComparisonLevel):
     def __init__(
         self,
         col_name: str,
@@ -52,7 +52,7 @@ class distance_function_level(ComparisonLevel):
         Returns:
             ComparisonLevel: A comparison level for a given distance function
         """
-        col = InputColumn(col_name, sql_dialect=_mutable_params["dialect"])
+        col = InputColumn(col_name, sql_dialect=self._sql_dialect)
 
         if higher_is_more_similar:
             operator = ">="
@@ -70,7 +70,7 @@ class distance_function_level(ComparisonLevel):
         if m_probability:
             level_dict["m_probability"] = m_probability
 
-        super().__init__(level_dict, sql_dialect=_mutable_params["dialect"])
+        super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
 
 def null_level(col_name) -> ComparisonLevel:
@@ -141,7 +141,7 @@ def levenshtein_level(
     )
 
 
-class JaroWinklerLevelBase(distance_function_level):
+class JaroWinklerLevelBase(DistanceFunctionLevelBase):
     def __init__(
         self,
         col_name: str,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -63,6 +63,10 @@ class DistanceFunctionLevelBase(ComparisonLevel):
 
         super().__init__(level_dict, sql_dialect=self._sql_dialect)
 
+    @property
+    def _distance_level(self):
+        raise NotImplementedError("Distance function not supported in this dialect")
+
 
 def null_level(col_name) -> ComparisonLevel:
     """Represents comparisons where one or both sides of the comparison
@@ -125,7 +129,7 @@ class LevenshteinLevelBase(DistanceFunctionLevelBase):
             ComparisonLevel: A comparison level that evaluates the
                 levenshtein similarity
         """
-        super.__init__(
+        super().__init__(
             col_name,
             self._levenshtein_name,
             distance_threshold,
@@ -189,7 +193,7 @@ class JaccardLevelBase(DistanceFunctionLevelBase):
         Returns:
             ComparisonLevel: A comparison level that evaluates the jaccard similarity
         """
-        super.__init__(
+        super().__init__(
             col_name,
             self._jaccard_name,
             distance_threshold,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -14,9 +14,10 @@ _mutable_params = {
     # "jaro_winkler": "jaro_winkler",
     # "size_array_intersect_function": None,
 }
-# defines default values for dialect-dependent properties
-class DialectLevel():
 
+
+# defines default values for dialect-dependent properties
+class DialectLevel:
     @property
     def _sql_dialect(self):
         raise NotImplementedError("No SQL dialect specified")
@@ -28,6 +29,10 @@ class DialectLevel():
     @property
     def _jaro_winkler_name(self):
         return "jaro_winkler"
+
+    @property
+    def _jaccard_name(self):
+        return "jaccard"
 
 
 class DistanceFunctionLevelBase(ComparisonLevel):
@@ -47,11 +52,12 @@ class DistanceFunctionLevelBase(ComparisonLevel):
             distance_function_name (str): The name of the distance function
             distance_threshold (Union[int, float]): The threshold to use to assess
                 similarity
-            higher_is_more_similar (bool): If True, a higher value of the distance function
-                indicates a higher similarity (e.g. jaro_winkler).  If false, a higher
-                value indicates a lower similarity (e.g. levenshtein).
-            m_probability (float, optional): Starting value for m probability. Defaults to
-                None.
+            higher_is_more_similar (bool): If True, a higher value of the
+                distance function indicates a higher similarity (e.g. jaro_winkler).
+                If false, a higher value indicates a lower similarity
+                (e.g. levenshtein).
+            m_probability (float, optional): Starting value for m probability
+                Defaults to None.
 
         Returns:
             ComparisonLevel: A comparison level for a given distance function
@@ -67,9 +73,10 @@ class DistanceFunctionLevelBase(ComparisonLevel):
             f"{distance_function_name}({col.name_l()}, {col.name_r()}) "
             f"{operator} {distance_threshold}"
         )
+        chart_label = f"{distance_function_name} {operator} {distance_threshold}"
         level_dict = {
             "sql_condition": sql_cond,
-            "label_for_charts": f"{distance_function_name} {operator} {distance_threshold}",
+            "label_for_charts": chart_label,
         }
         if m_probability:
             level_dict["m_probability"] = m_probability
@@ -131,11 +138,12 @@ class LevenshteinLevelBase(DistanceFunctionLevelBase):
             col_name (str): Input column name
             distance_threshold (Union[int, float]): The threshold to use to assess
                 similarity
-            m_probability (float, optional): Starting value for m probability. Defaults to
-                None.
+            m_probability (float, optional): Starting value for m probability.
+                Defaults to None.
 
         Returns:
-            ComparisonLevel: A comparison level that evaluates the levenshtein similarity
+            ComparisonLevel: A comparison level that evaluates the
+                levenshtein similarity
         """
         super.__init__(
             col_name,
@@ -159,11 +167,12 @@ class JaroWinklerLevelBase(DistanceFunctionLevelBase):
             col_name (str): Input column name
             distance_threshold (Union[int, float]): The threshold to use to assess
                 similarity
-            m_probability (float, optional): Starting value for m probability. Defaults to
-                None.
+            m_probability (float, optional): Starting value for m probability.
+                Defaults to None.
 
         Returns:
-            ComparisonLevel: A comparison level that evaluates the jaro winkler similarity
+            ComparisonLevel: A comparison level that evaluates the
+                jaro winkler similarity
         """
 
         super().__init__(
@@ -176,33 +185,37 @@ class JaroWinklerLevelBase(DistanceFunctionLevelBase):
 
     @property
     def _jaro_winkler_name(self):
-        raise NotImplementedError("Jaro-winkler function name not defined on base class")
+        raise NotImplementedError(
+            "Jaro-winkler function name not defined on base class"
+        )
 
 
-def jaccard_level(
-    col_name: str,
-    distance_threshold: Union[int, float],
-    m_probability=None,
-) -> ComparisonLevel:
-    """Represents a comparison using a jaccard distance function
+class JaccardLevelBase(DistanceFunctionLevelBase):
+    def __init__(
+        self,
+        col_name: str,
+        distance_threshold: Union[int, float],
+        m_probability=None,
+    ) -> ComparisonLevel:
+        """Represents a comparison using a jaccard distance function
 
-    Args:
-        col_name (str): Input column name
-        distance_threshold (Union[int, float]): The threshold to use to assess
-            similarity
-        m_probability (float, optional): Starting value for m probability. Defaults to
-            None.
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+            m_probability (float, optional): Starting value for m probability.
+                Defaults to None.
 
-    Returns:
-        ComparisonLevel: A comparison level that evaluates the jaccard similarity
-    """
-    return distance_function_level(
-        col_name,
-        "jaccard",
-        distance_threshold,
-        True,
-        m_probability=m_probability,
-    )
+        Returns:
+            ComparisonLevel: A comparison level that evaluates the jaccard similarity
+        """
+        super.__init__(
+            col_name,
+            self._jaccard_name,
+            distance_threshold,
+            True,
+            m_probability=m_probability,
+        )
 
 
 def else_level(

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -1,7 +1,6 @@
 from typing import Union
 
 from .comparison import Comparison
-from . import comparison_level_library as cl
 from .misc import ensure_is_iterable
 
 
@@ -37,8 +36,8 @@ class ExactMatchBase(Comparison):
         comparison_dict = {
             "comparison_description": "Exact match vs. anything else",
             "comparison_levels": [
-                cl.null_level(col_name),
-                cl.exact_match_level(
+                self._null_level(col_name),
+                self._exact_match_level(
                     col_name,
                     term_frequency_adjustments=term_frequency_adjustments,
                     m_probability=m_probability_exact_match,
@@ -109,9 +108,9 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
         m_probabilities = ensure_is_iterable(m_probability_or_probabilities_lev)
 
         comparison_levels = []
-        comparison_levels.append(cl.null_level(col_name))
+        comparison_levels.append(self._null_level(col_name))
         if include_exact_match_level:
-            level = cl.exact_match_level(
+            level = self._exact_match_level(
                 col_name,
                 term_frequency_adjustments=term_frequency_adjustments,
                 m_probability=m_probability_exact_match,
@@ -383,7 +382,7 @@ class ArrayIntersectAtSizesComparisonBase(Comparison):
         m_probabilities = ensure_is_iterable(m_probability_or_probabilities_sizes)
 
         comparison_levels = []
-        comparison_levels.append(cl.null_level(col_name))
+        comparison_levels.append(self._null_level(col_name))
 
         for size_intersect, m_prob in zip(sizes, m_probabilities):
             level = self._array_intersect_level(

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -12,7 +12,7 @@ class ExactMatchBase(Comparison):
         m_probability_exact_match=None,
         m_probability_else=None,
         include_colname_in_charts_label=False,
-    ) -> Comparison:
+    ):
         """A comparison of the data in `col_name` with two levels:
         - Exact match
         - Anything else
@@ -61,7 +61,7 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
         m_probability_exact_match=None,
         m_probability_or_probabilities_lev: Union[float, list] = None,
         m_probability_else=None,
-    ) -> Comparison:
+    ):
         """A comparison of the data in `col_name` with a user-provided distance
         function used to assess middle similarity levels.
 
@@ -169,7 +169,7 @@ class LevenshteinAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparis
         m_probability_exact_match=None,
         m_probability_or_probabilities_lev: Union[float, list] = None,
         m_probability_else=None,
-    ) -> Comparison:
+    ):
         """A comparison of the data in `col_name` with the levenshtein distance used to
         assess middle similarity levels.
 
@@ -228,7 +228,7 @@ class JaccardAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparisonBa
         m_probability_exact_match=None,
         m_probability_or_probabilities_lev: Union[float, list] = None,
         m_probability_else=None,
-    ) -> Comparison:
+    ):
         """A comparison of the data in `col_name` with the jaccard distance used to
         assess middle similarity levels.
 
@@ -287,7 +287,7 @@ class JaroWinklerAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparis
         m_probability_exact_match=None,
         m_probability_or_probabilities_lev: Union[float, list] = None,
         m_probability_else=None,
-    ) -> Comparison:
+    ):
         """A comparison of the data in `col_name` with the jaro_winkler distance used to
         assess middle similarity levels.
 
@@ -343,7 +343,7 @@ class ArrayIntersectAtSizesComparisonBase(Comparison):
         size_or_sizes: Union[int, list] = [1],
         m_probability_or_probabilities_sizes: Union[float, list] = None,
         m_probability_else=None,
-    ) -> Comparison:
+    ):
         """A comparison of the data in array column `col_name` with various
         intersection sizes to assess similarity levels.
 

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -5,46 +5,49 @@ from . import comparison_level_library as cl
 from .misc import ensure_is_iterable
 
 
-def exact_match(
-    col_name,
-    term_frequency_adjustments=False,
-    m_probability_exact_match=None,
-    m_probability_else=None,
-    include_colname_in_charts_label=False,
-) -> Comparison:
-    """A comparison of the data in `col_name` with two levels:
-    - Exact match
-    - Anything else
+class ExactMatchBase(Comparison):
+    def __init__(
+        self,
+        col_name,
+        term_frequency_adjustments=False,
+        m_probability_exact_match=None,
+        m_probability_else=None,
+        include_colname_in_charts_label=False,
+    ) -> Comparison:
+        """A comparison of the data in `col_name` with two levels:
+        - Exact match
+        - Anything else
 
-    Args:
-        col_name (str): The name of the column to compare
-        term_frequency_adjustments (bool, optional): If True, term frequency adjustments
-            will be made on the exact match level. Defaults to False.
-        m_probability_exact_match (_type_, optional): If provided, overrides the
-            default m probability for the exact match level. Defaults to None.
-        m_probability_else (_type_, optional): If provided, overrides the
-            default m probability for the 'anything else' level. Defaults to None.
-        include_colname_in_charts_label: If true, append col name to label for charts.
-            Defaults to False.
+        Args:
+            col_name (str): The name of the column to compare
+            term_frequency_adjustments (bool, optional): If True, term frequency
+                adjustments will be made on the exact match level. Defaults to False.
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
+            include_colname_in_charts_label: If true, append col name to label for
+                charts.  Defaults to False.
 
-    Returns:
-        Comparison: A comparison that can be inclued in the Splink settings dictionary
-    """
+        Returns:
+            Comparison: A comparison that can be inclued in the Splink settings
+                dictionary
+        """
 
-    comparison_dict = {
-        "comparison_description": "Exact match vs. anything else",
-        "comparison_levels": [
-            cl.null_level(col_name),
-            cl.exact_match_level(
-                col_name,
-                term_frequency_adjustments=term_frequency_adjustments,
-                m_probability=m_probability_exact_match,
-                include_colname_in_charts_label=include_colname_in_charts_label,
-            ),
-            cl.else_level(m_probability=m_probability_else),
-        ],
-    }
-    return Comparison(comparison_dict)
+        comparison_dict = {
+            "comparison_description": "Exact match vs. anything else",
+            "comparison_levels": [
+                cl.null_level(col_name),
+                cl.exact_match_level(
+                    col_name,
+                    term_frequency_adjustments=term_frequency_adjustments,
+                    m_probability=m_probability_exact_match,
+                    include_colname_in_charts_label=include_colname_in_charts_label,
+                ),
+                self._else_level(m_probability=m_probability_else),
+            ],
+        }
+        super().__init__(comparison_dict)
 
 
 class DistanceFunctionAtThresholdsComparisonBase(Comparison):
@@ -60,8 +63,8 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
         m_probability_or_probabilities_lev: Union[float, list] = None,
         m_probability_else=None,
     ) -> Comparison:
-        """A comparison of the data in `col_name` with a user-provided distance function
-        used to assess middle similarity levels.
+        """A comparison of the data in `col_name` with a user-provided distance
+        function used to assess middle similarity levels.
 
         The user-provided distance function must exist in the SQL backend.
 
@@ -132,7 +135,7 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
             comparison_levels.append(level)
 
         comparison_levels.append(
-            cl.else_level(m_probability=m_probability_else),
+            self._else_level(m_probability=m_probability_else),
         )
 
         comparison_desc = ""
@@ -389,7 +392,7 @@ class ArrayIntersectAtSizesComparisonBase(Comparison):
             comparison_levels.append(level)
 
         comparison_levels.append(
-            cl.else_level(m_probability=m_probability_else),
+            self._else_level(m_probability=m_probability_else),
         )
 
         comparison_desc = ""

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -65,8 +65,9 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
 
         The user-provided distance function must exist in the SQL backend.
 
-        An example of the output with default arguments and setting `distance_function_name`
-        to `jaccard` and `distance_threshold_or_thresholds = [0.9,0.7]` would be
+        An example of the output with default arguments and setting
+        `distance_function_name` to `jaccard` and
+        `distance_threshold_or_thresholds = [0.9,0.7]` would be
         - Exact match
         - Jaccard distance <= 0.9
         - Jaccard distance <= 0.7
@@ -75,11 +76,13 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
         Args:
             col_name (str): The name of the column to compare
             distance_function_name (str): The name of the distance function.
-            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-                to use for the middle similarity level(s). Defaults to [1, 2].
-            higher_is_more_similar (bool): If True, a higher value of the distance function
-                indicates a higher similarity (e.g. jaro_winkler).  If false, a higher
-                value indicates a lower similarity (e.g. levenshtein).
+            distance_threshold_or_thresholds (Union[int, list], optional): The
+                threshold(s) to use for the middle similarity level(s).
+                Defaults to [1, 2].
+            higher_is_more_similar (bool): If True, a higher value of the distance
+                function indicates a higher similarity (e.g. jaro_winkler).
+                If false, a higher value indicates a lower similarity
+                (e.g. levenshtein).
             include_exact_match_level (bool, optional): If True, include an exact match
                 level. Defaults to True.
             term_frequency_adjustments (bool, optional): If True, apply term frequency
@@ -113,16 +116,14 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
             comparison_levels.append(level)
 
         for thres, m_prob in zip(distance_thresholds, m_probabilities):
-            # we want to allow people to pass a string (if they have some custom function)
-            # but also need derived classes to pass their types
-            # i.e. IF we are being called with a distance_function_name (as a distance function)
-            # then call the appropiate distance_function_level
-            # otherwise call the custom level function
+            # these function arguments hold for all cases.
             kwargs = dict(
                 col_name=col_name,
                 distance_threshold=thres,
                 m_probability=m_prob,
             )
+            # separate out the two that are only used
+            # when we have a user-supplied function, rather than a predefined subclass
             # feels a bit hacky, but will do at least for time being
             if not self._is_distance_subclass:
                 kwargs["distance_function_name"] = distance_function_name
@@ -179,8 +180,9 @@ class LevenshteinAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparis
 
         Args:
             col_name (str): The name of the column to compare
-            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-                to use for the middle similarity level(s). Defaults to [1, 2].
+            distance_threshold_or_thresholds (Union[int, list], optional): The
+                threshold(s) to use for the middle similarity level(s).
+                Defaults to [1, 2].
             include_exact_match_level (bool, optional): If True, include an exact match
                 level. Defaults to True.
             term_frequency_adjustments (bool, optional): If True, apply term frequency
@@ -237,8 +239,9 @@ class JaccardAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparisonBa
 
         Args:
             col_name (str): The name of the column to compare
-            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-                to use for the middle similarity level(s). Defaults to [0.9, 0.7].
+            distance_threshold_or_thresholds (Union[int, list], optional): The
+                threshold(s) to use for the middle similarity level(s).
+                Defaults to [0.9, 0.7].
             include_exact_match_level (bool, optional): If True, include an exact match
                 level. Defaults to True.
             term_frequency_adjustments (bool, optional): If True, apply term frequency
@@ -295,8 +298,9 @@ class JaroWinklerAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparis
 
         Args:
             col_name (str): The name of the column to compare
-            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-                to use for the middle similarity level(s). Defaults to [0.9, 0.7].
+            distance_threshold_or_thresholds (Union[int, list], optional): The
+                threshold(s) to use for the middle similarity level(s).
+                Defaults to [0.9, 0.7].
             include_exact_match_level (bool, optional): If True, include an exact match
                 level. Defaults to True.
             term_frequency_adjustments (bool, optional): If True, apply term frequency

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -47,255 +47,264 @@ def exact_match(
     return Comparison(comparison_dict)
 
 
-def distance_function_at_thresholds(
-    col_name: str,
-    distance_function_name: str,
-    distance_threshold_or_thresholds: Union[int, list],
-    higher_is_more_similar: bool = True,
-    include_exact_match_level=True,
-    term_frequency_adjustments=False,
-    m_probability_exact_match=None,
-    m_probability_or_probabilities_lev: Union[float, list] = None,
-    m_probability_else=None,
-) -> Comparison:
-    """A comparison of the data in `col_name` with a user-provided distance function
-    used to assess middle similarity levels.
+class DistanceFunctionAtThresholdsComparisonBase(Comparison):
+    def __init__(
+        self,
+        col_name: str,
+        distance_function_name: str,
+        distance_threshold_or_thresholds: Union[int, list],
+        higher_is_more_similar: bool = True,
+        include_exact_match_level=True,
+        term_frequency_adjustments=False,
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_lev: Union[float, list] = None,
+        m_probability_else=None,
+    ) -> Comparison:
+        """A comparison of the data in `col_name` with a user-provided distance function
+        used to assess middle similarity levels.
 
-    The user-provided distance function must exist in the SQL backend.
+        The user-provided distance function must exist in the SQL backend.
 
-    An example of the output with default arguments and setting `distance_function_name`
-    to `jaccard` and `distance_threshold_or_thresholds = [0.9,0.7]` would be
-    - Exact match
-    - Jaccard distance <= 0.9
-    - Jaccard distance <= 0.7
-    - Anything else
+        An example of the output with default arguments and setting `distance_function_name`
+        to `jaccard` and `distance_threshold_or_thresholds = [0.9,0.7]` would be
+        - Exact match
+        - Jaccard distance <= 0.9
+        - Jaccard distance <= 0.7
+        - Anything else
 
-    Args:
-        col_name (str): The name of the column to compare
-        distance_function_name (str): The name of the distance function
-        distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-            to use for the middle similarity level(s). Defaults to [1, 2].
-        higher_is_more_similar (bool): If True, a higher value of the distance function
-            indicates a higher similarity (e.g. jaro_winkler).  If false, a higher
-            value indicates a lower similarity (e.g. levenshtein).
-        include_exact_match_level (bool, optional): If True, include an exact match
-            level. Defaults to True.
-        term_frequency_adjustments (bool, optional): If True, apply term frequency
-            adjustments to the exact match level. Defaults to False.
-        m_probability_exact_match (_type_, optional): If provided, overrides the
-            default m probability for the exact match level. Defaults to None.
-        m_probability_or_probabilities_lev (Union[float, list], optional):
-            _description_. If provided, overrides the default m probabilities
-            for the thresholds specified. Defaults to None.
-        m_probability_else (_type_, optional): If provided, overrides the
-            default m probability for the 'anything else' level. Defaults to None.
+        Args:
+            col_name (str): The name of the column to compare
+            distance_function_name (str): The name of the distance function
+            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
+                to use for the middle similarity level(s). Defaults to [1, 2].
+            higher_is_more_similar (bool): If True, a higher value of the distance function
+                indicates a higher similarity (e.g. jaro_winkler).  If false, a higher
+                value indicates a lower similarity (e.g. levenshtein).
+            include_exact_match_level (bool, optional): If True, include an exact match
+                level. Defaults to True.
+            term_frequency_adjustments (bool, optional): If True, apply term frequency
+                adjustments to the exact match level. Defaults to False.
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_or_probabilities_lev (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the thresholds specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
 
-    Returns:
-        Comparison:
-    """
+        Returns:
+            Comparison:
+        """
 
-    distance_thresholds = ensure_is_iterable(distance_threshold_or_thresholds)
+        distance_thresholds = ensure_is_iterable(distance_threshold_or_thresholds)
 
-    if m_probability_or_probabilities_lev is None:
-        m_probability_or_probabilities_lev = [None] * len(distance_thresholds)
-    m_probabilities = ensure_is_iterable(m_probability_or_probabilities_lev)
+        if m_probability_or_probabilities_lev is None:
+            m_probability_or_probabilities_lev = [None] * len(distance_thresholds)
+        m_probabilities = ensure_is_iterable(m_probability_or_probabilities_lev)
 
-    comparison_levels = []
-    comparison_levels.append(cl.null_level(col_name))
-    if include_exact_match_level:
-        level = cl.exact_match_level(
-            col_name,
-            term_frequency_adjustments=term_frequency_adjustments,
-            m_probability=m_probability_exact_match,
+        comparison_levels = []
+        comparison_levels.append(cl.null_level(col_name))
+        if include_exact_match_level:
+            level = cl.exact_match_level(
+                col_name,
+                term_frequency_adjustments=term_frequency_adjustments,
+                m_probability=m_probability_exact_match,
+            )
+            comparison_levels.append(level)
+
+        for thres, m_prob in zip(distance_thresholds, m_probabilities):
+            # need to rethink the logic of how this all flows:
+            level = cl.DistanceFunctionLevelBase(
+                col_name,
+                distance_function_name=distance_function_name,
+                higher_is_more_similar=higher_is_more_similar,
+                distance_threshold=thres,
+                m_probability=m_prob,
+            )
+            comparison_levels.append(level)
+
+        comparison_levels.append(
+            cl.else_level(m_probability=m_probability_else),
         )
-        comparison_levels.append(level)
 
-    for thres, m_prob in zip(distance_thresholds, m_probabilities):
-        level = cl.distance_function_level(
-            col_name,
-            distance_function_name=distance_function_name,
-            higher_is_more_similar=higher_is_more_similar,
-            distance_threshold=thres,
-            m_probability=m_prob,
+        comparison_desc = ""
+        if include_exact_match_level:
+            comparison_desc += "Exact match vs. "
+
+        thres_desc = ", ".join([str(d) for d in distance_thresholds])
+        plural = "" if len(distance_thresholds) == 1 else "s"
+        comparison_desc += (
+            f"{distance_function_name} at threshold{plural} {thres_desc} vs. "
         )
-        comparison_levels.append(level)
+        comparison_desc += "anything else"
 
-    comparison_levels.append(
-        cl.else_level(m_probability=m_probability_else),
-    )
-
-    comparison_desc = ""
-    if include_exact_match_level:
-        comparison_desc += "Exact match vs. "
-
-    thres_desc = ", ".join([str(d) for d in distance_thresholds])
-    plural = "" if len(distance_thresholds) == 1 else "s"
-    comparison_desc += (
-        f"{distance_function_name} at threshold{plural} {thres_desc} vs. "
-    )
-    comparison_desc += "anything else"
-
-    comparison_dict = {
-        "comparison_description": comparison_desc,
-        "comparison_levels": comparison_levels,
-    }
-    return Comparison(comparison_dict)
+        comparison_dict = {
+            "comparison_description": comparison_desc,
+            "comparison_levels": comparison_levels,
+        }
+        super().__init__(comparison_dict)
 
 
-def levenshtein_at_thresholds(
-    col_name: str,
-    distance_threshold_or_thresholds: Union[int, list] = [1, 2],
-    include_exact_match_level=True,
-    term_frequency_adjustments=False,
-    m_probability_exact_match=None,
-    m_probability_or_probabilities_lev: Union[float, list] = None,
-    m_probability_else=None,
-) -> Comparison:
-    """A comparison of the data in `col_name` with the levenshtein distance used to
-    assess middle similarity levels.
+class LevenshteinAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparisonBase):
+    def __init__(
+        self,
+        col_name: str,
+        distance_threshold_or_thresholds: Union[int, list] = [1, 2],
+        include_exact_match_level=True,
+        term_frequency_adjustments=False,
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_lev: Union[float, list] = None,
+        m_probability_else=None,
+    ) -> Comparison:
+        """A comparison of the data in `col_name` with the levenshtein distance used to
+        assess middle similarity levels.
 
-    An example of the output with default arguments and setting
-    `distance_threshold_or_thresholds = [1,2]` would be
-    - Exact match
-    - levenshtein distance <= 1
-    - levenshtein distance <= 2
-    - Anything else
+        An example of the output with default arguments and setting
+        `distance_threshold_or_thresholds = [1,2]` would be
+        - Exact match
+        - levenshtein distance <= 1
+        - levenshtein distance <= 2
+        - Anything else
 
-    Args:
-        col_name (str): The name of the column to compare
-        distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-            to use for the middle similarity level(s). Defaults to [1, 2].
-        include_exact_match_level (bool, optional): If True, include an exact match
-            level. Defaults to True.
-        term_frequency_adjustments (bool, optional): If True, apply term frequency
-            adjustments to the exact match level. Defaults to False.
-        m_probability_exact_match (_type_, optional): If provided, overrides the
-            default m probability for the exact match level. Defaults to None.
-        m_probability_or_probabilities_lev (Union[float, list], optional):
-            _description_. If provided, overrides the default m probabilities
-            for the thresholds specified. Defaults to None.
-        m_probability_else (_type_, optional): If provided, overrides the
-            default m probability for the 'anything else' level. Defaults to None.
+        Args:
+            col_name (str): The name of the column to compare
+            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
+                to use for the middle similarity level(s). Defaults to [1, 2].
+            include_exact_match_level (bool, optional): If True, include an exact match
+                level. Defaults to True.
+            term_frequency_adjustments (bool, optional): If True, apply term frequency
+                adjustments to the exact match level. Defaults to False.
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_or_probabilities_lev (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the thresholds specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
 
-    Returns:
-        Comparison:
-    """
+        Returns:
+            Comparison:
+        """
 
-    return distance_function_at_thresholds(
-        col_name,
-        cl._mutable_params["levenshtein"],
-        distance_threshold_or_thresholds,
-        False,
-        include_exact_match_level,
-        term_frequency_adjustments,
-        m_probability_exact_match,
-        m_probability_or_probabilities_lev,
-        m_probability_else,
-    )
-
-
-def jaccard_at_thresholds(
-    col_name: str,
-    distance_threshold_or_thresholds: Union[int, list] = [0.9, 0.7],
-    include_exact_match_level=True,
-    term_frequency_adjustments=False,
-    m_probability_exact_match=None,
-    m_probability_or_probabilities_lev: Union[float, list] = None,
-    m_probability_else=None,
-) -> Comparison:
-    """A comparison of the data in `col_name` with the jaccard distance used to
-    assess middle similarity levels.
-
-    An example of the output with default arguments and setting
-    `distance_threshold_or_thresholds = [1,2]` would be
-    - Exact match
-    - Jaccard distance <= 0.9
-    - Jaccard distance <= 0.7
-    - Anything else
-
-    Args:
-        col_name (str): The name of the column to compare
-        distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-            to use for the middle similarity level(s). Defaults to [0.9, 0.7].
-        include_exact_match_level (bool, optional): If True, include an exact match
-            level. Defaults to True.
-        term_frequency_adjustments (bool, optional): If True, apply term frequency
-            adjustments to the exact match level. Defaults to False.
-        m_probability_exact_match (_type_, optional): If provided, overrides the
-            default m probability for the exact match level. Defaults to None.
-        m_probability_or_probabilities_lev (Union[float, list], optional):
-            _description_. If provided, overrides the default m probabilities
-            for the thresholds specified. Defaults to None.
-        m_probability_else (_type_, optional): If provided, overrides the
-            default m probability for the 'anything else' level. Defaults to None.
-
-    Returns:
-        Comparison:
-    """
-
-    return distance_function_at_thresholds(
-        col_name,
-        "jaccard",
-        distance_threshold_or_thresholds,
-        True,
-        include_exact_match_level,
-        term_frequency_adjustments,
-        m_probability_exact_match,
-        m_probability_or_probabilities_lev,
-        m_probability_else,
-    )
+        super().__init__(
+            col_name,
+            self._levenshtein_name,
+            distance_threshold_or_thresholds,
+            False,
+            include_exact_match_level,
+            term_frequency_adjustments,
+            m_probability_exact_match,
+            m_probability_or_probabilities_lev,
+            m_probability_else,
+        )
 
 
-def jaro_winkler_at_thresholds(
-    col_name: str,
-    distance_threshold_or_thresholds: Union[int, list] = [0.9, 0.7],
-    include_exact_match_level=True,
-    term_frequency_adjustments=False,
-    m_probability_exact_match=None,
-    m_probability_or_probabilities_lev: Union[float, list] = None,
-    m_probability_else=None,
-) -> Comparison:
-    """A comparison of the data in `col_name` with the jaro_winkler distance used to
-    assess middle similarity levels.
+class JaccardAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparisonBase):
+    def __init__(
+        self,
+        col_name: str,
+        distance_threshold_or_thresholds: Union[int, list] = [0.9, 0.7],
+        include_exact_match_level=True,
+        term_frequency_adjustments=False,
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_lev: Union[float, list] = None,
+        m_probability_else=None,
+    ) -> Comparison:
+        """A comparison of the data in `col_name` with the jaccard distance used to
+        assess middle similarity levels.
 
-    An example of the output with default arguments and setting
-    `distance_threshold_or_thresholds = [1,2]` would be
-    - Exact match
-    - jaro_winkler distance <= 0.9
-    - jaro_winkler distance <= 0.7
-    - Anything else
+        An example of the output with default arguments and setting
+        `distance_threshold_or_thresholds = [1,2]` would be
+        - Exact match
+        - Jaccard distance <= 0.9
+        - Jaccard distance <= 0.7
+        - Anything else
 
-    Args:
-        col_name (str): The name of the column to compare
-        distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
-            to use for the middle similarity level(s). Defaults to [0.9, 0.7].
-        include_exact_match_level (bool, optional): If True, include an exact match
-            level. Defaults to True.
-        term_frequency_adjustments (bool, optional): If True, apply term frequency
-            adjustments to the exact match level. Defaults to False.
-        m_probability_exact_match (_type_, optional): If provided, overrides the
-            default m probability for the exact match level. Defaults to None.
-        m_probability_or_probabilities_lev (Union[float, list], optional):
-            _description_. If provided, overrides the default m probabilities
-            for the thresholds specified. Defaults to None.
-        m_probability_else (_type_, optional): If provided, overrides the
-            default m probability for the 'anything else' level. Defaults to None.
+        Args:
+            col_name (str): The name of the column to compare
+            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
+                to use for the middle similarity level(s). Defaults to [0.9, 0.7].
+            include_exact_match_level (bool, optional): If True, include an exact match
+                level. Defaults to True.
+            term_frequency_adjustments (bool, optional): If True, apply term frequency
+                adjustments to the exact match level. Defaults to False.
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_or_probabilities_lev (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the thresholds specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
 
-    Returns:
-        Comparison:
-    """
+        Returns:
+            Comparison:
+        """
 
-    return distance_function_at_thresholds(
-        col_name,
-        cl._mutable_params["jaro_winkler"],
-        distance_threshold_or_thresholds,
-        True,
-        include_exact_match_level,
-        term_frequency_adjustments,
-        m_probability_exact_match,
-        m_probability_or_probabilities_lev,
-        m_probability_else,
-    )
+        super.__init__(
+            col_name,
+            self._jaccard_name,
+            distance_threshold_or_thresholds,
+            True,
+            include_exact_match_level,
+            term_frequency_adjustments,
+            m_probability_exact_match,
+            m_probability_or_probabilities_lev,
+            m_probability_else,
+        )
+
+
+class JaroWinklerAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparisonBase):
+    def __init__(
+        self,
+        col_name: str,
+        distance_threshold_or_thresholds: Union[int, list] = [0.9, 0.7],
+        include_exact_match_level=True,
+        term_frequency_adjustments=False,
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_lev: Union[float, list] = None,
+        m_probability_else=None,
+    ) -> Comparison:
+        """A comparison of the data in `col_name` with the jaro_winkler distance used to
+        assess middle similarity levels.
+
+        An example of the output with default arguments and setting
+        `distance_threshold_or_thresholds = [1,2]` would be
+        - Exact match
+        - jaro_winkler distance <= 0.9
+        - jaro_winkler distance <= 0.7
+        - Anything else
+
+        Args:
+            col_name (str): The name of the column to compare
+            distance_threshold_or_thresholds (Union[int, list], optional): The threshold(s)
+                to use for the middle similarity level(s). Defaults to [0.9, 0.7].
+            include_exact_match_level (bool, optional): If True, include an exact match
+                level. Defaults to True.
+            term_frequency_adjustments (bool, optional): If True, apply term frequency
+                adjustments to the exact match level. Defaults to False.
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_or_probabilities_lev (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the thresholds specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
+
+        Returns:
+            Comparison:
+        """
+
+        super().__init__(
+            col_name,
+            self._jaro_winkler_name,
+            distance_threshold_or_thresholds,
+            True,
+            include_exact_match_level,
+            term_frequency_adjustments,
+            m_probability_exact_match,
+            m_probability_or_probabilities_lev,
+            m_probability_else,
+        )
 
 
 class ArrayIntersectAtSizesComparisonBase(Comparison):

--- a/splink/dialect_base.py
+++ b/splink/dialect_base.py
@@ -1,0 +1,18 @@
+# defines default values for dialect-dependent properties
+class DialectBase:
+    @property
+    def _sql_dialect(self):
+        raise NotImplementedError("No SQL dialect specified")
+
+    @property
+    def _levenshtein_name(self):
+        return "levenshtein"
+
+    @property
+    def _jaro_winkler_name(self):
+        return "jaro_winkler"
+
+    @property
+    def _jaccard_name(self):
+        return "jaccard"
+

--- a/splink/dialect_base.py
+++ b/splink/dialect_base.py
@@ -15,4 +15,3 @@ class DialectBase:
     @property
     def _jaccard_name(self):
         return "jaccard"
-

--- a/splink/duckdb/duckb_base.py
+++ b/splink/duckdb/duckb_base.py
@@ -1,0 +1,25 @@
+from ..dialect_base import (
+    DialectBase,
+)
+
+
+def size_array_intersect_sql(col_name_l, col_name_r):
+    # sum of individual (unique) array sizes, minus the (unique) union
+    return (
+        f"list_unique({col_name_l}) + list_unique({col_name_r})"
+        f" - list_unique(list_concat({col_name_l}, {col_name_r}))"
+    )
+
+
+class DuckDBBase(DialectBase):
+    @property
+    def _sql_dialect(self):
+        return "duckdb"
+
+    @property
+    def _size_array_intersect_function(self):
+        return size_array_intersect_sql
+
+    @property
+    def _jaro_winkler_name(self):
+        return "jaro_winkler_similarity"

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -26,7 +26,8 @@ _mutable_params["dialect"] = "duckdb"
 _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 
 
-class array_intersect_level(ArrayIntersectLevelBase):
+class DuckDBLevel():
+
     @property
     def _sql_dialect(self):
         return "duckdb"
@@ -34,3 +35,7 @@ class array_intersect_level(ArrayIntersectLevelBase):
     @property
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
+
+
+class array_intersect_level(DuckDBLevel, ArrayIntersectLevelBase):
+    pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -9,7 +9,7 @@ from ..comparison_level_library import (  # noqa: F401
     DistanceFunctionLevelBase,
     columns_reversed_level,
     DistanceInKMLevelBase,
-    percentage_difference_level,
+    PercentageDifferenceLevelBase,
     ArrayIntersectLevelBase,
 )
 from .duckb_base import (
@@ -36,6 +36,10 @@ class jaccard_level(DuckDBBase, JaccardLevelBase):
 
 
 class array_intersect_level(DuckDBBase, ArrayIntersectLevelBase):
+    pass
+
+
+class percentage_difference_level(DuckDBBase, PercentageDifferenceLevelBase):
     pass
 
 

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -1,12 +1,13 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
+    DialectLevel,
     exact_match_level,
     levenshtein_level,
     jaccard_level,
     JaroWinklerLevelBase,
     else_level,
     null_level,
-    distance_function_level,
+    DistanceFunctionLevelBase,
     columns_reversed_level,
     distance_in_km_level,
     percentage_difference_level,
@@ -25,7 +26,7 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 _mutable_params["dialect"] = "duckdb"
 
 
-class DuckDBLevel():
+class DuckDBLevel(DialectLevel):
 
     @property
     def _sql_dialect(self):
@@ -39,6 +40,8 @@ class DuckDBLevel():
     def _jaro_winkler_name(self):
         return "jaro_winkler_similarity"
 
+class distance_function_level(DuckDBLevel, DistanceFunctionLevelBase):
+    pass
 
 class jaro_winkler_level(DuckDBLevel, JaroWinklerLevelBase):
     pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -3,7 +3,7 @@ from ..comparison_level_library import (  # noqa: F401
     DialectLevel,
     exact_match_level,
     LevenshteinLevelBase,
-    jaccard_level,
+    JaccardLevelBase,
     JaroWinklerLevelBase,
     else_level,
     null_level,
@@ -27,7 +27,6 @@ _mutable_params["dialect"] = "duckdb"
 
 
 class DuckDBLevel(DialectLevel):
-
     @property
     def _sql_dialect(self):
         return "duckdb"
@@ -40,14 +39,22 @@ class DuckDBLevel(DialectLevel):
     def _jaro_winkler_name(self):
         return "jaro_winkler_similarity"
 
+
 class distance_function_level(DuckDBLevel, DistanceFunctionLevelBase):
     pass
+
 
 class levenshtein_level(DuckDBLevel, LevenshteinLevelBase):
     pass
 
+
 class jaro_winkler_level(DuckDBLevel, JaroWinklerLevelBase):
     pass
+
+
+class jaccard_level(DuckDBLevel, JaccardLevelBase):
+    pass
+
 
 class array_intersect_level(DuckDBLevel, ArrayIntersectLevelBase):
     pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -8,7 +8,7 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     DistanceFunctionLevelBase,
     columns_reversed_level,
-    distance_in_km_level,
+    DistanceInKMLevelBase,
     percentage_difference_level,
     ArrayIntersectLevelBase,
 )
@@ -36,4 +36,8 @@ class jaccard_level(DuckDBBase, JaccardLevelBase):
 
 
 class array_intersect_level(DuckDBBase, ArrayIntersectLevelBase):
+    pass
+
+
+class distance_in_km_level(DuckDBBase, DistanceInKMLevelBase):
     pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -1,5 +1,4 @@
-from ..comparison_level_library import (  # noqa: F401
-    _mutable_params,
+from ..comparison_level_library import (
     ExactMatchLevelBase,
     LevenshteinLevelBase,
     JaccardLevelBase,
@@ -15,8 +14,6 @@ from ..comparison_level_library import (  # noqa: F401
 from .duckb_base import (
     DuckDBBase,
 )
-
-_mutable_params["dialect"] = "duckdb"
 
 
 class null_level(DuckDBBase, NullLevelBase):

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -3,7 +3,7 @@ from ..comparison_level_library import (  # noqa: F401
     exact_match_level,
     levenshtein_level,
     jaccard_level,
-    jaro_winkler_level,
+    JaroWinklerLevelBase,
     else_level,
     null_level,
     distance_function_level,
@@ -23,7 +23,6 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 
 
 _mutable_params["dialect"] = "duckdb"
-_mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 
 
 class DuckDBLevel():
@@ -36,6 +35,13 @@ class DuckDBLevel():
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
 
+    @property
+    def _jaro_winkler_name(self):
+        return "jaro_winkler_similarity"
+
+
+class jaro_winkler_level(DuckDBLevel, JaroWinklerLevelBase):
+    pass
 
 class array_intersect_level(DuckDBLevel, ArrayIntersectLevelBase):
     pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -4,10 +4,10 @@ from ..comparison_level_library import (  # noqa: F401
     LevenshteinLevelBase,
     JaccardLevelBase,
     JaroWinklerLevelBase,
-    else_level,
+    ElseLevelBase,
     null_level,
     DistanceFunctionLevelBase,
-    columns_reversed_level,
+    ColumnsReversedLevelBase,
     DistanceInKMLevelBase,
     PercentageDifferenceLevelBase,
     ArrayIntersectLevelBase,
@@ -17,6 +17,14 @@ from .duckb_base import (
 )
 
 _mutable_params["dialect"] = "duckdb"
+
+
+class else_level(DuckDBBase, ElseLevelBase):
+    pass
+
+
+class columns_reversed_level(DuckDBBase, ColumnsReversedLevelBase):
+    pass
 
 
 class distance_function_level(DuckDBBase, DistanceFunctionLevelBase):

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -1,6 +1,5 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    DialectLevel,
     exact_match_level,
     LevenshteinLevelBase,
     JaccardLevelBase,
@@ -13,48 +12,28 @@ from ..comparison_level_library import (  # noqa: F401
     percentage_difference_level,
     ArrayIntersectLevelBase,
 )
-
-
-def size_array_intersect_sql(col_name_l, col_name_r):
-    # sum of individual (unique) array sizes, minus the (unique) union
-    return (
-        f"list_unique({col_name_l}) + list_unique({col_name_r})"
-        f" - list_unique(list_concat({col_name_l}, {col_name_r}))"
-    )
-
+from .duckb_base import (
+    DuckDBBase,
+)
 
 _mutable_params["dialect"] = "duckdb"
 
 
-class DuckDBLevel(DialectLevel):
-    @property
-    def _sql_dialect(self):
-        return "duckdb"
-
-    @property
-    def _size_array_intersect_function(self):
-        return size_array_intersect_sql
-
-    @property
-    def _jaro_winkler_name(self):
-        return "jaro_winkler_similarity"
-
-
-class distance_function_level(DuckDBLevel, DistanceFunctionLevelBase):
+class distance_function_level(DuckDBBase, DistanceFunctionLevelBase):
     pass
 
 
-class levenshtein_level(DuckDBLevel, LevenshteinLevelBase):
+class levenshtein_level(DuckDBBase, LevenshteinLevelBase):
     pass
 
 
-class jaro_winkler_level(DuckDBLevel, JaroWinklerLevelBase):
+class jaro_winkler_level(DuckDBBase, JaroWinklerLevelBase):
     pass
 
 
-class jaccard_level(DuckDBLevel, JaccardLevelBase):
+class jaccard_level(DuckDBBase, JaccardLevelBase):
     pass
 
 
-class array_intersect_level(DuckDBLevel, ArrayIntersectLevelBase):
+class array_intersect_level(DuckDBBase, ArrayIntersectLevelBase):
     pass

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -2,7 +2,7 @@ from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
     DialectLevel,
     exact_match_level,
-    levenshtein_level,
+    LevenshteinLevelBase,
     jaccard_level,
     JaroWinklerLevelBase,
     else_level,
@@ -41,6 +41,9 @@ class DuckDBLevel(DialectLevel):
         return "jaro_winkler_similarity"
 
 class distance_function_level(DuckDBLevel, DistanceFunctionLevelBase):
+    pass
+
+class levenshtein_level(DuckDBLevel, LevenshteinLevelBase):
     pass
 
 class jaro_winkler_level(DuckDBLevel, JaroWinklerLevelBase):

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -1,11 +1,11 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    exact_match_level,
+    ExactMatchLevelBase,
     LevenshteinLevelBase,
     JaccardLevelBase,
     JaroWinklerLevelBase,
     ElseLevelBase,
-    null_level,
+    NullLevelBase,
     DistanceFunctionLevelBase,
     ColumnsReversedLevelBase,
     DistanceInKMLevelBase,
@@ -17,6 +17,14 @@ from .duckb_base import (
 )
 
 _mutable_params["dialect"] = "duckdb"
+
+
+class null_level(DuckDBBase, NullLevelBase):
+    pass
+
+
+class exact_match_level(DuckDBBase, ExactMatchLevelBase):
+    pass
 
 
 class else_level(DuckDBBase, ElseLevelBase):

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -4,7 +4,7 @@ from ..comparison_level_library import (
 
 
 from ..comparison_library import (  # noqa: F401
-    exact_match,
+    ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
     JaroWinklerAtThresholdsComparisonBase,
@@ -15,6 +15,7 @@ from .duckb_base import (
     DuckDBBase,
 )
 from .duckdb_comparison_level_library import (
+    else_level,
     distance_function_level,
     levenshtein_level,
     jaro_winkler_level,
@@ -26,33 +27,47 @@ from .duckdb_comparison_level_library import (
 _mutable_params["dialect"] = "duckdb"
 
 
+class DuckDBComparison(DuckDBBase):
+    @property
+    def _else_level(self):
+        return else_level
+
+
+class exact_match(DuckDBComparison, ExactMatchBase):
+    pass
+
+
 class distance_function_at_thresholds(
-    DuckDBBase, DistanceFunctionAtThresholdsComparisonBase
+    DuckDBComparison, DistanceFunctionAtThresholdsComparisonBase
 ):
     @property
     def _distance_level(self):
         return distance_function_level
 
 
-class levenshtein_at_thresholds(DuckDBBase, LevenshteinAtThresholdsComparisonBase):
+class levenshtein_at_thresholds(
+    DuckDBComparison, LevenshteinAtThresholdsComparisonBase
+):
     @property
     def _distance_level(self):
         return levenshtein_level
 
 
-class jaro_winkler_at_thresholds(DuckDBBase, JaroWinklerAtThresholdsComparisonBase):
+class jaro_winkler_at_thresholds(
+    DuckDBComparison, JaroWinklerAtThresholdsComparisonBase
+):
     @property
     def _distance_level(self):
         return jaro_winkler_level
 
 
-class jaccard_at_thresholds(DuckDBBase, JaccardAtThresholdsComparisonBase):
+class jaccard_at_thresholds(DuckDBComparison, JaccardAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return jaccard_level
 
 
-class array_intersect_at_sizes(DuckDBBase, ArrayIntersectAtSizesComparisonBase):
+class array_intersect_at_sizes(DuckDBComparison, ArrayIntersectAtSizesComparisonBase):
     @property
     def _array_intersect_level(self):
         return array_intersect_level

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -15,6 +15,8 @@ from .duckb_base import (
     DuckDBBase,
 )
 from .duckdb_comparison_level_library import (
+    exact_match_level,
+    null_level,
     else_level,
     distance_function_level,
     levenshtein_level,
@@ -28,6 +30,14 @@ _mutable_params["dialect"] = "duckdb"
 
 
 class DuckDBComparison(DuckDBBase):
+    @property
+    def _exact_match_level(self):
+        return exact_match_level
+
+    @property
+    def _null_level(self):
+        return null_level
+
     @property
     def _else_level(self):
         return else_level

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -14,6 +14,12 @@ from ..comparison_library import (  # noqa: F401
 from .duckb_base import (
     DuckDBBase,
 )
+from .duckdb_comparison_level_library import (
+    distance_function_level,
+    levenshtein_level,
+    jaro_winkler_level,
+    jaccard_level,
+)
 
 # _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 _mutable_params["dialect"] = "duckdb"
@@ -23,23 +29,31 @@ _mutable_params["dialect"] = "duckdb"
 class distance_function_at_thresholds(
     DuckDBBase, DistanceFunctionAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return distance_function_level
 
 
 class levenshtein_at_thresholds(
     DuckDBBase, LevenshteinAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return levenshtein_level
 
 
 class jaro_winkler_at_thresholds(
     DuckDBBase, JaroWinklerAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return jaro_winkler_level
 
 
 class jaccard_at_thresholds(DuckDBBase, JaccardAtThresholdsComparisonBase):
-    pass
+    @property
+    def _distance_level(self):
+        return jaccard_level
 
 
 class array_intersect_at_sizes(DuckDBBase, ArrayIntersectAtSizesComparisonBase):

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -1,9 +1,4 @@
-from ..comparison_level_library import (
-    _mutable_params,
-)
-
-
-from ..comparison_library import (  # noqa: F401
+from ..comparison_library import (
     ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
@@ -24,9 +19,6 @@ from .duckdb_comparison_level_library import (
     jaccard_level,
     array_intersect_level,
 )
-
-# _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
-_mutable_params["dialect"] = "duckdb"
 
 
 class DuckDBComparison(DuckDBBase):

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -5,21 +5,42 @@ from ..comparison_level_library import (
 
 from ..comparison_library import (  # noqa: F401
     exact_match,
-    levenshtein_at_thresholds,
-    distance_function_at_thresholds,
-    jaccard_at_thresholds,
-    jaro_winkler_at_thresholds,
+    DistanceFunctionAtThresholdsComparisonBase,
+    LevenshteinAtThresholdsComparisonBase,
+    JaroWinklerAtThresholdsComparisonBase,
+    JaccardAtThresholdsComparisonBase,
     ArrayIntersectAtSizesComparisonBase,
 )
-from .duckdb_comparison_level_library import (
-    array_intersect_level,
+from .duckb_base import (
+    DuckDBBase,
 )
 
-_mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
+# _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 _mutable_params["dialect"] = "duckdb"
 
 
-class array_intersect_at_sizes(ArrayIntersectAtSizesComparisonBase):
-    @property
-    def _array_intersect_level(self):
-        return array_intersect_level
+
+class distance_function_at_thresholds(
+    DuckDBBase, DistanceFunctionAtThresholdsComparisonBase
+):
+    pass
+
+
+class levenshtein_at_thresholds(
+    DuckDBBase, LevenshteinAtThresholdsComparisonBase
+):
+    pass
+
+
+class jaro_winkler_at_thresholds(
+    DuckDBBase, JaroWinklerAtThresholdsComparisonBase
+):
+    pass
+
+
+class jaccard_at_thresholds(DuckDBBase, JaccardAtThresholdsComparisonBase):
+    pass
+
+
+class array_intersect_at_sizes(DuckDBBase, ArrayIntersectAtSizesComparisonBase):
+    pass

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -26,7 +26,6 @@ from .duckdb_comparison_level_library import (
 _mutable_params["dialect"] = "duckdb"
 
 
-
 class distance_function_at_thresholds(
     DuckDBBase, DistanceFunctionAtThresholdsComparisonBase
 ):
@@ -35,17 +34,13 @@ class distance_function_at_thresholds(
         return distance_function_level
 
 
-class levenshtein_at_thresholds(
-    DuckDBBase, LevenshteinAtThresholdsComparisonBase
-):
+class levenshtein_at_thresholds(DuckDBBase, LevenshteinAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return levenshtein_level
 
 
-class jaro_winkler_at_thresholds(
-    DuckDBBase, JaroWinklerAtThresholdsComparisonBase
-):
+class jaro_winkler_at_thresholds(DuckDBBase, JaroWinklerAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return jaro_winkler_level

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -19,6 +19,7 @@ from .duckdb_comparison_level_library import (
     levenshtein_level,
     jaro_winkler_level,
     jaccard_level,
+    array_intersect_level,
 )
 
 # _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
@@ -57,4 +58,6 @@ class jaccard_at_thresholds(DuckDBBase, JaccardAtThresholdsComparisonBase):
 
 
 class array_intersect_at_sizes(DuckDBBase, ArrayIntersectAtSizesComparisonBase):
-    pass
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level

--- a/splink/spark/spark_base.py
+++ b/splink/spark/spark_base.py
@@ -1,0 +1,17 @@
+from ..dialect_base import (
+    DialectBase,
+)
+
+
+def size_array_intersect_sql(col_name_l, col_name_r):
+    return f"size(array_intersect({col_name_l}, {col_name_r}))"
+
+
+class SparkBase(DialectBase):
+    @property
+    def _sql_dialect(self):
+        return "spark"
+
+    @property
+    def _size_array_intersect_function(self):
+        return size_array_intersect_sql

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -1,5 +1,4 @@
-from ..comparison_level_library import (  # noqa: F401
-    _mutable_params,
+from ..comparison_level_library import (
     ExactMatchLevelBase,
     LevenshteinLevelBase,
     ElseLevelBase,
@@ -14,8 +13,6 @@ from ..comparison_level_library import (  # noqa: F401
 from .spark_base import (
     SparkBase,
 )
-
-_mutable_params["dialect"] = "spark"
 
 
 class null_level(SparkBase, NullLevelBase):

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -1,9 +1,9 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    exact_match_level,
+    ExactMatchLevelBase,
     LevenshteinLevelBase,
     ElseLevelBase,
-    null_level,
+    NullLevelBase,
     DistanceFunctionLevelBase,
     ColumnsReversedLevelBase,
     JaccardLevelBase,
@@ -16,6 +16,14 @@ from .spark_base import (
 )
 
 _mutable_params["dialect"] = "spark"
+
+
+class null_level(SparkBase, NullLevelBase):
+    pass
+
+
+class exact_match_level(SparkBase, ExactMatchLevelBase):
+    pass
 
 
 class else_level(SparkBase, ElseLevelBase):

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -7,7 +7,7 @@ from ..comparison_level_library import (  # noqa: F401
     null_level,
     DistanceFunctionLevelBase,
     columns_reversed_level,
-    jaccard_level,
+    JaccardLevelBase,
     JaroWinklerLevelBase,
     distance_in_km_level,
     ArrayIntersectLevelBase,
@@ -21,9 +21,7 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 _mutable_params["dialect"] = "spark"
 
 
-
 class SparkLevel(DialectLevel):
-
     @property
     def _sql_dialect(self):
         return "spark"
@@ -36,11 +34,18 @@ class SparkLevel(DialectLevel):
 class distance_function_level(SparkLevel, DistanceFunctionLevelBase):
     pass
 
+
 class levenshtein_level(SparkLevel, LevenshteinLevelBase):
     pass
 
+
 class jaro_winkler_level(SparkLevel, JaroWinklerLevelBase):
     pass
+
+
+class jaccard_level(SparkLevel, JaccardLevelBase):
+    pass
+
 
 class array_intersect_level(SparkLevel, ArrayIntersectLevelBase):
     pass

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -8,7 +8,7 @@ from ..comparison_level_library import (  # noqa: F401
     columns_reversed_level,
     JaccardLevelBase,
     JaroWinklerLevelBase,
-    distance_in_km_level,
+    DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
 )
 from .spark_base import (
@@ -35,4 +35,8 @@ class jaccard_level(SparkBase, JaccardLevelBase):
 
 
 class array_intersect_level(SparkBase, ArrayIntersectLevelBase):
+    pass
+
+
+class distance_in_km_level(SparkBase, DistanceInKMLevelBase):
     pass

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -7,6 +7,7 @@ from ..comparison_level_library import (
     ColumnsReversedLevelBase,
     JaccardLevelBase,
     JaroWinklerLevelBase,
+    PercentageDifferenceLevelBase,
     DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
 )
@@ -48,6 +49,10 @@ class jaccard_level(SparkBase, JaccardLevelBase):
 
 
 class array_intersect_level(SparkBase, ArrayIntersectLevelBase):
+    pass
+
+
+class percentage_difference_level(SparkBase, PercentageDifferenceLevelBase):
     pass
 
 

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -5,7 +5,7 @@ from ..comparison_level_library import (  # noqa: F401
     levenshtein_level,
     else_level,
     null_level,
-    distance_function_level,
+    DistanceFunctionLevelBase,
     columns_reversed_level,
     jaccard_level,
     JaroWinklerLevelBase,
@@ -32,6 +32,9 @@ class SparkLevel(DialectLevel):
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
 
+
+class distance_function_level(SparkLevel, DistanceFunctionLevelBase):
+    pass
 
 class jaro_winkler_level(SparkLevel, JaroWinklerLevelBase):
     pass

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -2,7 +2,7 @@ from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
     DialectLevel,
     exact_match_level,
-    levenshtein_level,
+    LevenshteinLevelBase,
     else_level,
     null_level,
     DistanceFunctionLevelBase,
@@ -34,6 +34,9 @@ class SparkLevel(DialectLevel):
 
 
 class distance_function_level(SparkLevel, DistanceFunctionLevelBase):
+    pass
+
+class levenshtein_level(SparkLevel, LevenshteinLevelBase):
     pass
 
 class jaro_winkler_level(SparkLevel, JaroWinklerLevelBase):

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -2,10 +2,10 @@ from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
     exact_match_level,
     LevenshteinLevelBase,
-    else_level,
+    ElseLevelBase,
     null_level,
     DistanceFunctionLevelBase,
-    columns_reversed_level,
+    ColumnsReversedLevelBase,
     JaccardLevelBase,
     JaroWinklerLevelBase,
     DistanceInKMLevelBase,
@@ -16,6 +16,14 @@ from .spark_base import (
 )
 
 _mutable_params["dialect"] = "spark"
+
+
+class else_level(SparkBase, ElseLevelBase):
+    pass
+
+
+class columns_reversed_level(SparkBase, ColumnsReversedLevelBase):
+    pass
 
 
 class distance_function_level(SparkBase, DistanceFunctionLevelBase):

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -1,6 +1,5 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    DialectLevel,
     exact_match_level,
     LevenshteinLevelBase,
     else_level,
@@ -12,40 +11,28 @@ from ..comparison_level_library import (  # noqa: F401
     distance_in_km_level,
     ArrayIntersectLevelBase,
 )
-
-
-def size_array_intersect_sql(col_name_l, col_name_r):
-    return f"size(array_intersect({col_name_l}, {col_name_r}))"
-
+from .spark_base import (
+    SparkBase,
+)
 
 _mutable_params["dialect"] = "spark"
 
 
-class SparkLevel(DialectLevel):
-    @property
-    def _sql_dialect(self):
-        return "spark"
-
-    @property
-    def _size_array_intersect_function(self):
-        return size_array_intersect_sql
-
-
-class distance_function_level(SparkLevel, DistanceFunctionLevelBase):
+class distance_function_level(SparkBase, DistanceFunctionLevelBase):
     pass
 
 
-class levenshtein_level(SparkLevel, LevenshteinLevelBase):
+class levenshtein_level(SparkBase, LevenshteinLevelBase):
     pass
 
 
-class jaro_winkler_level(SparkLevel, JaroWinklerLevelBase):
+class jaro_winkler_level(SparkBase, JaroWinklerLevelBase):
     pass
 
 
-class jaccard_level(SparkLevel, JaccardLevelBase):
+class jaccard_level(SparkBase, JaccardLevelBase):
     pass
 
 
-class array_intersect_level(SparkLevel, ArrayIntersectLevelBase):
+class array_intersect_level(SparkBase, ArrayIntersectLevelBase):
     pass

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -1,5 +1,6 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
+    DialectLevel,
     exact_match_level,
     levenshtein_level,
     else_level,
@@ -7,7 +8,7 @@ from ..comparison_level_library import (  # noqa: F401
     distance_function_level,
     columns_reversed_level,
     jaccard_level,
-    jaro_winkler_level,
+    JaroWinklerLevelBase,
     distance_in_km_level,
     ArrayIntersectLevelBase,
 )
@@ -20,7 +21,9 @@ def size_array_intersect_sql(col_name_l, col_name_r):
 _mutable_params["dialect"] = "spark"
 
 
-class array_intersect_level(ArrayIntersectLevelBase):
+
+class SparkLevel(DialectLevel):
+
     @property
     def _sql_dialect(self):
         return "spark"
@@ -28,3 +31,10 @@ class array_intersect_level(ArrayIntersectLevelBase):
     @property
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
+
+
+class jaro_winkler_level(SparkLevel, JaroWinklerLevelBase):
+    pass
+
+class array_intersect_level(SparkLevel, ArrayIntersectLevelBase):
+    pass

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -27,7 +27,6 @@ from .spark_comparison_level_library import (
 _mutable_params["dialect"] = "spark"
 
 
-
 class distance_function_at_thresholds(
     SparkBase, DistanceFunctionAtThresholdsComparisonBase
 ):
@@ -36,33 +35,25 @@ class distance_function_at_thresholds(
         return distance_function_level
 
 
-class levenshtein_at_thresholds(
-    SparkBase, LevenshteinAtThresholdsComparisonBase
-):
+class levenshtein_at_thresholds(SparkBase, LevenshteinAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return levenshtein_level
 
 
-class jaro_winkler_at_thresholds(
-    SparkBase, JaroWinklerAtThresholdsComparisonBase
-):
+class jaro_winkler_at_thresholds(SparkBase, JaroWinklerAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return jaro_winkler_level
 
 
-class jaccard_at_thresholds(
-    SparkBase, JaccardAtThresholdsComparisonBase
-):
+class jaccard_at_thresholds(SparkBase, JaccardAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return jaccard_level
 
 
-class array_intersect_at_sizes(
-    SparkBase, ArrayIntersectAtSizesComparisonBase
-):
+class array_intersect_at_sizes(SparkBase, ArrayIntersectAtSizesComparisonBase):
     @property
     def _array_intersect_level(self):
         return array_intersect_level

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -5,22 +5,42 @@ from ..comparison_level_library import (
 
 from ..comparison_library import (  # noqa: F401
     exact_match,
-    levenshtein_at_thresholds,
-    distance_function_at_thresholds,
-    jaccard_at_thresholds,
-    jaro_winkler_at_thresholds,
+    DistanceFunctionAtThresholdsComparisonBase,
+    LevenshteinAtThresholdsComparisonBase,
+    JaroWinklerAtThresholdsComparisonBase,
+    JaccardAtThresholdsComparisonBase,
     ArrayIntersectAtSizesComparisonBase,
 )
 
-from .spark_comparison_level_library import (
-    array_intersect_level,
+from .spark_base import (
+    SparkBase,
 )
 
 
 _mutable_params["dialect"] = "spark"
 
 
-class array_intersect_at_sizes(ArrayIntersectAtSizesComparisonBase):
-    @property
-    def _array_intersect_level(self):
-        return array_intersect_level
+class distance_function_at_thresholds(
+    SparkBase, DistanceFunctionAtThresholdsComparisonBase
+):
+    pass
+
+
+class levenshtein_at_thresholds(
+    SparkBase, LevenshteinAtThresholdsComparisonBase
+):
+    pass
+
+
+class jaro_winkler_at_thresholds(
+    SparkBase, JaroWinklerAtThresholdsComparisonBase
+):
+    pass
+
+
+class jaccard_at_thresholds(SparkBase, JaccardAtThresholdsComparisonBase):
+    pass
+
+
+class array_intersect_at_sizes(SparkBase, ArrayIntersectAtSizesComparisonBase):
+    pass

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -16,6 +16,8 @@ from .spark_base import (
     SparkBase,
 )
 from .spark_comparison_level_library import (
+    exact_match_level,
+    null_level,
     else_level,
     distance_function_level,
     levenshtein_level,
@@ -29,6 +31,14 @@ _mutable_params["dialect"] = "spark"
 
 
 class SparkComparison(SparkBase):
+    @property
+    def _exact_match_level(self):
+        return exact_match_level
+
+    @property
+    def _null_level(self):
+        return null_level
+
     @property
     def _else_level(self):
         return else_level

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -15,32 +15,51 @@ from ..comparison_library import (  # noqa: F401
 from .spark_base import (
     SparkBase,
 )
+from .spark_comparison_level_library import (
+    distance_function_level,
+    levenshtein_level,
+    jaro_winkler_level,
+    jaccard_level,
+)
 
 
 _mutable_params["dialect"] = "spark"
 
 
+
 class distance_function_at_thresholds(
     SparkBase, DistanceFunctionAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return distance_function_level
 
 
 class levenshtein_at_thresholds(
     SparkBase, LevenshteinAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return levenshtein_level
 
 
 class jaro_winkler_at_thresholds(
     SparkBase, JaroWinklerAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return jaro_winkler_level
 
 
-class jaccard_at_thresholds(SparkBase, JaccardAtThresholdsComparisonBase):
-    pass
+class jaccard_at_thresholds(
+    SparkBase, JaccardAtThresholdsComparisonBase
+):
+    @property
+    def _distance_level(self):
+        return jaccard_level
 
 
-class array_intersect_at_sizes(SparkBase, ArrayIntersectAtSizesComparisonBase):
+class array_intersect_at_sizes(
+    SparkBase, ArrayIntersectAtSizesComparisonBase
+):
     pass

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -4,7 +4,7 @@ from ..comparison_level_library import (
 
 
 from ..comparison_library import (  # noqa: F401
-    exact_match,
+    ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
     JaroWinklerAtThresholdsComparisonBase,
@@ -16,6 +16,7 @@ from .spark_base import (
     SparkBase,
 )
 from .spark_comparison_level_library import (
+    else_level,
     distance_function_level,
     levenshtein_level,
     jaro_winkler_level,
@@ -27,33 +28,45 @@ from .spark_comparison_level_library import (
 _mutable_params["dialect"] = "spark"
 
 
+class SparkComparison(SparkBase):
+    @property
+    def _else_level(self):
+        return else_level
+
+
+class exact_match(SparkComparison, ExactMatchBase):
+    pass
+
+
 class distance_function_at_thresholds(
-    SparkBase, DistanceFunctionAtThresholdsComparisonBase
+    SparkComparison, DistanceFunctionAtThresholdsComparisonBase
 ):
     @property
     def _distance_level(self):
         return distance_function_level
 
 
-class levenshtein_at_thresholds(SparkBase, LevenshteinAtThresholdsComparisonBase):
+class levenshtein_at_thresholds(SparkComparison, LevenshteinAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return levenshtein_level
 
 
-class jaro_winkler_at_thresholds(SparkBase, JaroWinklerAtThresholdsComparisonBase):
+class jaro_winkler_at_thresholds(
+    SparkComparison, JaroWinklerAtThresholdsComparisonBase
+):
     @property
     def _distance_level(self):
         return jaro_winkler_level
 
 
-class jaccard_at_thresholds(SparkBase, JaccardAtThresholdsComparisonBase):
+class jaccard_at_thresholds(SparkComparison, JaccardAtThresholdsComparisonBase):
     @property
     def _distance_level(self):
         return jaccard_level
 
 
-class array_intersect_at_sizes(SparkBase, ArrayIntersectAtSizesComparisonBase):
+class array_intersect_at_sizes(SparkComparison, ArrayIntersectAtSizesComparisonBase):
     @property
     def _array_intersect_level(self):
         return array_intersect_level

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -1,9 +1,4 @@
-from ..comparison_level_library import (
-    _mutable_params,
-)
-
-
-from ..comparison_library import (  # noqa: F401
+from ..comparison_library import (
     ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
@@ -25,9 +20,6 @@ from .spark_comparison_level_library import (
     jaccard_level,
     array_intersect_level,
 )
-
-
-_mutable_params["dialect"] = "spark"
 
 
 class SparkComparison(SparkBase):

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -20,6 +20,7 @@ from .spark_comparison_level_library import (
     levenshtein_level,
     jaro_winkler_level,
     jaccard_level,
+    array_intersect_level,
 )
 
 
@@ -62,4 +63,6 @@ class jaccard_at_thresholds(
 class array_intersect_at_sizes(
     SparkBase, ArrayIntersectAtSizesComparisonBase
 ):
-    pass
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level

--- a/splink/sqlite/sqlite_base.py
+++ b/splink/sqlite/sqlite_base.py
@@ -1,0 +1,9 @@
+from ..dialect_base import (
+    DialectBase,
+)
+
+
+class SqliteBase(DialectBase):
+    @property
+    def _sql_dialect(self):
+        return "sqlite"

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -11,5 +11,6 @@ from .sqlite_base import (
 
 _mutable_params["dialect"] = "sqlite"
 
+
 class distance_function_level(SqliteBase, DistanceFunctionLevelBase):
     pass

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -1,5 +1,4 @@
-from ..comparison_level_library import (  # noqa: F401
-    _mutable_params,
+from ..comparison_level_library import (
     NullLevelBase,
     ExactMatchLevelBase,
     ElseLevelBase,
@@ -8,8 +7,6 @@ from ..comparison_level_library import (  # noqa: F401
 from .sqlite_base import (
     SqliteBase,
 )
-
-_mutable_params["dialect"] = "sqlite"
 
 
 class null_level(SqliteBase, NullLevelBase):

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -1,9 +1,21 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
+    DialectLevel,
     exact_match_level,
     else_level,
     null_level,
-    distance_function_level,
+    DistanceFunctionLevelBase,
 )
 
 _mutable_params["dialect"] = "sqlite"
+
+
+class SqliteLevel(DialectLevel):
+
+    @property
+    def _sql_dialect(self):
+        return "sqlite"
+
+
+class distance_function_level(SqliteLevel, DistanceFunctionLevelBase):
+    pass

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -1,20 +1,15 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    DialectLevel,
     exact_match_level,
     else_level,
     null_level,
     DistanceFunctionLevelBase,
 )
+from .sqlite_base import (
+    SqliteBase,
+)
 
 _mutable_params["dialect"] = "sqlite"
 
-
-class SqliteLevel(DialectLevel):
-    @property
-    def _sql_dialect(self):
-        return "sqlite"
-
-
-class distance_function_level(SqliteLevel, DistanceFunctionLevelBase):
+class distance_function_level(SqliteBase, DistanceFunctionLevelBase):
     pass

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -1,8 +1,8 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
-    exact_match_level,
+    NullLevelBase,
+    ExactMatchLevelBase,
     ElseLevelBase,
-    null_level,
     DistanceFunctionLevelBase,
 )
 from .sqlite_base import (
@@ -10,6 +10,14 @@ from .sqlite_base import (
 )
 
 _mutable_params["dialect"] = "sqlite"
+
+
+class null_level(SqliteBase, NullLevelBase):
+    pass
+
+
+class exact_match_level(SqliteBase, ExactMatchLevelBase):
+    pass
 
 
 class else_level(SqliteBase, ElseLevelBase):

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -11,7 +11,6 @@ _mutable_params["dialect"] = "sqlite"
 
 
 class SqliteLevel(DialectLevel):
-
     @property
     def _sql_dialect(self):
         return "sqlite"

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -2,7 +2,9 @@ from ..comparison_level_library import (
     NullLevelBase,
     ExactMatchLevelBase,
     ElseLevelBase,
+    ColumnsReversedLevelBase,
     DistanceFunctionLevelBase,
+    PercentageDifferenceLevelBase,
 )
 from .sqlite_base import (
     SqliteBase,
@@ -21,5 +23,13 @@ class else_level(SqliteBase, ElseLevelBase):
     pass
 
 
+class columns_reversed_level(SqliteBase, ColumnsReversedLevelBase):
+    pass
+
+
 class distance_function_level(SqliteBase, DistanceFunctionLevelBase):
+    pass
+
+
+class percentage_difference_level(SqliteBase, PercentageDifferenceLevelBase):
     pass

--- a/splink/sqlite/sqlite_comparison_level_library.py
+++ b/splink/sqlite/sqlite_comparison_level_library.py
@@ -1,7 +1,7 @@
 from ..comparison_level_library import (  # noqa: F401
     _mutable_params,
     exact_match_level,
-    else_level,
+    ElseLevelBase,
     null_level,
     DistanceFunctionLevelBase,
 )
@@ -10,6 +10,10 @@ from .sqlite_base import (
 )
 
 _mutable_params["dialect"] = "sqlite"
+
+
+class else_level(SqliteBase, ElseLevelBase):
+    pass
 
 
 class distance_function_level(SqliteBase, DistanceFunctionLevelBase):

--- a/splink/sqlite/sqlite_comparison_library.py
+++ b/splink/sqlite/sqlite_comparison_library.py
@@ -10,6 +10,8 @@ from .sqlite_base import (
     SqliteBase,
 )
 from .sqlite_comparison_level_library import (
+    exact_match_level,
+    null_level,
     else_level,
     distance_function_level,
 )
@@ -18,6 +20,14 @@ _mutable_params["dialect"] = "sqlite"
 
 
 class SqliteComparison(SqliteBase):
+    @property
+    def _exact_match_level(self):
+        return exact_match_level
+
+    @property
+    def _null_level(self):
+        return null_level
+
     @property
     def _else_level(self):
         return else_level

--- a/splink/sqlite/sqlite_comparison_library.py
+++ b/splink/sqlite/sqlite_comparison_library.py
@@ -22,4 +22,3 @@ class distance_function_at_thresholds(
     @property
     def _distance_level(self):
         return distance_function_level
-

--- a/splink/sqlite/sqlite_comparison_library.py
+++ b/splink/sqlite/sqlite_comparison_library.py
@@ -3,21 +3,32 @@ from ..comparison_level_library import (
 )
 
 from ..comparison_library import (  # noqa: F401
-    exact_match,
+    ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
 )
 from .sqlite_base import (
     SqliteBase,
 )
 from .sqlite_comparison_level_library import (
+    else_level,
     distance_function_level,
 )
 
 _mutable_params["dialect"] = "sqlite"
 
 
+class SqliteComparison(SqliteBase):
+    @property
+    def _else_level(self):
+        return else_level
+
+
+class exact_match(SqliteComparison, ExactMatchBase):
+    pass
+
+
 class distance_function_at_thresholds(
-    SqliteBase, DistanceFunctionAtThresholdsComparisonBase
+    SqliteComparison, DistanceFunctionAtThresholdsComparisonBase
 ):
     @property
     def _distance_level(self):

--- a/splink/sqlite/sqlite_comparison_library.py
+++ b/splink/sqlite/sqlite_comparison_library.py
@@ -1,8 +1,4 @@
-from ..comparison_level_library import (
-    _mutable_params,
-)
-
-from ..comparison_library import (  # noqa: F401
+from ..comparison_library import (
     ExactMatchBase,
     DistanceFunctionAtThresholdsComparisonBase,
 )
@@ -15,8 +11,6 @@ from .sqlite_comparison_level_library import (
     else_level,
     distance_function_level,
 )
-
-_mutable_params["dialect"] = "sqlite"
 
 
 class SqliteComparison(SqliteBase):

--- a/splink/sqlite/sqlite_comparison_library.py
+++ b/splink/sqlite/sqlite_comparison_library.py
@@ -2,10 +2,19 @@ from ..comparison_level_library import (
     _mutable_params,
 )
 
-
 from ..comparison_library import (  # noqa: F401
     exact_match,
-    distance_function_at_thresholds,
+    DistanceFunctionAtThresholdsComparisonBase,
+)
+from .sqlite_base import (
+    SqliteBase,
 )
 
 _mutable_params["dialect"] = "sqlite"
+
+
+class distance_function_at_thresholds(
+    SqliteBase, DistanceFunctionAtThresholdsComparisonBase
+):
+    pass
+

--- a/splink/sqlite/sqlite_comparison_library.py
+++ b/splink/sqlite/sqlite_comparison_library.py
@@ -9,6 +9,9 @@ from ..comparison_library import (  # noqa: F401
 from .sqlite_base import (
     SqliteBase,
 )
+from .sqlite_comparison_level_library import (
+    distance_function_level,
+)
 
 _mutable_params["dialect"] = "sqlite"
 
@@ -16,5 +19,7 @@ _mutable_params["dialect"] = "sqlite"
 class distance_function_at_thresholds(
     SqliteBase, DistanceFunctionAtThresholdsComparisonBase
 ):
-    pass
+    @property
+    def _distance_level(self):
+        return distance_function_level
 

--- a/tests/test_columns_selected.py
+++ b/tests/test_columns_selected.py
@@ -5,7 +5,6 @@ from splink.comparison_level_library import else_level
 
 from splink.duckdb.duckdb_linker import DuckDBLinker
 
-from splink.duckdb.duckdb_comparison_level_library import _mutable_params
 import splink.duckdb.duckdb_comparison_level_library as cll
 
 
@@ -17,11 +16,6 @@ def test_regression(tmp_path):
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv").head(20)
 
     # Overwrite the surname comparison to include duck-db specific syntax
-
-    _mutable_params["dialect"] = "duckdb"  # noqa: F811
-    _mutable_params["levenshtein"] = "levenshtein"
-    _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
-
     for rmc in [True, False]:
         for ricc in [True, False]:
             levels = [
@@ -81,10 +75,6 @@ def test_discussion_example(tmp_path):
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv").head(20)
 
     # Overwrite the surname comparison to include duck-db specific syntax
-
-    _mutable_params["dialect"] = "duckdb"  # noqa: F811
-    _mutable_params["levenshtein"] = "levenshtein"
-    _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
 
     df = df.rename(columns={"first_name": "fname"})
     df["canonicals_fname"] = df["fname"]

--- a/tests/test_columns_selected.py
+++ b/tests/test_columns_selected.py
@@ -1,7 +1,7 @@
 # Regression test for https://github.com/moj-analytical-services/splink/issues/795
 
 import os
-from splink.comparison_level_library import else_level
+from splink.duckdb.duckdb_comparison_level_library import else_level
 
 from splink.duckdb.duckdb_linker import DuckDBLinker
 

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -6,6 +6,7 @@ from splink.comparison_level_library import (
     null_level,
     distance_in_km_level,
     percentage_difference_level,
+    _mutable_params,
 )
 from splink.duckdb.duckdb_linker import DuckDBLinker
 
@@ -62,6 +63,8 @@ def test_haversine_level():
         d["lat_long_arr"] = [d["lat"], d["lon"]]
 
     df = pd.DataFrame(data)
+
+    _mutable_params["dialect"] = "duckdb"
 
     settings = {
         "unique_id_column_name": "id",

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -1,12 +1,11 @@
 import pandas as pd
-from splink.comparison_level_library import (
+from splink.duckdb.duckdb_comparison_level_library import (
     columns_reversed_level,
     else_level,
     exact_match_level,
     null_level,
     distance_in_km_level,
     percentage_difference_level,
-    _mutable_params,
 )
 from splink.duckdb.duckdb_linker import DuckDBLinker
 
@@ -63,8 +62,6 @@ def test_haversine_level():
         d["lat_long_arr"] = [d["lat"], d["lon"]]
 
     df = pd.DataFrame(data)
-
-    _mutable_params["dialect"] = "duckdb"
 
     settings = {
         "unique_id_column_name": "id",

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -6,7 +6,6 @@ from splink.duckdb.duckdb_comparison_library import (
     exact_match,
     jaro_winkler_at_thresholds,
 )
-from splink.duckdb.duckdb_comparison_level_library import _mutable_params
 import pandas as pd
 import pyarrow.parquet as pq
 
@@ -22,11 +21,6 @@ def test_full_example_duckdb(tmp_path):
     settings_dict = get_settings_dict()
 
     # Overwrite the surname comparison to include duck-db specific syntax
-
-    _mutable_params["dialect"] = "duckdb"  # noqa: F811
-    _mutable_params["levenshtein"] = "levenshtein"
-    _mutable_params["jaro_winkler"] = "jaro_winkler_similarity"
-
     settings_dict["comparisons"][0] = jaro_winkler_at_thresholds("first_name")
     settings_dict["comparisons"][1] = jaccard_at_thresholds("SUR name")
     settings_dict["blocking_rules_to_generate_predictions"] = [

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -3,7 +3,6 @@ import os
 from splink.spark.spark_linker import SparkLinker
 import splink.spark.spark_comparison_library as cl
 from splink.spark.spark_comparison_level_library import (
-    _mutable_params,
     array_intersect_level,
     else_level,
 )
@@ -17,7 +16,6 @@ def test_full_example_spark(df_spark, tmp_path):
 
     # Convert a column to an array to enable testing intersection
     df_spark = df_spark.withColumn("email", array("email"))
-    _mutable_params["dialect"] = "spark"
     settings_dict = get_settings_dict()
 
     # Only needed because the value can be overwritten by other tests

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -30,7 +30,6 @@ def test_full_example_sqlite(tmp_path):
     df.to_sql("input_df_tablename", con)
 
     _mutable_params["dialect"] = "sqlite"  # noqa: F811
-    _mutable_params["levenshtein"] = "levenshtein"  # noqa: F811
     settings_dict = get_settings_dict()
     linker = SQLiteLinker(
         "input_df_tablename",
@@ -81,7 +80,6 @@ def test_small_link_example_sqlite():
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     _mutable_params["dialect"] = "sqlite"  # noqa: F811
-    _mutable_params["levenshtein"] = "levenshtein"  # noqa: F811
     settings_dict = get_settings_dict()
 
     settings_dict["link_type"] = "link_only"

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -3,14 +3,8 @@ import os
 import sqlite3
 import pandas as pd
 
-from splink.comparison_level_library import (
-    _mutable_params,
-)
 from basic_settings import get_settings_dict
 from linker_utils import _test_table_registration, register_roc_data
-
-_mutable_params["dialect"] = "sqlite"
-_mutable_params["levenshtein"] = "levenshtein"
 
 
 def test_full_example_sqlite(tmp_path):
@@ -29,7 +23,6 @@ def test_full_example_sqlite(tmp_path):
 
     df.to_sql("input_df_tablename", con)
 
-    _mutable_params["dialect"] = "sqlite"  # noqa: F811
     settings_dict = get_settings_dict()
     linker = SQLiteLinker(
         "input_df_tablename",
@@ -79,7 +72,6 @@ def test_small_link_example_sqlite():
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
-    _mutable_params["dialect"] = "sqlite"  # noqa: F811
     settings_dict = get_settings_dict()
 
     settings_dict["link_type"] = "link_only"

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import pandas as pd
-from splink.comparison_library import exact_match
+from splink.duckdb.duckdb_comparison_library import exact_match
 from splink.duckdb.duckdb_linker import DuckDBLinker
 
 settings_template = {

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -2,9 +2,7 @@ from copy import deepcopy
 import pandas as pd
 from splink.comparison_library import exact_match
 from splink.duckdb.duckdb_linker import DuckDBLinker
-from splink.comparison_level_library import _mutable_params
 
-_mutable_params["dialect"] = "duckdb"
 settings_template = {
     "probability_two_random_records_match": 0.01,
     "unique_id_column_name": "id",

--- a/tests/test_m_train.py
+++ b/tests/test_m_train.py
@@ -1,7 +1,6 @@
 from splink.duckdb.duckdb_linker import DuckDBLinker
 from splink.duckdb.duckdb_comparison_library import levenshtein_at_thresholds
 import pandas as pd
-from splink.comparison_level_library import _mutable_params
 
 
 def test_m_train():
@@ -15,7 +14,6 @@ def test_m_train():
     ]
     df = pd.DataFrame(data)
 
-    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "dedupe_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],

--- a/tests/test_salting_len.py
+++ b/tests/test_salting_len.py
@@ -4,8 +4,6 @@ from tests.basic_settings import get_settings_dict
 
 from splink.spark.spark_linker import SparkLinker
 
-from splink.spark.spark_comparison_level_library import _mutable_params
-
 
 def check_same_ids(df1, df2, unique_id_col="unique_id"):
     col_l = f"{unique_id_col}_l"
@@ -46,8 +44,6 @@ def generate_linker_output(
 def test_salting_spark(spark):
     # Test that the number of rows in salted link jobs is identical
     # to those not salted.
-
-    _mutable_params["dialect"] = "spark"
 
     df_spark = spark.read.csv(
         "./tests/datasets/fake_1000_from_splink_demos.csv", header=True

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -2,7 +2,6 @@ from splink.duckdb.duckdb_comparison_library import levenshtein_at_thresholds
 from splink.duckdb.duckdb_linker import DuckDBLinker
 import pandas as pd
 import numpy as np
-from splink.comparison_level_library import _mutable_params
 
 from pytest import approx
 
@@ -19,7 +18,6 @@ def test_u_train():
     ]
     df = pd.DataFrame(data)
 
-    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "dedupe_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],
@@ -65,7 +63,6 @@ def test_u_train_link_only():
     df_l = pd.DataFrame(data_l)
     df_r = pd.DataFrame(data_r)
 
-    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "link_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],
@@ -115,7 +112,6 @@ def test_u_train_link_only_sample():
 
     target_rows = 1800000
 
-    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "link_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],
@@ -176,7 +172,6 @@ def test_u_train_multilink():
     expected_total_links = 2 * 3 + 2 * 4 + 2 * 7 + 3 * 4 + 3 * 7 + 4 * 7
     expected_total_links_with_dedupes = (2 + 3 + 4 + 7) * (2 + 3 + 4 + 7 - 1) / 2
 
-    _mutable_params["dialect"] = "duckdb"
     settings = {
         "link_type": "link_only",
         "comparisons": [levenshtein_at_thresholds("name", 2)],


### PR DESCRIPTION
Following on from #887, in the interest of keeping the codebase consistent I have converted the rest of the comparison and comparison-level libraries to use an inheritance-based approach rather than `_mutable_params`, which has now been removed completely.

The approach is as follows:
* Each specific template `ComparisonLevel` and `Comparison` inherit from their specific base class
  * Dialect-specific versions inherit from these, and from specific dialect mixins, which contain the relevant properties
  * the mix-ins inherit from a base dialect-class, which gives the default values (previously the unmodified `_mutable_params`
* Dialect-specific `Comparison`s have information attached about relevant dialect-specific `ComparisonLevel`s (via mixins), even in the case where these don't have meaningful differences (such as `exact_match_level`) - this is to ensure that things like `InputColumn` receive the right dialect information. This is a little clunky, but couldn't find a cleaner solution

So how it would work creating new `ComparisonLevel`s:
* Define a new subclass of `ComparisonLevel` in `splink/comparison_level_library.py`, with logic + docstring in the `__init__`. Make reference to anything dialect-specific via a property on the object
* For any dialect this supports this, define a subclass in the appropriate library file, also inheriting from the dialect-specific object. Generally there will be no need to any additional implementation of the class, so the additional code needed compared to the old approach is fairly minimal
* Make any additions to the base dialect object (in `splink/{dialect}/{dialect}_base.py`) if new properties are needed

The approach is similar for a new `Comparison`, with the key added step:
* Any referenced `ComparisonLevel`s in the `__init__` logic need to be referred to via properties on the object
* If not defined already, then the property containing any levels needed may need to be added to the appropriate derived object

Hopefully this is all fairly straightforward to follow from the code itself.

In terms of changes made and not made (as the diff is large):
* All references to `_mutable_params` are gone
* There are no changes to the logic of any `Comparison` or `ComparisonLevel`s, only that they have been made into classes, and properties are used in places where `_mutable_params` would have been before.
* There are no changes to the logic of any tests, only that `_mutable_params` has been removed, and consequently some comparisons are not imported from `splink.comparison_library` but from the relevant dialect-specific library used in the test in question.
* I have also added a few levels into dialect libraries that can use them, as it is no longer (immediately) possible to import from the central library
  * Users can still use a level in a dialect even if we haven't specifically created it - they would just need to create an empty class inheriting from the relevant imported objects

Note: this has the potential to break any scripts using something like the approach in tests:
```py
import splink.comparison_library as cl
...
_mutable_params["dialect"] = "spark"
...
```
in place of
```py
import splink.spark.spark_comparison_library as cl
```
but that is probably not considered usage that is part of the public API.