### PR TITLE
Add `datediff` comparison levels

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -400,3 +400,56 @@ class ArrayIntersectLevelBase(ComparisonLevel):
     @property
     def _size_array_intersect_function(self):
         raise NotImplementedError("Intersect function not defined on base class")
+
+
+class DateDiffLevelBase(ComparisonLevel):
+    def __init__(
+        self,
+        date_col: str,
+        date_threshold: int,
+        date_metric: str = "day",
+        m_probability=None,
+    ):
+        """Use the ...
+
+        Arguments:
+            date_col (str): Input column name
+            date_threshold (int): The total difference in time between two given
+                dates. This is used in tandem with `date_metric` to determine .
+                If you are using `year` as your metric, then a value of 1 would
+                require that your dates lie within 1 year of one another.
+            date_metric (str): The unit of time with which to measure your
+                `date_threshold`.
+                Your metric should be one of `day`, `month` or `year`.
+                Defaults to `day`.
+            m_probability (float, optional): Starting value for m probability.
+                Defaults to None.
+
+        Returns:
+            ComparisonLevel: A comparison level that evaluates the distance between
+                two coordinates
+        """
+
+        date = InputColumn(date_col, sql_dialect=self._sql_dialect)
+        date_l, date_r = date.names_l_r()
+
+        datediff_sql = self._datediff_function(
+            date_l, date_r, date_threshold, date_metric
+        )
+        label = f"Within {date_threshold} {date_metric}"
+        if date_threshold > 1:
+            label += "s"
+
+        level_dict = {
+            "sql_condition": datediff_sql,
+            "label_for_charts": label,
+        }
+
+        if m_probability:
+            level_dict["m_probability"] = m_probability
+
+        super().__init__(level_dict, sql_dialect=self._sql_dialect)
+
+    @property
+    def _datediff_function(self):
+        raise NotImplementedError("Datediff function not defined on base class")

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -426,8 +426,8 @@ class DateDiffLevelBase(ComparisonLevel):
                 Defaults to None.
 
         Returns:
