### PR TITLE
docs updates

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,7 +31,7 @@ jobs:
       - run: tree docs/
 
       #- run: find docs/demos/ \! -name '\docs\demos\*.ipynb'  | xargs --null rm -f
-      - run: pip install --upgrade pip && pip install mkdocs==1.3.0 mknotebooks mkdocs-schema-reader mkdocs-material mkdocs-gen-files mkdocs-autorefs mkdocs-include-markdown-plugin  mkdocs-material-extensions mkdocs-mermaid2-plugin mkdocs-monorepo-plugin mkdocs-semiliterate mkdocs-simple-plugin mkdocstrings mkdocstrings-python mkdocstrings-python-legacy mkdocs-semiliterate
+      - run: pip install --upgrade pip && pip install mkdocs==1.4.2 mknotebooks mkdocs-schema-reader mkdocs-material==8.5.11 mkdocs-gen-files mkdocs-autorefs mkdocs-include-markdown-plugin  mkdocs-material-extensions mkdocs-mermaid2-plugin mkdocs-monorepo-plugin mkdocs-semiliterate mkdocs-simple-plugin mkdocstrings mkdocstrings-python mkdocstrings-python-legacy mkdocs-semiliterate
       - run: pip install jinja2==3.0.3 splink==3.0.0.dev18 && mkdocs gh-deploy --force
       - run: mkdocs --version
       - run: tree docs/

--- a/docs/comparison_level_library.md
+++ b/docs/comparison_level_library.md
@@ -2,21 +2,139 @@
 tags:
   - API
   - comparisons
+  - Levenstein
+  - Jaro-Winkler
+  - Jaccard
 ---
 # Documentation for `comparison_level_library` 
 
-::: splink.comparison_level_library
+
+::: splink.comparison_level_library.NullLevelBase
     handler: python
     selection:
       members:
-        - distance_function_level
-        - null_level
-        - exact_match_level
-        - levenshtein_level
-        - jaccard_level
-        - else_level
-        - columns_reversed_level
-        - array_intersect_level
+        -  __init__
     rendering:
-      show_root_heading: false
-      show_source: true
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+---
+
+::: splink.comparison_level_library.ExactMatchLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+      
+---
+
+::: splink.comparison_level_library.ElseLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+---
+
+
+::: splink.comparison_level_library.DistanceFunctionLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+      
+
+---
+
+::: splink.comparison_level_library.LevenshteinLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false   
+      heading_level: 1
+
+---
+
+
+::: splink.comparison_level_library.JaroWinklerLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+ 
+
+
+::: splink.comparison_level_library.JaccardLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+
+
+::: splink.comparison_level_library.ColumnsReversedLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+
+
+::: splink.comparison_level_library.DistanceInKMLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1    
+
+
+::: splink.comparison_level_library.PercentageDifferenceLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1   
+      
+::: splink.comparison_level_library.ArrayIntersectLevelBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1   

--- a/docs/comparison_library.md
+++ b/docs/comparison_library.md
@@ -2,18 +2,75 @@
 tags:
   - API
   - comparisons
+  - Levenstein
+  - Jaro-Winkler
+  - Jaccard
 ---
 # Documentation for `comparison_library` 
 
-::: splink.comparison_library
+::: splink.comparison_library.ExactMatchBase
     handler: python
     selection:
       members:
-        - exact_match
-        - distance_function_at_thresholds
-        - levenshtein_at_thresholds
-        - jaccard_at_thresholds
-        - array_intersect_at_sizes
+        -  __init__
     rendering:
-      show_root_heading: false
-      show_source: true
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+      
+
+::: splink.comparison_library.DistanceFunctionAtThresholdsComparisonBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+::: splink.comparison_library.LevenshteinAtThresholdsComparisonBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+      
+      
+::: splink.comparison_library.JaccardAtThresholdsComparisonBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false   
+      heading_level: 1
+
+::: splink.comparison_library.JaroWinklerAtThresholdsComparisonBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+::: splink.comparison_library.ArrayIntersectAtSizesComparisonBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 1
+
+      
+      
+      
+    

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+  
+  document$.subscribe(() => {
+    MathJax.typesetPromise()
+  })

