### PR TITLE
Edit unlinkables table name when logged in db

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1333,7 +1333,9 @@ class Linker:
             sql_infinity_expression=self._infinity_expression,
         )
         for sql in sqls:
-            self._enqueue_sql(sql["sql"], sql["output_table_name"])
+            output_table_name = sql["output_table_name"]
+            output_table_name = output_table_name.replace("predict", "self_link")
+            self._enqueue_sql(sql["sql"], output_table_name)
 
         predictions = self._execute_sql_pipeline(use_cache=False)
 


### PR DESCRIPTION
This PR simply changes the table name of one of our intermediate tables in the `unlinklables_chart` pipeline.

Instead of outputting an additional `__splink__df_predict_abcdef`, we now get a table named `__splink__df_self_link_abcdef`.

Why? When you run a full pipeline, you currently generate multiple `__splink__df_predict` tables and it's difficult to disentangle them. With this change it becomes much simpler to identify which is the primary `predict` table.