### PR TITLE
Fixing tooltip for count and sum_matches in comparison viewer dashboard tooltip

### DIFF
--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -9109,14 +9109,14 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	) {
 	  let base_spec_2 = cloneDeep(base_spec);
 	  let sort_field;
+	  data.forEach((d) => {
+		d.sum_matches = d.match_probability * d.count;
+	  });
 	  if (sort_bars == "sort_match_weight") {
 	    data.sort(sort_match_weight);
 	    sort_field = "match_weight";
 	  }
 	  if (sort_bars == "sort_sum_matches") {
-	    data.forEach((d) => {
-	      d.sum_matches = d.match_probability * d.count;
-	    });
 	    data.sort(sort_sum_matches);
 	    sort_field = "sum_matches";
 	  }

--- a/splink/splink_comparison_viewer.py
+++ b/splink/splink_comparison_viewer.py
@@ -44,7 +44,8 @@ def row_examples(linker: Linker, example_rows_per_category=2):
     sql = """
     select *,
         ROW_NUMBER() OVER (PARTITION BY gam_concat order by rand_order)
-            AS row_example_index
+            AS row_example_index,
+        COUNT(*) OVER (PARTITION BY gam_concat) AS count
     from __splink__df_predict_with_row_id
     """
 


### PR DESCRIPTION
Until now, the tooltip found by hovering over the histogram bars on the comparison viewer dashboard has always shown 'NaN' for the count and sum_matches fields. This patch fixes this.

The cumulative comparisons field has yet to be fixed.

All tests pass on [my fork](https://github.com/James-Osmond/splink/pull/6).
