### PR TITLE
`add_l_or_r_to_identifier` now has case for type exp.Lambda

### DIFF
--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -11,10 +11,12 @@ def sqlglot_transform_sql(sql, func):
 def _add_l_or_r_to_identifier(node):
     if isinstance(node, exp.Identifier):
         if isinstance(node.parent, exp.Bracket):
-            l_r = node.parent.parent.table
+            l_r = f"_{node.parent.parent.table}"
+        elif isinstance(node.parent, exp.Lambda):
+            l_r = ""
         else:
-            l_r = node.parent.table
-        node.args["this"] += f"_{l_r}"
+            l_r = f"_{node.parent.table}"
+        node.args["this"] += l_r if l_r != "_" else ""
     return node
 
 

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -25,6 +25,11 @@ def test_move_l_r_table_prefix_to_column_suffix():
     expected = "name_l['first'] = name_r['first'] and levenshtein(dob_l, dob_r) < 2"
     assert res.lower() == expected.lower()
 
+    br = "len(list_filter(l.name_list, x -> list_contains(r.name_list, x))) >= 1"
+    res = move_l_r_table_prefix_to_column_suffix(br)
+    expected = "len(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    assert res.lower() == expected.lower()
+
 
 def test_cast_concat_as_varchar():
 


### PR DESCRIPTION
See [this previous PR](https://github.com/moj-analytical-services/splink/pull/979) for more details.