--- a/docs/topic_guides/comparators.md
+++ b/docs/topic_guides/comparators.md
@@ -1,0 +1,80 @@
+---
+tags:
+  - API
+  - comparisons
+  - Levenstein
+  - Jaro-Winkler
+  - Jaccard
+---
+# Comparators
+
+
+String comparators are algorithms used in data linkage to compare and evaluate the similarity between two strings of text. These algorithms can be applied to different types of data, including names, addresses, and other identifying information, to determine if two records refer to the same individual or entity.
+
+One common use of string comparators in data linkage is to identify duplicates within a dataset. By comparing the strings of two records and calculating their similarity, the algorithm can flag records that may be duplicates and require further investigation. This can help to improve the accuracy and completeness of the data by eliminating incorrect or redundant information.
+
+Another use of string comparators in data linkage is to merge different datasets or databases. By comparing strings across multiple sources, the algorithm can identify records that refer to the same individual or entity and merge them into a single record. This can be useful for creating a more comprehensive and accurate view of the data, and for identifying trends and patterns that may not be visible in a single dataset.
+
+
+## Jaro similarity
+
+
+The Jaro similarity measure is a string similarity measure that quantifies the similarity between two strings based on the number of common characters between them and their relative position. It is often used in applications such as entity resolution and duplicate detection, and is particularly useful for comparing strings that are similar in length and contain similar characters.
+
+The formula for Jaro similarity is as follows:
+
+$$Jaro = \frac{1}{3} \left[ \frac{m}{|s_1|} + \frac{m}{|s_2|} + \frac{m-t}{m} \right]$$
+
+where $s_1$ and $s_2$ are the two strings being compared, 
+
+$m$ is the number of common characters (which are considered matching only if they are the same and not farther than $\left\lfloor \frac{\min(|s_1|,|s_2|)}{2} \right\rfloor - 1$ characters apart), 
+
+and $t$ is the number of transpositions (which is calculated as the number of matching characters that are not in the right order divided by two).
+
+
+
+
+## Jaro Winkler similarity
+
+
+The formula for Jaro Winkler is:
+
+$$Jaro Winkler = Jaro + p \cdot l \cdot (1 - Jaro)$$
+
+where :
+
+$Jaro$ is the Jaro similarity score, 
+$p$ is the scaling factorfor how much the score is adjusted upwards for having common prefixes.$p$ should not exceed 0.25 
+(i.e. 1/4, with 4 being the maximum length of the prefix being considered), otherwise the similarity could become larger than 1. The standard value for this constant in Winkler's work is $p$ = 0.1 )
+
+$l$ is the length of the common prefix, 
+and $1 - Jaro$ is the penalty for non-matching characters at the beginning of the strings.
+
+
+## Levenstein edit distance 
+
+The Levenstein edit distance is a measure of the similarity between two strings of text. It is calculated by counting the number of operations (insertions, deletions, or substitutions) needed to transform one string into the other.
+
+
+The formula for Levenstein Distance, also known as Edit Distance, is:
+
+$$Levenstein(s_1, s_2) = \min \lbrace \begin{array}{l}
+\text{insertion} \ ,
+\text{deletion} ,
+\text{substitution} 
+\end{array} \rbrace $$
+
+where $s_1$ and $s_2$ are the two strings being compared. This metric measures the minimum number of edit operations (insertions, deletions, and substitutions) required to transform one string into the other, and can be used to compare strings that may not be identical but are still similar.
+
+## Jaccard similarity 
+
+
+The Jaccard similarity is a measure of similarity between two sets of data, and is often used in text analysis to compare the similarity of two string/documents.
+
+The Jaccard similarity formula is:
+
+$$J(A,B)=\frac{|A \cap B|}{|A \cup B|}$$
+
+In order for the algorith to work it is necessary to first divide each string into "shingles." Shingles refer to fixed-size subsets of a given set of data. 
+
+For example, if we have a field containing a long string of words such as an address or a company name, the algorithm divides it into shingles of a fixed size (e.g. one word per shingle or perhaps a trigram). This creates a set of shingles from the original data, which allows us to efficiently calculate the Jaccard similarity between it and other sets of data by comparing the shingles they share

