### PR TITLE
feat: Support sqlglot versions >=5.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "altair"
-version = "4.2.1"
+version = "4.2.2"
 description = "Altair: A declarative statistical visualization library for Python."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "altair-4.2.1-py3-none-any.whl", hash = "sha256:67e099a651c78028c4e135e3b5bd9680ed7dd928ca7b61c9c7376c58e41d2b02"},
-    {file = "altair-4.2.1.tar.gz", hash = "sha256:4939fd9119c57476bf305af9ca0bd1aa7779b2450b874d3623660e879d0fcad1"},
+    {file = "altair-4.2.2-py3-none-any.whl", hash = "sha256:8b45ebeaf8557f2d760c5c77b79f02ae12aee7c46c27c06014febab6f849bc87"},
+    {file = "altair-4.2.2.tar.gz", hash = "sha256:39399a267c49b30d102c10411e67ab26374156a84b1aeb9fcd15140429ba49c5"},
 ]
 
 [package.dependencies]
@@ -945,15 +945,18 @@ files = [
 
 [[package]]
 name = "sqlglot"
-version = "5.1.0"
+version = "10.5.10"
 description = "An easily customizable SQL parser and transpiler"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "sqlglot-5.1.0-py3-none-any.whl", hash = "sha256:dac8b6c35170aab8f6b7eadf036ffde9ece971395b53686b2c280911970fa38b"},
-    {file = "sqlglot-5.1.0.tar.gz", hash = "sha256:8f90a0119aaf52cbb3c3cc589ca74661bc0a5be73b9cedaae0f00827f67beaf9"},
+    {file = "sqlglot-10.5.10-py3-none-any.whl", hash = "sha256:09f48b1cc9d21dbfc0c53916d4febf6731e4c8eb318097c7a2c1cb678c54bcaa"},
+    {file = "sqlglot-10.5.10.tar.gz", hash = "sha256:cbac4a89842b3ec4c303a40dc582248c1795f37f1b06425e1e709223194c53b9"},
 ]
+
+[package.extras]
+dev = ["autoflake", "black", "duckdb", "isort", "mypy (>=0.990)", "pandas", "pdoc", "pre-commit", "pyspark", "python-dateutil"]
 
 [[package]]
 name = "tabulate"
@@ -1042,21 +1045,21 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "3.12.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
-    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+    {file = "zipp-3.12.0-py3-none-any.whl", hash = "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"},
+    {file = "zipp-3.12.0.tar.gz", hash = "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "fb9630ec92853e35f9e13cd4a1d126e7b3fbd960affa0234fd99dde5111a48f2"
+content-hash = "3a8ecd972057eeabff0da8565d08e987348bed5ff735693fe5f398da067fe16a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.7"
 jsonschema = ">=3.2,<5.0"
 pandas = "^1.0.0"
 duckdb = "^0.6.0"
-sqlglot = "5.1.0"
+sqlglot = ">=5.1.0"
 altair = "^4.2.0"
 Jinja2 = "^3.0.3"
 

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -1,29 +1,23 @@
 from __future__ import annotations
 
+import logging
 import math
 import re
 from statistics import median
 from textwrap import dedent
 from typing import TYPE_CHECKING
-import logging
-
 
 import sqlglot
 from sqlglot.expressions import Identifier
 from sqlglot.optimizer.normalize import normalize
 
-from .default_from_jsonschema import default_value_from_schema
-from .input_column import InputColumn
-from .misc import (
-    dedupe_preserving_order,
-    interpolate,
-    join_list_with_commas_final_and,
-    match_weight_to_bayes_factor,
-)
-from .parse_sql import get_columns_used_from_sql
 from .constants import LEVEL_NOT_OBSERVED_TEXT
-
-from .input_column import sqlglot_tree_signature
+from .default_from_jsonschema import default_value_from_schema
+from .input_column import InputColumn, sqlglot_tree_signature
+from .misc import (dedupe_preserving_order, interpolate,
+                   join_list_with_commas_final_and,
+                   match_weight_to_bayes_factor)
+from .parse_sql import get_columns_used_from_sql
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:
@@ -411,9 +405,13 @@ class ComparisonLevel:
         sql = self._sql_condition
         if self._is_else_level:
             return True
-
+        dialect = self._sql_dialect
+        # TODO: really self._sql_dialect should always be set, something gets
+        # messed up during the deepcopy()ing of a Comparison
+        if dialect is None:
+            dialect = "spark"
         try:
-            sqlglot.parse_one(sql, read=self._sql_dialect)
+            sqlglot.parse_one(sql, read=dialect)
         except sqlglot.ParseError as e:
             raise ValueError(f"Error parsing sql_statement:\n{sql}") from e
 

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -8,15 +8,22 @@ def sqlglot_transform_sql(sql, func):
     return transformed_tree.sql()
 
 
-def _add_l_or_r_to_identifier(node):
-    if isinstance(node, exp.Identifier):
-        if isinstance(node.parent, exp.Bracket):
-            l_r = f"_{node.parent.parent.table}"
-        elif isinstance(node.parent, exp.Lambda):
-            l_r = ""
-        else:
-            l_r = f"_{node.parent.table}"
-        node.args["this"] += l_r if l_r != "_" else ""
+def _add_l_or_r_to_identifier(node: exp.Expression):
+    if not isinstance(node, exp.Identifier):
+        return node
+
+    p = node.parent
+    if isinstance(p, (exp.Lambda, exp.Anonymous)):
+        # node is the `x` in the lambda `x -> list_contains(r.name_list, x))`
+        parent_table = ""
+    else:
+        parent_table = p.table
+
+    if parent_table != "":
+        l_r = "_" + parent_table
+    else:
+        l_r = ""
+    node.args["this"] += l_r
     return node
 
 


### PR DESCRIPTION
Fixes
https://github.com/moj-analytical-services/splink/issues/991

Note of caution:
poetry.lock has locked the sqlglot version to
10.5.10, so in the future that is the only version
that we will be testing in a dev environment and in CI.
I did check that 5.1.0 still works by
`poetry shell && pip install sqlglot==5.1.0 && pytest tests`,
but we might unwittingly make some changes in the future that
break 5.1.0 compatibilty and we won't know.

One solution would be to actually test 5.1.0 in CI,
but I don't think that effort is worth it. If someone
files a bug report then we fix it, but otherwise
I think we can trust that the sqlglot API is stable enough
that the odds of this are low. Plus I think we can update our
requirements to sqlglot>=6.0.0 in ~6-12 months, so we won't be
living with this risk for a huge long while.