### PR TITLE
Update `find_matches_to_new_records` to automatically generate our tf tables

### DIFF
--- a/splink/settings.py
+++ b/splink/settings.py
@@ -203,7 +203,6 @@ class Settings:
 
         for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.l_name_as_l())
-        for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.r_name_as_r())
 
         for cc in self.comparisons:
@@ -220,7 +219,6 @@ class Settings:
 
         for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.name_l())
-        for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.name_r())
 
         for cc in self.comparisons:
@@ -241,7 +239,6 @@ class Settings:
 
         for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.name_l())
-        for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.name_r())
 
         for cc in self.comparisons:
@@ -262,7 +259,6 @@ class Settings:
 
         for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.name_l())
-        for uid_col in self._unique_id_input_columns:
             cols.append(uid_col.name_r())
 
         for cc in self.comparisons:

--- a/tests/test_find_new_matches.py
+++ b/tests/test_find_new_matches.py
@@ -40,6 +40,13 @@ def test_tf_tables_init_works():
             s,
         )
 
+        # Compute tf table for first name
+        # This:
+        # 1. Does nothing if term frequencies are not used
+        # 2. Should use the cache and not break if tf adj is requested for fn
+        # 3. Use both the cache and also create surname in our final example
+        linker.compute_tf_table("first_name")
+
         # Running without _df_concat_with_tf
         linker.__deepcopy__(None).find_matches_to_new_records(
             [record], blocking_rules=[], match_weight_threshold=-10000

--- a/tests/test_find_new_matches.py
+++ b/tests/test_find_new_matches.py
@@ -1,0 +1,84 @@
+from splink.duckdb.duckdb_linker import DuckDBLinker
+from splink.duckdb.duckdb_comparison_library import exact_match
+import pandas as pd
+from copy import deepcopy
+
+from tests.basic_settings import get_settings_dict
+
+df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+
+settings = get_settings_dict()
+settings_tf = deepcopy(settings, None)
+# Settings with two term frequency columns
+settings_tf["comparisons"][1] = exact_match(
+    "surname", True, m_probability_exact_match=0.7, m_probability_else=0.1
+)
+settings_no_tf = deepcopy(settings, None)
+# Settings with no term frequencies
+settings_no_tf["comparisons"][0] = exact_match(
+    "first_name", False, m_probability_exact_match=0.7, m_probability_else=0.1
+)
+
+# The record to be matched
+record = {
+    "unique_id": 1,
+    "first_name": "Eliza",
+    "surname": "Smith",
+    "dob": "1971-05-24",
+    "city": "London",
+    "email": "eliza@smith.net",
+    "group": 10000,
+}
+
+
+def test_tf_tables_init_works():
+    for s in [settings_tf, settings_no_tf, settings]:
+
+        linker = DuckDBLinker(
+            df,
+            s,
+        )
+
+        # Running without _df_concat_with_tf
+        linker.__deepcopy__(None).find_matches_to_new_records(
+            [record], blocking_rules=[], match_weight_threshold=-10000
+        )
+
+        # Trial for if _df_concat_with_tf already exists...
+        linker._initialise_df_concat_with_tf()
+        linker.find_matches_to_new_records(
+            [record], blocking_rules=[], match_weight_threshold=-10000
+        )
+
+
+def test_matches_work():
+    linker = DuckDBLinker(
+        df,
+        settings,
+    )
+
+    # Train our model to get more reasonable outputs...
+    linker.estimate_u_using_random_sampling(target_rows=1e6)
+
+    blocking_rule = "l.first_name = r.first_name and l.surname = r.surname"
+    linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
+
+    blocking_rule = "l.dob = r.dob"
+    linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
+
+    brs = ["l.surname = r.surname"]
+
+    matches = linker.find_matches_to_new_records(
+        [record], blocking_rules=brs, match_weight_threshold=-10000
+    )
+
+    matches = matches.as_pandas_dataframe()
+    assert len(matches) == 10
+
+    matches = linker.find_matches_to_new_records(
+        [record], blocking_rules=brs, match_weight_threshold=0
+    )
+
+    matches = matches.as_pandas_dataframe()
+    assert len(matches) == 2

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -97,9 +97,6 @@ def test_full_example_duckdb(tmp_path):
         "group": 10000,
     }
 
-    linker.compute_tf_table("first_name")
-    linker._initialise_df_concat_with_tf()
-
     linker.find_matches_to_new_records(
         [record], blocking_rules=[], match_weight_threshold=-10000
     )

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -117,8 +117,6 @@ def test_full_example_spark(df_spark, tmp_path):
         "group": 10000,
     }
 
-    linker.compute_tf_table("first_name")
-
     linker.find_matches_to_new_records(
         [record], blocking_rules=[], match_weight_threshold=-10000
     )


### PR DESCRIPTION
Resolves [Issue #815](https://github.com/moj-analytical-services/splink/issues/815).

The following code either:
1. If `concat_with_tf` exists in the underlying databases, queues up our required term frequency tables in the CTE expression with chains of [these expressions](https://github.com/moj-analytical-services/splink/blob/388a2f71a93208bb01ba1a22f2227aceac380655/splink/term_frequencies.py#L76).
2. If `concat_with_tf` doesn't exist, simply queue up `_initialise_df_concat_with_tf` and don't materialise (as is done in the `predict()` step).

I've added in some quick tests to check both methods work with and without tf tables.
If you'd like to see an expansion of these basic tests, just say.