--- a/docs/topic_guides/phonetic.md
+++ b/docs/topic_guides/phonetic.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - API
+  - comparisons
+  - blocking
+  - Soundex
+  - Double Metaphone
+---
+
+
+# Phonetic transformation algorithms
+
+Soundex and Double Metaphone are phonetic matching algorithms that can be used to identify words that sound similar, even if they are spelled differently. These algorithms are often used in a preprocessing step for data linking and can assist in the blocking process. By incorporating them into blocking rules, it allows for possible candidate pairs of entities with phonetically similar transforms to be considered for linking. This can result in a "fuzzier" blocking process, which may be beneficial for certain projects.
+
+## Soundex
+
+Soundex is a widely-used algorithm for phonetic matching. It was developed by Margaret K. Odell and Robert C. Russell in the early 1900s. The basic idea behind Soundex is to encode words based on their sounds, rather than their spelling. This allows words that sound similar to be encoded in the same way, even if they are spelled differently.
+
+To encode a word with Soundex, the algorithm follows these steps:
+
+```
+Retain the first letter of the word.
+Replace each of the following letters with the corresponding number:
+B, F, P, V: 1
+C, G, J, K, Q, S, X, Z: 2
+D, T: 3
+L: 4
+M, N: 5
+R: 6
+
+Replace all other letters with the number 0.
+```
+
+As for an example of similar names having the same Soundex code, consider the names "Smith" and "Smythe". 
+These names are spelled differently, but they have the same pronunciation, so they would be encoded as "S530" using Soundex.
+
+
+## Double Metaphone
+
+Double Metaphone is a more advanced algorithm for phonetic matching, developed by Lawrence Philips in the 1990s. It is based on the Soundex algorithm, but is designed to be more accurate and to handle a wider range of words.
+
+To encode a word with Double Metaphone, the algorithm follows these steps:
+
+```
+Retain the first letter of the word.
+Remove any vowels, except for the first letter.
+Replace certain letters with other letters or combinations of letters, as follows:
+B: B
+C: X if followed by "ia" or "h" (e.g. "Cia" becomes "X", "Ch" becomes "X"), otherwise "S"
+D: J if followed by "ge", "gy", "gi", otherwise "T"
+G: J if followed by "g", "d", "i", "y", "e", otherwise "K"
+K: K
+L: L
+M: M
+N: N
+P: F
+Q: K
+R: R
+S: X if followed by "h" (e.g. "Sh" becomes "X"), otherwise "S"
+T: X if followed by "ia" or "ch" (e.g. "Tia" becomes "X", "Tch" becomes "X"), otherwise "T"
+V: F
+X: KS
+Z: S
+```
+
+For example, surnames such as Cone and Kohn are encoded in the same way as "KN" , because they sound similar even though they are spelled differently. 
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ markdown_extensions:
   - meta
   - admonition
   - pymdownx.details
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
@@ -64,6 +66,8 @@ nav:
       - Defining and customising comparisons: "topic_guides/customising_comparisons.ipynb"
       - Run times, performance and linking large data: "topic_guides/drivers_of_performance.md"
       - Optimising Spark performance: "topic_guides/optimising_spark.md"
+      - Comparators: "topic_guides/comparators.md"
+      - Phonetic transformations for blocking: "topic_guides/phonetic.md"
       - Salting blocking rules: "topic_guides/salting.md"
   - API Reference:
       - Linker API:
@@ -114,3 +118,7 @@ nav:
 
 extra_css:
 - css/custom.css
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
A few bits and bobs for the documentation

- mkdocs has been upgraded from 1.3.0 to 1.4.2 (more features possible). The `documentation.yaml` github action file contains the right versions of packages for this to work.

- pages can display [mathjax](https://www.mathjax.org/) which provides the oportunity to have LaTeX on the docs with the addition of `javascripts/mathjax.js` (javascripts is the folder name mkdocs expects javascript to be in) and the appropriate config on `mkdocs.yml`

- pages added to topic guides about comparators (JW/Jaccard etc) and phonetic transformations (like Soundex and Double Metaphone). Can always add more info here but its a good start.

-  ensured that `comparison_library.md` and `comparison_level_library.md` doc pages  are not empty/broken as they are now. With the current PR the docstrings from the current functions are being shown again . As architecture/internals change this will probably need to be updated (as perhaps doc wise they dont make as much sense, but this needs a discussion)