### PR TITLE
Update and fix table registration

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -205,9 +205,10 @@ class DuckDBLinker(Linker):
         elif isinstance(input, list):
             input = pd.DataFrame.from_records(input)
 
-        # Will error if an invalid data type is passed
+        # Registration errors will automatically
+        # occur if an invalid data type is passed as an argument
         self._con.register(table_name, input)
-        return DuckDBLinkerDataFrame(table_name, table_name, self)
+        return self._table_to_splink_dataframe(table_name, table_name)
 
     def initialise_settings(self, settings_dict: dict):
         if "sql_dialect" not in settings_dict:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -449,7 +449,6 @@ class Linker:
                 This determines the type of table that your results are output in.
         """
 
-
         output_tablename_templated = "__splink__df_sql_query"
 
         splink_dataframe = self._sql_to_splink_dataframe_checking_cache(

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -449,19 +449,26 @@ class Linker:
                 This determines the type of table that your results are output in.
         """
 
-        hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
-        # Ensure hash is valid sql table name
+
         output_tablename_templated = "__splink__df_sql_query"
-        hashed_tablename = f"{output_tablename_templated}_{hash}"
+        # Pandas outputs are instantly cleaned up, so there's no need to check the cache
+        use_cache = False if output_type == "pandas" else True
+        # if output_type != "pandas":
+        #     hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
+        #     output_tablename_templated = f"{output_tablename_templated}{hash}"
 
         splink_dataframe = self._sql_to_splink_dataframe_checking_cache(
             sql,
-            hashed_tablename,
+            output_tablename_templated,
+            materialise_as_hash=False,
+            use_cache=False,
         )
+
         if output_type in ("splink_df", "splinkdf"):
             return splink_dataframe
         elif output_type == "pandas":
             out = splink_dataframe.as_pandas_dataframe()
+            # If pandas, drop the table to cleanup the db
             splink_dataframe.drop_table_from_database()
             return out
         else:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -451,11 +451,6 @@ class Linker:
 
 
         output_tablename_templated = "__splink__df_sql_query"
-        # Pandas outputs are instantly cleaned up, so there's no need to check the cache
-        use_cache = False if output_type == "pandas" else True
-        # if output_type != "pandas":
-        #     hash = hashlib.sha256(sql.encode()).hexdigest()[:7]
-        #     output_tablename_templated = f"{output_tablename_templated}{hash}"
 
         splink_dataframe = self._sql_to_splink_dataframe_checking_cache(
             sql,

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -7,7 +7,7 @@ import math
 
 import pandas as pd
 
-from pyspark.sql import Row
+from pyspark.sql import Row, DataFrame
 
 from ..linker import Linker
 from ..splink_dataframe import SplinkDataFrame
@@ -311,7 +311,7 @@ class SparkLinker(Linker):
         elif isinstance(input, list):
             input = pd.DataFrame.from_records(input)
             input = self.spark.createDataFrame(input)
-        elif type(input).__name__ in ["DataFrame", "Table"]:
+        elif isinstance(input, pd.DataFrame):
             input = self.spark.createDataFrame(input)
 
         input.createOrReplaceTempView(table_name)

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -112,6 +112,10 @@ class SQLiteLinker(Linker):
 
     def _execute_sql_against_backend(self, sql, templated_name, physical_name):
 
+        # In the case of a table already existing in the database,
+        # execute sql is only reached if the user has explicitly turned off the cache
+        self._delete_table_from_database(physical_name)
+
         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
         logger.log(5, log_sql(sql))
 

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -3,7 +3,7 @@ from tests.cc_testing_utils import check_df_equality
 import pytest
 
 
-def _test_table_registration(linker):
+def _test_table_registration(linker, additional_tables_to_register=[]):
 
     # Standard pandas df...
     a = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -22,7 +22,9 @@ def _test_table_registration(linker):
     with pytest.raises(ValueError):
         linker.register_table(test_dict, "__splink_df_pd")
     # Test overwriting works
-    linker.register_table(test_dict, "__splink_df_pd", overwrite=True)
+    linker.register_table(test_dict_df, "__splink_df_pd", overwrite=True)
+    out = linker.query_sql("select * from __splink_df_pd", output_type="pandas")
+    assert check_df_equality(out, test_dict_df)
 
     # Record level dictionary
     b = [
@@ -49,6 +51,11 @@ def _test_table_registration(linker):
     assert check_df_equality(
         pd.DataFrame.from_records(r_dict), pd.DataFrame.from_records(b)
     )
+
+    # Test registration on additional data types for specific linkers
+    if additional_tables_to_register:
+        for table in additional_tables_to_register:
+            linker.register_table(table, "test_table", overwrite=True)
 
 
 def register_roc_data(linker):

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -9,6 +9,7 @@ from splink.spark.spark_comparison_level_library import (
 )
 
 from pyspark.sql.functions import array
+from pyspark.sql.types import StructType, StructField, StringType
 from basic_settings import get_settings_dict
 from linker_utils import _test_table_registration, register_roc_data
 
@@ -90,7 +91,14 @@ def test_full_example_spark(df_spark, tmp_path):
 
     linker.unlinkables_chart(source_dataset="Testing")
 
-    _test_table_registration(linker)
+    # Check spark tables are being registered correctly
+    data = [("Thomas","FakeName"),]
+    schema = StructType(
+        [StructField("firstname",StringType(),True),
+        StructField("lastname",StringType(),True),]
+    )
+    df = linker.spark.createDataFrame(data=data, schema=schema)
+    _test_table_registration(linker, [df, linker.spark.createDataFrame([], StructType([]))])
 
     register_roc_data(linker)
     linker.roc_chart_from_labels_table("labels")

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -92,13 +92,19 @@ def test_full_example_spark(df_spark, tmp_path):
     linker.unlinkables_chart(source_dataset="Testing")
 
     # Check spark tables are being registered correctly
-    data = [("Thomas","FakeName"),]
+    data = [
+        ("Thomas", "FakeName"),
+    ]
     schema = StructType(
-        [StructField("firstname",StringType(),True),
-        StructField("lastname",StringType(),True),]
+        [
+            StructField("firstname", StringType(), True),
+            StructField("lastname", StringType(), True),
+        ]
     )
     df = linker.spark.createDataFrame(data=data, schema=schema)
-    _test_table_registration(linker, [df, linker.spark.createDataFrame([], StructType([]))])
+    _test_table_registration(
+        linker, [df, linker.spark.createDataFrame([], StructType([]))]
+    )
 
     register_roc_data(linker)
     linker.roc_chart_from_labels_table("labels")


### PR DESCRIPTION
There were some slight issues with how SQL querying was being performed with the cache and how spark tables were being registered. These should both now be fixed below.

SQL querying now no longer uses the cache and instead just overwrites the query object every time a new query is performed. I think this makes more sense and should reduce clutter on the users db anyway.

The spark linker simply needed the following check added - `elif isinstance(input, pd.DataFrame):`