-            ComparisonLevel: A comparison level that evaluates the distance between
-                two coordinates
+            ComparisonLevel: A comparison level that evaluates whether two dates fall
+                within a given interval.
         """
 
         date = InputColumn(date_col, sql_dialect=self._sql_dialect)

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -412,3 +412,146 @@ class ArrayIntersectAtSizesComparisonBase(Comparison):
     @property
     def _array_intersect_level(self):
         raise NotImplementedError("Intersect level not defined on base class")
+
+
+class DateDiffAtThresholdsComparisonBase(Comparison):
+    def __init__(
+        self,
+        col_name: str,
+        date_thresholds: Union[int, list] = [1],
+        date_metrics: Union[str, list] = ["day"],
+        include_exact_match_level=True,
+        term_frequency_adjustments=False,
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_sizes: Union[float, list] = None,
+        m_probability_else=None,
+    ):
+        """A comparison of the data in the date column `col_name` with various
+        date thresholds and metrics to assess similarity levels.
+
+        An example of the output with default arguments and settings
+        `date_thresholds = [1]` and `date_metrics = ['day']` would be
+        - The two input dates are within 1 day of one another
+        - Anything else (i.e. all other dates lie outside this range)
+
+        `date_thresholds` and `date_metrics` should be used in conjunction
+        with one another.
+        For example, `date_thresholds = [10, 12, 15]` with
+        `date_metrics = ['day', 'month', 'year']` would result in the following checks:
+        - The two dates are within 10 days of one another
+        - The two dates are within 12 months of one another
+        - And the two dates are within 15 years of one another
+
+        Args:
+            col_name (str): The name of the date column to compare.
+            date_thresholds (Union[int, list], optional): The size(s) of given date
+                thresholds, to assess whether two dates fall within a given time interval.
+                These values can be any integer value and should be used in tandem with
+                `date_metrics`.
+            date_metrics (Union[str, list], optional): The unit of time you wish your
+                `date_thresholds` to be measured against.
+                Metrics should be one of `day`, `month` or `year`.
+            include_exact_match_level (bool, optional): If True, include an exact match
+                level. Defaults to True.
+            term_frequency_adjustments (bool, optional): If True, apply term frequency
+                adjustments to the exact match level. Defaults to False.
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_or_probabilities_sizes (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the sizes specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
+
+        Returns:
+            Comparison: A comparison that can be inclued in the Splink settings
+                dictionary.
+        """
+
+        thresholds = ensure_is_iterable(date_thresholds)
+        metrics = ensure_is_iterable(date_metrics)
+
+        error_logger = []
+        if len(thresholds) == 0:
+            error_logger.append(
+                "`date_thresholds` must have at least one element, so that Comparison "
+                "has more than just an 'else' level"
+            )
+
+        if len(metrics) == 0:
+            error_logger.append(
+                "`date_metrics` must have at least one element, so that Comparison "
+                "has more than just an 'else' level"
+            )
+
+        if len(thresholds) != len(metrics):
+            error_logger.append(
+                "There is a difference in length between your supplied `date_thresholds` "
+                "and `date_metrics`. Please ensure that both arguments are of the same length "
+                "before continuing."
+            )
+
+        if any(size <= 0 for size in thresholds):
+            error_logger.append("All entries of `date_thresholds` must be postive")
+
+        if any(metric not in ["day", "month", "year"] for metric in metrics):
+            error_logger.append(
+                "`date_metrics` only accepts `day`, `month` and `year` as valid arguments."
+            )
+
+        if len(error_logger) > 0:
+
+            raise ValueError(
+                "The following errors were identified in your arguments:\n"
+                "\n\n".join(error_logger)
+            )
+
+        if m_probability_or_probabilities_sizes is None:
+            m_probability_or_probabilities_sizes = [None] * len(thresholds)
+        m_probabilities = ensure_is_iterable(m_probability_or_probabilities_sizes)
+
+        comparison_levels = []
+        comparison_levels.append(self._null_level(col_name))
+        if include_exact_match_level:
+            level = self._exact_match_level(
+                col_name,
+                term_frequency_adjustments=term_frequency_adjustments,
+                m_probability=m_probability_exact_match,
+            )
+            comparison_levels.append(level)
+
+        for date_thres, date_metr, m_prob in zip(thresholds, metrics, m_probabilities):
+            level = self._datediff_level(
+                col_name,
+                date_threshold=date_thres,
+                date_metric=date_metr,
+                m_probability=m_prob,
+            )
+            comparison_levels.append(level)
+
+        comparison_levels.append(
+            self._else_level(m_probability=m_probability_else),
+        )
+
+        comparison_desc = ""
+        if include_exact_match_level:
+            comparison_desc += "Exact match vs. "
+
+        thres_desc = ", ".join(
+            [f"{m.title()}(s): {v}" for m, v in zip(metrics, thresholds)]
+        )
+        plural = "" if len(thresholds) == 1 else "s"
+        comparison_desc += (
+            f"Dates within the following threshold{plural} {thres_desc} vs. "
+        )
+        comparison_desc += "anything else"
+
+        comparison_dict = {
+            "comparison_description": comparison_desc,
+            "comparison_levels": comparison_levels,
+        }
+        super().__init__(comparison_dict)
+
+    @property
+    def _datediff_level(self):
+        raise NotImplementedError("Datediff level not defined on base class")

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -420,7 +420,7 @@ class DateDiffAtThresholdsComparisonBase(Comparison):
         self,
         col_name: str,
         date_thresholds: Union[int, list] = [1],
-        date_metrics: Union[str, list] = ["day"],
+        date_metrics: Union[str, list] = ["year"],
         include_exact_match_level=True,
         term_frequency_adjustments=False,
         m_probability_exact_match=None,

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from .comparison import Comparison
 from .misc import ensure_is_iterable
+from .comparison_library_utils import datediff_error_logger
 
 
 class ExactMatchBase(Comparison):
@@ -445,7 +446,8 @@ class DateDiffAtThresholdsComparisonBase(Comparison):
         Args:
             col_name (str): The name of the date column to compare.
             date_thresholds (Union[int, list], optional): The size(s) of given date
-                thresholds, to assess whether two dates fall within a given time interval.
+                thresholds, to assess whether two dates fall within a given time
+                interval.
                 These values can be any integer value and should be used in tandem with
                 `date_metrics`.
             date_metrics (Union[str, list], optional): The unit of time you wish your
@@ -471,40 +473,8 @@ class DateDiffAtThresholdsComparisonBase(Comparison):
         thresholds = ensure_is_iterable(date_thresholds)
         metrics = ensure_is_iterable(date_metrics)
 
-        error_logger = []
-        if len(thresholds) == 0:
-            error_logger.append(
-                "`date_thresholds` must have at least one element, so that Comparison "
-                "has more than just an 'else' level"
-            )
-
-        if len(metrics) == 0:
-            error_logger.append(
-                "`date_metrics` must have at least one element, so that Comparison "
-                "has more than just an 'else' level"
-            )
-
-        if len(thresholds) != len(metrics):
-            error_logger.append(
-                "There is a difference in length between your supplied `date_thresholds` "
-                "and `date_metrics`. Please ensure that both arguments are of the same length "
-                "before continuing."
-            )
-
-        if any(size <= 0 for size in thresholds):
-            error_logger.append("All entries of `date_thresholds` must be postive")
-
-        if any(metric not in ["day", "month", "year"] for metric in metrics):
-            error_logger.append(
-                "`date_metrics` only accepts `day`, `month` and `year` as valid arguments."
-            )
-
-        if len(error_logger) > 0:
-
-            raise ValueError(
-                "The following errors were identified in your arguments:\n"
-                "\n\n".join(error_logger)
-            )
+        # Validate user inputs
+        datediff_error_logger(thresholds, metrics)
 
         if m_probability_or_probabilities_sizes is None:
             m_probability_or_probabilities_sizes = [None] * len(thresholds)

--- a/splink/comparison_library_utils.py
+++ b/splink/comparison_library_utils.py
@@ -4,6 +4,7 @@ def datediff_error_logger(thresholds, metrics):
     # verbose and failing the lint.
 
     error_logger = []
+
     if len(thresholds) == 0:
         error_logger.append(
             "`date_thresholds` must have at least one element, so that Comparison "
@@ -34,8 +35,13 @@ def datediff_error_logger(thresholds, metrics):
 
     if len(error_logger) > 0:
 
+        error_logger.insert(
+            0,
+            "The following error(s) were identified while validating "
+            "your arguments for `datediff_at_thresholds`:"
+        )
+
         raise ValueError(
-            "The following errors were identified in your arguments:\n"
             "\n\n".join(error_logger)
         )
 

--- a/splink/comparison_library_utils.py
+++ b/splink/comparison_library_utils.py
@@ -1,0 +1,42 @@
+def datediff_error_logger(thresholds, metrics):
+
+    # Extracted from the DateDiffAtThresholdsComparisonBase class as that was overly
+    # verbose and failing the lint.
+
+    error_logger = []
+    if len(thresholds) == 0:
+        error_logger.append(
+            "`date_thresholds` must have at least one element, so that Comparison "
+            "has more than just an 'else' level"
+        )
+
+    if len(metrics) == 0:
+        error_logger.append(
+            "`date_metrics` must have at least one element, so that Comparison "
+            "has more than just an 'else' level"
+        )
+
+    if len(thresholds) != len(metrics):
+        error_logger.append(
+            "There is a difference in length between your supplied "
+            "`date_thresholds` and `date_metrics`. Please ensure that both "
+            "arguments are of the same length before continuing."
+        )
+
+    if any(size <= 0 for size in thresholds):
+        error_logger.append("All entries of `date_thresholds` must be postive")
+
+    if any(metric not in ["day", "month", "year"] for metric in metrics):
+        error_logger.append(
+            "`date_metrics` only accepts `day`, `month` and `year` as "
+            "valid arguments."
+        )
+
+    if len(error_logger) > 0:
+
+        raise ValueError(
+            "The following errors were identified in your arguments:\n"
+            "\n\n".join(error_logger)
+        )
+
+    return

--- a/splink/comparison_library_utils.py
+++ b/splink/comparison_library_utils.py
@@ -38,11 +38,9 @@ def datediff_error_logger(thresholds, metrics):
         error_logger.insert(
             0,
             "The following error(s) were identified while validating "
-            "your arguments for `datediff_at_thresholds`:"
+            "your arguments for `datediff_at_thresholds`:",
         )
 
-        raise ValueError(
-            "\n\n".join(error_logger)
-        )
+        raise ValueError("\n\n".join(error_logger))
 
     return

--- a/splink/duckdb/duckb_base.py
+++ b/splink/duckdb/duckb_base.py
@@ -11,6 +11,12 @@ def size_array_intersect_sql(col_name_l, col_name_r):
     )
 
 
+def datediff_sql(col_name_l, col_name_r, date_threshold, date_metric):
+    return f"""
+        abs(date_diff('{date_metric}', {col_name_l}, {col_name_r})) <= {date_threshold}
+    """
+
+
 class DuckDBBase(DialectBase):
     @property
     def _sql_dialect(self):
@@ -19,6 +25,10 @@ class DuckDBBase(DialectBase):
     @property
     def _size_array_intersect_function(self):
         return size_array_intersect_sql
+
+    @property
+    def _datediff_function(self):
+        return datediff_sql
 
     @property
     def _jaro_winkler_name(self):

--- a/splink/duckdb/duckdb_comparison_level_library.py
+++ b/splink/duckdb/duckdb_comparison_level_library.py
@@ -10,6 +10,7 @@ from ..comparison_level_library import (
     DistanceInKMLevelBase,
     PercentageDifferenceLevelBase,
     ArrayIntersectLevelBase,
+    DateDiffLevelBase,
 )
 from .duckb_base import (
     DuckDBBase,
@@ -57,4 +58,8 @@ class percentage_difference_level(DuckDBBase, PercentageDifferenceLevelBase):
 
 
 class distance_in_km_level(DuckDBBase, DistanceInKMLevelBase):
+    pass
+
+
+class datediff_level(DuckDBBase, DateDiffLevelBase):
     pass

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -5,6 +5,7 @@ from ..comparison_library import (
     JaroWinklerAtThresholdsComparisonBase,
     JaccardAtThresholdsComparisonBase,
     ArrayIntersectAtSizesComparisonBase,
+    DateDiffAtThresholdsComparisonBase,
 )
 from .duckb_base import (
     DuckDBBase,
@@ -18,6 +19,7 @@ from .duckdb_comparison_level_library import (
     jaro_winkler_level,
     jaccard_level,
     array_intersect_level,
+    datediff_level,
 )
 
 
@@ -73,3 +75,9 @@ class array_intersect_at_sizes(DuckDBComparison, ArrayIntersectAtSizesComparison
     @property
     def _array_intersect_level(self):
         return array_intersect_level
+
+
+class datediff_at_thresholds(DuckDBComparison, DateDiffAtThresholdsComparisonBase):
+    @property
+    def _datediff_level(self):
+        return datediff_level

--- a/splink/spark/spark_base.py
+++ b/splink/spark/spark_base.py
@@ -7,10 +7,30 @@ def size_array_intersect_sql(col_name_l, col_name_r):
     return f"size(array_intersect({col_name_l}, {col_name_r}))"
 
 
+def datediff_sql(col_name_l, col_name_r, date_threshold, date_metric):
+
+    if date_metric == "day":
+        date_f = f"abs(datediff({col_name_l}, {col_name_r}))"
+    elif date_metric in ["month", "year"]:
+        date_f = f"floor(abs(months_between({col_name_l}, {col_name_r})"
+        if date_metric == "year":
+            date_f += " / 12))"
+        else:
+            date_f += "))"
+
+    return f"""
+        {date_f} <= {date_threshold}
+    """
+
+
 class SparkBase(DialectBase):
     @property
     def _sql_dialect(self):
         return "spark"
+
+    @property
+    def _datediff_function(self):
+        return datediff_sql
 
     @property
     def _size_array_intersect_function(self):

--- a/splink/spark/spark_comparison_level_library.py
+++ b/splink/spark/spark_comparison_level_library.py
@@ -10,6 +10,7 @@ from ..comparison_level_library import (
     PercentageDifferenceLevelBase,
     DistanceInKMLevelBase,
     ArrayIntersectLevelBase,
+    DateDiffLevelBase,
 )
 from .spark_base import (
     SparkBase,
@@ -57,4 +58,8 @@ class percentage_difference_level(SparkBase, PercentageDifferenceLevelBase):
 
 
 class distance_in_km_level(SparkBase, DistanceInKMLevelBase):
+    pass
+
+
+class datediff_level(SparkBase, DateDiffLevelBase):
     pass

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -5,6 +5,7 @@ from ..comparison_library import (
     JaroWinklerAtThresholdsComparisonBase,
     JaccardAtThresholdsComparisonBase,
     ArrayIntersectAtSizesComparisonBase,
+    DateDiffAtThresholdsComparisonBase,
 )
 
 from .spark_base import (
@@ -19,6 +20,7 @@ from .spark_comparison_level_library import (
     jaro_winkler_level,
     jaccard_level,
     array_intersect_level,
+    datediff_level,
 )
 
 
@@ -72,3 +74,9 @@ class array_intersect_at_sizes(SparkComparison, ArrayIntersectAtSizesComparisonB
     @property
     def _array_intersect_level(self):
         return array_intersect_level
+
+
+class datediff_at_thresholds(SparkComparison, DateDiffAtThresholdsComparisonBase):
+    @property
+    def _datediff_level(self):
+        return datediff_level

--- a/tests/test_datediff_level.py
+++ b/tests/test_datediff_level.py
@@ -71,7 +71,7 @@ def gen_settings(type, comparison_library=False):
 
 
 def test_datediff_levels(spark):
-    # def test_datediff_levels():
+
     df = pd.DataFrame(
         [
             {
@@ -125,7 +125,6 @@ def test_datediff_levels(spark):
     # DuckDBFrame
     dlinker = DuckDBLinker(df, duck_settings)
     duck_df_e = dlinker.predict().as_pandas_dataframe()
-    duck_df_e.to_csv("duck_df_e.csv")
     dlinker = DuckDBLinker(df, duck_settings_cll)
     duck_cl_df_e = dlinker.predict().as_pandas_dataframe()
 
@@ -177,3 +176,32 @@ def test_datediff_levels(spark):
                     ]["gamma_dob"].values[0]
                     == k
                 )
+
+
+def test_datediff_error_logger():
+
+    # Differing lengths between thresholds and units
+    with pytest.raises(ValueError):
+        cld.datediff_at_thresholds(
+            "dob", [1], ["day", "month", "year", "year"]
+        )
+    # Negative threshold
+    with pytest.raises(ValueError):
+        cld.datediff_at_thresholds(
+            "dob", [-1], ["day"]
+        )
+    # Invalid metric
+    with pytest.raises(ValueError):
+        cld.datediff_at_thresholds(
+            "dob", [1], ["dy"]
+        )
+    # Threshold len == 0
+    with pytest.raises(ValueError):
+        cld.datediff_at_thresholds(
+            "dob", [], ["dy"]
+        )
+    # Metric len == 0
+    with pytest.raises(ValueError):
+        cld.datediff_at_thresholds(
+            "dob", [1], []
+        )

--- a/tests/test_datediff_level.py
+++ b/tests/test_datediff_level.py
@@ -1,0 +1,179 @@
+import pandas as pd
+import pytest
+
+from splink.duckdb.duckdb_linker import DuckDBLinker
+from splink.spark.spark_linker import SparkLinker
+
+import splink.duckdb.duckdb_comparison_library as cld
+import splink.duckdb.duckdb_comparison_level_library as clld
+import splink.spark.spark_comparison_library as cls
+import splink.spark.spark_comparison_level_library as clls
+
+
+# Capture differing comparison levels to allow unique settings generation
+comp_levels = {
+    "duckdb": {"cl": cld, "cll": clld},
+    "spark": {"cl": cls, "cll": clls},
+}
+
+
+def gen_settings(type, comparison_library=False):
+
+    c_levels = comp_levels[type]
+    exact_match_fn = c_levels["cl"].exact_match("first_name")
+
+    # For testing the comparison library version
+    if comparison_library:
+        return {
+            "link_type": "dedupe_only",
+            "comparisons": [
+                exact_match_fn,
+                c_levels["cl"].datediff_at_thresholds(
+                    "dob", [30, 12, 5, 100], ["day", "month", "year", "year"]
+                ),
+            ],
+        }
+
+    # For testing the cll version
+    dob_diff = {
+        "output_column_name": "dob",
+        "comparison_levels": [
+            c_levels["cll"].null_level("dob"),
+            c_levels["cll"].exact_match_level("dob"),
+            c_levels["cll"].datediff_level(
+                date_col="dob",
+                date_threshold=30,
+                date_metric="day",
+            ),
+            c_levels["cll"].datediff_level(
+                date_col="dob",
+                date_threshold=12,
+                date_metric="month",
+            ),
+            c_levels["cll"].datediff_level(
+                date_col="dob",
+                date_threshold=5,
+                date_metric="year",
+            ),
+            c_levels["cll"].datediff_level(
+                date_col="dob",
+                date_threshold=100,
+                date_metric="year",
+            ),
+            c_levels["cll"].else_level(),
+        ],
+    }
+
+    return {
+        "link_type": "dedupe_only",
+        "comparisons": [exact_match_fn, dob_diff],
+    }
+
+
+def test_datediff_levels(spark):
+    # def test_datediff_levels():
+    df = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "first_name": "Tom",
+                "dob": "2000-01-01",
+            },
+            {
+                "unique_id": 2,
+                "first_name": "Robin",
+                "dob": "2000-01-30",
+            },
+            {
+                "unique_id": 3,
+                "first_name": "Zoe",
+                "dob": "1995-09-30",
+            },
+            {
+                "unique_id": 4,
+                "first_name": "Sam",
+                "dob": "1966-07-30",
+            },
+            {
+                "unique_id": 5,
+                "first_name": "Andy",
+                "dob": "1996-03-25",
+            },
+            {
+                "unique_id": 6,
+                "first_name": "Alice",
+                "dob": "2000-03-25",
+            },
+            {
+                "unique_id": 7,
+                "first_name": "Afua",
+                "dob": "1960-01-01",
+            },
+        ]
+    )
+
+    # Generate our various settings objs
+    duck_settings = gen_settings("duckdb")
+    duck_settings_cll = gen_settings("duckdb", True)
+
+    spark_settings = gen_settings("spark")
+    spark_settings_cll = gen_settings("spark", True)
+
+    # We need to put our column in datetime format for this to work
+    df["dob"] = pd.to_datetime(df["dob"])
+
+    # DuckDBFrame
+    dlinker = DuckDBLinker(df, duck_settings)
+    duck_df_e = dlinker.predict().as_pandas_dataframe()
+    duck_df_e.to_csv("duck_df_e.csv")
+    dlinker = DuckDBLinker(df, duck_settings_cll)
+    duck_cl_df_e = dlinker.predict().as_pandas_dataframe()
+
+    # SparkFrame
+    sparkdf = spark.createDataFrame(df)
+    sparkdf.persist()
+
+    splinker = SparkLinker(
+        sparkdf,
+        spark_settings,
+    )
+    sp_df_e = splinker.predict().as_pandas_dataframe()
+    splinker = SparkLinker(sparkdf, spark_settings_cll)
+    sp_cl_df_e = splinker.predict().as_pandas_dataframe()
+
+    # # Dict key: {size: gamma_level value}
+    size_gamma_lookup = {1: 11, 2: 6, 3: 3, 4: 1}
+
+    linker_outputs = {
+        "duckdb_cll": duck_df_e,
+        "duckdb_cl": duck_cl_df_e,
+        "spark_cll": sp_df_e,
+        "spark_cl": sp_cl_df_e,
+    }
+
+    # Check gamma sizes are as expected
+    for k, v in size_gamma_lookup.items():
+        for linker_pred in linker_outputs.values():
+            assert sum(linker_pred["gamma_dob"] == k) == v
+
+    # Check individual IDs are assigned to the correct gamma values
+    # Dict key: {gamma_value: tuple of ID pairs}
+    size_gamma_lookup = {
+        4: {"id_pairs": [(1, 2)]},
+        3: {"id_pairs": [(3, 5), (1, 6), (2, 6)]},
+        2: {"id_pairs": [(1, 3), (2, 3), (1, 5), (2, 5), (3, 6), (5, 6)]},
+    }
+
+    for k, v in size_gamma_lookup.items():
+        for ids in v["id_pairs"]:
+            for linker_name, linker_pred in linker_outputs.items():
+
+                print(f"Checking IDs: {ids} for {linker_name}")
+
+                assert (
+                    linker_pred.loc[
+                        (linker_pred.unique_id_l == ids[0])
+                        & (linker_pred.unique_id_r == ids[1])
+                    ]["gamma_dob"].values[0]
+                    == k
+                )

--- a/tests/test_datediff_level.py
+++ b/tests/test_datediff_level.py
@@ -182,26 +182,16 @@ def test_datediff_error_logger():
 
     # Differing lengths between thresholds and units
     with pytest.raises(ValueError):
-        cld.datediff_at_thresholds(
-            "dob", [1], ["day", "month", "year", "year"]
-        )
+        cld.datediff_at_thresholds("dob", [1], ["day", "month", "year", "year"])
     # Negative threshold
     with pytest.raises(ValueError):
-        cld.datediff_at_thresholds(
-            "dob", [-1], ["day"]
-        )
+        cld.datediff_at_thresholds("dob", [-1], ["day"])
     # Invalid metric
     with pytest.raises(ValueError):
-        cld.datediff_at_thresholds(
-            "dob", [1], ["dy"]
-        )
+        cld.datediff_at_thresholds("dob", [1], ["dy"])
     # Threshold len == 0
     with pytest.raises(ValueError):
-        cld.datediff_at_thresholds(
-            "dob", [], ["dy"]
-        )
+        cld.datediff_at_thresholds("dob", [], ["dy"])
     # Metric len == 0
     with pytest.raises(ValueError):
-        cld.datediff_at_thresholds(
-            "dob", [1], []
-        )
+        cld.datediff_at_thresholds("dob", [1], [])


### PR DESCRIPTION
This introduces a simple `datediff` comparison class, utilising the new inheritance structure Andy implemented.

Very simply, it allows users to provide date interval levels for a given date field. I've implemented it in both `spark`and `duckdb`for now, as these are the primary linkers people are utilising. It shouldn't be much extra work if we want to get it working in both `athena` and `sqlite`.

The comparison level can take `day`, `month` and `year` as arguments and will compute whether two dates lie within some given time interval.