### PR TITLE
_initialise_df_concat optionally returns list

### DIFF
--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -154,7 +154,7 @@ def truth_space_table_from_labels_table(
 ):
 
     # Read from the cache or generate
-    concat_with_tf = linker._initialise_df_concat_with_tf()
+    input_nodes = linker._initialise_df_concat_with_tf(return_as_list=True)
 
     sqls = predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename)
 
@@ -169,7 +169,7 @@ def truth_space_table_from_labels_table(
     for sql in sqls:
         linker._enqueue_sql(sql["sql"], sql["output_table_name"])
 
-    df_truth_space_table = linker._execute_sql_pipeline([concat_with_tf])
+    df_truth_space_table = linker._execute_sql_pipeline(input_nodes)
 
     return df_truth_space_table
 
@@ -257,7 +257,7 @@ def prediction_errors_from_labels_table(
 ):
 
     # Read from the cache or generate
-    concat_with_tf = linker._initialise_df_concat_with_tf()
+    input_nodes = linker._initialise_df_concat_with_tf(return_as_list=True)
 
     sqls = predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename)
 
@@ -297,7 +297,7 @@ def prediction_errors_from_labels_table(
 
     linker._enqueue_sql(sql, "__splink__labels_with_fp_fn_status")
 
-    return linker._execute_sql_pipeline([concat_with_tf])
+    return linker._execute_sql_pipeline(input_nodes)
 
 
 def _predict_from_label_column_sql(linker, label_colname):

--- a/splink/pipeline.py
+++ b/splink/pipeline.py
@@ -51,8 +51,6 @@ class SQLPipeline:
 
         parts = deepcopy(self.queue)
         for df in input_dataframes:
-            if df is None:
-                continue
             if not df.physical_and_template_names_equal:
                 sql = f"select * from {df.physical_name}"
                 task = SQLTask(

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -168,7 +168,7 @@ def _add_100_percentile_to_df_percentiles(percentile_rows):
 
 def profile_columns(linker, column_expressions, top_n=10, bottom_n=10):
 
-    df_concat = linker._initialise_df_concat()
+    input_dataframes = linker._initialise_df_concat(return_as_list=True)
 
     if type(column_expressions) == str:
         column_expressions = [column_expressions]
@@ -178,7 +178,7 @@ def profile_columns(linker, column_expressions, top_n=10, bottom_n=10):
     )
 
     linker._enqueue_sql(sql, "__splink__df_all_column_value_frequencies")
-    df_raw = linker._execute_sql_pipeline([df_concat], materialise_as_hash=True)
+    df_raw = linker._execute_sql_pipeline(input_dataframes, materialise_as_hash=True)
 
     sqls = _get_df_percentiles()
     for sql in sqls:


### PR DESCRIPTION
The possibility of input dataframes being `[None]` was causing problems for some of the logging functionality.

I also think it should probably be avoided by the 'principle of least surprise' - it's supposed to be a list of dataframes.

It's a bit fiddly because I also think it would be surprising if calling `_initialise_df_concat` returned a list.

So by default it returns a SplinkDataFrame or None, but if you pass `return_as_list` it returns either `[splink_df]` or `[]`