### PR TITLE
Df concat and df concat with tf return SplinkDataframe or None

### DIFF
--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -154,7 +154,7 @@ def truth_space_table_from_labels_table(
 ):
 
     # Read from the cache or generate
-    input_nodes = linker._initialise_df_concat_with_tf(return_as_list=True)
+    concat_with_tf = linker._initialise_df_concat_with_tf()
 
     sqls = predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename)
 
@@ -169,7 +169,7 @@ def truth_space_table_from_labels_table(
     for sql in sqls:
         linker._enqueue_sql(sql["sql"], sql["output_table_name"])
 
-    df_truth_space_table = linker._execute_sql_pipeline(input_nodes)
+    df_truth_space_table = linker._execute_sql_pipeline([concat_with_tf])
 
     return df_truth_space_table
 

--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -257,7 +257,7 @@ def prediction_errors_from_labels_table(
 ):
 
     # Read from the cache or generate
-    input_nodes = linker._initialise_df_concat_with_tf(return_as_list=True)
+    nodes_with_tf = linker._initialise_df_concat_with_tf()
 
     sqls = predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename)
 
@@ -297,7 +297,7 @@ def prediction_errors_from_labels_table(
 
     linker._enqueue_sql(sql, "__splink__labels_with_fp_fn_status")
 
-    return linker._execute_sql_pipeline(input_nodes)
+    return linker._execute_sql_pipeline([nodes_with_tf])
 
 
 def _predict_from_label_column_sql(linker, label_colname):

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -146,9 +146,7 @@ class EMTrainingSession:
     def _comparison_vectors(self):
         self._training_log_message()
 
-        nodes_with_tf = self._original_linker._initialise_df_concat_with_tf(
-            materialise=True
-        )
+        nodes_with_tf = self._original_linker._initialise_df_concat_with_tf()
 
         sql = block_using_rules_sql(self._training_linker)
         self._training_linker._enqueue_sql(sql, "__splink__df_blocked")

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -39,7 +39,7 @@ def estimate_u_values(linker: Linker, target_rows):
 
     logger.info("----- Estimating u probabilities using random sampling -----")
 
-    nodes_with_tf = linker._initialise_df_concat_with_tf(materialise=True)
+    nodes_with_tf = linker._initialise_df_concat_with_tf()
 
     original_settings_obj = linker._settings_obj
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1145,6 +1145,12 @@ class Linker:
             threshold_match_weight (float, optional): If specified,
                 filter the results to include only pairwise comparisons with a
                 match_weight above this threshold. Defaults to None.
+            materialise_after_computing_term_frequencies (bool): If true, Splink
+                will materialise the table containing the input nodes (rows)
+                joined to any term frequencies which have been asked
+                for in the settings object.  If False, this will be
+                computed as part of one possibly gigantic CTE
+                pipeline.   Defaults to True
 
         Examples:
             >>> linker = DuckDBLinker(df, connection=":memory:")

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -326,7 +326,7 @@ class Linker:
         else:
             return table_name
 
-    def _initialise_df_concat(self, materialise=False, return_as_list=False):
+    def _initialise_df_concat(self, materialise=False):
         cache = self._intermediate_table_cache
         concat_df = None
         if "__splink__df_concat" in cache:
@@ -346,15 +346,9 @@ class Linker:
                 concat_df = self._execute_sql_pipeline()
                 cache["__splink__df_concat"] = concat_df
 
-        if return_as_list:
-            if concat_df:
-                return [concat_df]
-            else:
-                return []
-
         return concat_df
 
-    def _initialise_df_concat_with_tf(self, materialise=True, return_as_list=False):
+    def _initialise_df_concat_with_tf(self, materialise=True):
         cache = self._intermediate_table_cache
         nodes_with_tf = None
         if "__splink__df_concat_with_tf" in cache:
@@ -377,12 +371,6 @@ class Linker:
             if materialise:
                 nodes_with_tf = self._execute_sql_pipeline()
                 cache["__splink__df_concat_with_tf"] = nodes_with_tf
-
-        if return_as_list:
-            if nodes_with_tf:
-                return [nodes_with_tf]
-            else:
-                return []
 
         return nodes_with_tf
 
@@ -876,10 +864,13 @@ class Linker:
         else:
             # Clear the pipeline if we are materialising
             self._pipeline.reset()
-            concat = self._initialise_df_concat(return_as_list=True)
+            df_concat = self._initialise_df_concat()
+            input_dfs = []
+            if df_concat:
+                input_dfs.append(df_concat)
             sql = term_frequencies_for_single_column_sql(input_col)
             self._enqueue_sql(sql, tf_tablename)
-            tf_df = self._execute_sql_pipeline(concat, materialise_as_hash=True)
+            tf_df = self._execute_sql_pipeline(input_dfs, materialise_as_hash=True)
             self._intermediate_table_cache[tf_tablename] = tf_df
 
         return tf_df
@@ -917,7 +908,7 @@ class Linker:
                 represents a table materialised in the database. Methods on the
                 SplinkDataFrame allow you to access the underlying data.
         """
-        concat_with_tf = self._initialise_df_concat_with_tf(materialise=True)
+        concat_with_tf = self._initialise_df_concat_with_tf()
         sql = block_using_rules_sql(self)
         self._enqueue_sql(sql, "__splink__df_blocked")
         return self._execute_sql_pipeline([concat_with_tf])
@@ -987,7 +978,7 @@ class Linker:
 
         # Ensure this has been run on the main linker so that it can be used by
         # training linked when it checks the cache
-        self._initialise_df_concat_with_tf(materialise=True)
+        self._initialise_df_concat_with_tf()
         estimate_m_values_from_label_column(
             self,
             self._input_tables_dict,
@@ -1091,7 +1082,7 @@ class Linker:
         """
         # Ensure this has been run on the main linker so that it's in the cache
         # to be used by the training linkers
-        self._initialise_df_concat_with_tf(materialise=True)
+        self._initialise_df_concat_with_tf()
 
         if comparisons_to_deactivate:
             # If user provided a string, convert to Comparison object
@@ -1138,6 +1129,7 @@ class Linker:
         self,
         threshold_match_probability: float = None,
         threshold_match_weight: float = None,
+        materialise_after_computing_term_frequencies=True,
     ) -> SplinkDataFrame:
         """Create a dataframe of scored pairwise comparisons using the parameters
         of the linkage model.
@@ -1172,9 +1164,13 @@ class Linker:
 
         # _initialise_df_concat_with_tf returns None if the table doesn't exist
         # and only SQL is queued in this step.
-        input_dataframes = self._initialise_df_concat_with_tf(
-            materialise=False, return_as_list=True
+        nodes_with_tf = self._initialise_df_concat_with_tf(
+            materialise=materialise_after_computing_term_frequencies
         )
+
+        input_dataframes = []
+        if nodes_with_tf:
+            input_dataframes.append(nodes_with_tf)
 
         sql = block_using_rules_sql(self)
         self._enqueue_sql(sql, "__splink__df_blocked")
@@ -1274,9 +1270,7 @@ class Linker:
                     self._enqueue_sql(tf["sql"], tf["output_table_name"])
         else:
             # This queues up our cols_with_tf and df_concat_with_tf tables.
-            concat_with_tf = self._initialise_df_concat_with_tf(
-                materialise=False, return_as_list=False
-            )
+            concat_with_tf = self._initialise_df_concat_with_tf(materialise=False)
 
         if concat_with_tf:
             input_dfs.append(concat_with_tf)
@@ -1433,7 +1427,7 @@ class Linker:
             BlockingRule(f"{uid_l} = {uid_r}")
         ]
 
-        input_nodes = self._initialise_df_concat_with_tf(return_as_list=True)
+        nodes_with_tf = self._initialise_df_concat_with_tf()
 
         sql = block_using_rules_sql(self)
 
@@ -1453,7 +1447,7 @@ class Linker:
             self._enqueue_sql(sql["sql"], output_table_name)
 
         predictions = self._execute_sql_pipeline(
-            input_dataframes=input_nodes, use_cache=False
+            input_dataframes=[nodes_with_tf], use_cache=False
         )
 
         self._settings_obj._blocking_rules_to_generate_predictions = (

--- a/splink/m_from_labels.py
+++ b/splink/m_from_labels.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def estimate_m_from_pairwise_labels(linker, table_name):
 
-    concat_with_tf = linker._initialise_df_concat_with_tf(materialise=True)
+    concat_with_tf = linker._initialise_df_concat_with_tf()
 
     sqls = block_from_labels(linker, table_name)
 

--- a/splink/m_training.py
+++ b/splink/m_training.py
@@ -33,7 +33,7 @@ def estimate_m_values_from_label_column(linker, df_dict, label_colname):
         BlockingRule(f"l.{label_colname} = r.{label_colname}")
     ]
 
-    concat_with_tf = linker._initialise_df_concat_with_tf(materialise=True)
+    concat_with_tf = linker._initialise_df_concat_with_tf()
 
     sql = block_using_rules_sql(training_linker)
     training_linker._enqueue_sql(sql, "__splink__df_blocked")

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -168,7 +168,11 @@ def _add_100_percentile_to_df_percentiles(percentile_rows):
 
 def profile_columns(linker, column_expressions, top_n=10, bottom_n=10):
 
-    input_dataframes = linker._initialise_df_concat(return_as_list=True)
+    df_concat = linker._initialise_df_concat(return_as_list=True)
+
+    input_dataframes = []
+    if df_concat:
+        input_dataframes.append(df_concat)
 
     if type(column_expressions) == str:
         column_expressions = [column_expressions]

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -168,7 +168,7 @@ def _add_100_percentile_to_df_percentiles(percentile_rows):
 
 def profile_columns(linker, column_expressions, top_n=10, bottom_n=10):
 
-    df_concat = linker._initialise_df_concat(return_as_list=True)
+    df_concat = linker._initialise_df_concat()
 
     input_dataframes = []
     if df_concat:


### PR DESCRIPTION
This simplifies `_initialise_df_concat` and `_initialise_df_concat_with_tf` so that they return either a SplinkDataFrame or None