### PR TITLE
`add_l_or_r_to_identifier` now has case for type exp.Lambda

### DIFF
--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -11,10 +11,12 @@ def sqlglot_transform_sql(sql, func):
 def _add_l_or_r_to_identifier(node):
     if isinstance(node, exp.Identifier):
         if isinstance(node.parent, exp.Bracket):
-            l_r = node.parent.parent.table
+            l_r = f'_{node.parent.parent.table}'
+        elif isinstance(node.parent, exp.Lambda):
+            l_r = ''
         else:
-            l_r = node.parent.table
-        node.args["this"] += f"_{l_r}"
+            l_r = f'_{node.parent.table}'
+        node.args["this"] += l_r if l_r != '_' else ''
     return node
 
 


### PR DESCRIPTION
Addresses [Issue #965](https://github.com/moj-analytical-services/splink/issues/965), allowing lambda functions to be used in the blocking rules for generating predictions if users want to generate ROC/ precision-recall curves.