### PR TITLE
Some cache tests

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -99,10 +99,10 @@ class CacheDictWithLogging(UserDict):
         return copy(splink_dataframe)
 
     def __setitem__(self, key, value):
-        super().__setitem__(key, value)
-
         if not isinstance(value, SplinkDataFrame):
             raise TypeError("Cached items must be of type SplinkDataFrame")
+
+        super().__setitem__(key, value)
 
         logger.log(
             1, f"Setting cache for template name {key}" f" with physical name {value}"

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -46,7 +46,7 @@ def missingness_data(linker, input_tablename):
         cache = linker._intermediate_table_cache
         concat_with_tf = "__splink__df_concat_with_tf"
         if concat_with_tf in cache:
-            splink_dataframe = input_tablename[concat_with_tf]
+            splink_dataframe = cache[concat_with_tf]
         else:
             splink_dataframe = linker._initialise_df_concat(materialise=True)
     else:

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -43,12 +43,7 @@ def missingness_sqls(columns, input_tablename):
 def missingness_data(linker, input_tablename):
 
     if input_tablename is None:
-        cache = linker._intermediate_table_cache
-        concat_with_tf = "__splink__df_concat_with_tf"
-        if concat_with_tf in cache:
-            splink_dataframe = cache[concat_with_tf]
-        else:
-            splink_dataframe = linker._initialise_df_concat(materialise=True)
+        splink_dataframe = linker._initialise_df_concat(materialise=True)
     else:
         splink_dataframe = linker._table_to_splink_dataframe(
             input_tablename, input_tablename
@@ -69,13 +64,8 @@ def completeness_data(linker, input_tablename=None, cols=None):
     sqls = []
 
     if input_tablename is None:
-        cache = linker._intermediate_table_cache
-        input_tablename = "__splink__df_concat_with_tf"
-        if input_tablename in cache:
-            splink_dataframe = cache[input_tablename]
-        else:
-            splink_dataframe = linker._initialise_df_concat(materialise=True)
-            input_tablename = splink_dataframe.physical_name
+        df_concat = linker._initialise_df_concat(materialise=True)
+        input_tablename = df_concat.physical_name
 
     columns = linker._settings_obj._columns_used_by_comparisons
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -243,10 +243,8 @@ def test_cache_register_compute_concat_with_tf_table(debug_mode):
     linker.debug_mode = debug_mode
 
     with patch.object(
-            linker,
-            "_execute_sql_against_backend",
-            new=make_mock_execute(linker)
-            ) as mock_execute_sql_pipeline:
+        linker, "_execute_sql_against_backend", new=make_mock_execute(linker)
+    ) as mock_execute_sql_pipeline:
         # can actually register frame, as that part not cached
         # don't need function so use any frame
         linker.register_table_input_nodes_concat_with_tf(df)
@@ -263,10 +261,8 @@ def test_cache_register_compute_tf_table(debug_mode):
     linker.debug_mode = debug_mode
 
     with patch.object(
-            linker,
-            "_execute_sql_against_backend",
-            new=make_mock_execute(linker)
-            ) as mock_execute_sql_pipeline:
+        linker, "_execute_sql_against_backend", new=make_mock_execute(linker)
+    ) as mock_execute_sql_pipeline:
         # can actually register frame, as that part not cached
         # don't need function so use any frame
         linker.register_term_frequency_lookup(df, "first_name")

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,10 +1,27 @@
 import os
-from splink.duckdb.duckdb_linker import DuckDBLinker
+from unittest.mock import patch, create_autospec
+
 import pandas as pd
+import pytest
+
+from splink.duckdb.duckdb_linker import DuckDBLinker, DuckDBLinkerDataFrame
+from splink.linker import SplinkDataFrame
 
 from tests.basic_settings import get_settings_dict
 
 df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+dummy_frame = pd.DataFrame(["id"])
+
+
+def make_mock_execute(linker):
+    # creates a mock version of linker._execute_sql_against_backend,
+    # so we can count calls
+    dummy_splink_df = DuckDBLinkerDataFrame("template", "dummy_frame", linker)
+    mock_execute = create_autospec(
+        linker._execute_sql_against_backend,
+        return_value=dummy_splink_df
+    )
+    return mock_execute
 
 
 def test_cache_id(tmp_path):
@@ -68,3 +85,55 @@ def test_materialising_works():
     linker = DuckDBLinker(df, settings)
     linker._initialise_df_concat_with_tf(materialise=False)
     linker.compute_tf_table("first_name")
+
+
+# run test in/not in debug mode to check functionality in both - cache shouldn't care
+@pytest.mark.parametrize("debug_mode", (False, True))
+def test_cache_access_initialise_df_concat(debug_mode):
+    settings = get_settings_dict()
+
+    linker = DuckDBLinker(df, settings)
+    linker.debug_mode = debug_mode
+    with patch.object(
+            linker,
+            "_execute_sql_against_backend",
+            new=make_mock_execute(linker)
+            ) as mock_execute_sql_pipeline:
+        # shouldn't touch DB if we don't materialise
+        linker._initialise_df_concat_with_tf(materialise=False)
+        mock_execute_sql_pipeline.assert_not_called()
+
+        # this should create the table in the db
+        linker._initialise_df_concat_with_tf(materialise=True)
+        # NB don't specify amount of times it is called, as will depend on debug_mode
+        mock_execute_sql_pipeline.assert_called()
+        # reset the call counter on the mock
+        mock_execute_sql_pipeline.reset_mock()
+
+        # this should NOT touch the database, but instead use the cache
+        linker._initialise_df_concat_with_tf(materialise=True)
+        mock_execute_sql_pipeline.assert_not_called()
+
+        # this should also use the cache - concat will just refer to concat_with_tf
+        linker._initialise_df_concat(materialise=True)
+        mock_execute_sql_pipeline.assert_not_called()
+
+
+@pytest.mark.parametrize("debug_mode", (False, True))
+def test_cache_access_compute_tf_table(debug_mode):
+    settings = get_settings_dict()
+
+    linker = DuckDBLinker(df, settings)
+    linker.debug_mode = debug_mode
+    with patch.object(
+            linker,
+            "_execute_sql_against_backend",
+            new=make_mock_execute(linker)
+            ) as mock_execute_sql_pipeline:
+        linker.compute_tf_table("first_name")
+        mock_execute_sql_pipeline.assert_called()
+        # reset the call counter on the mock
+        mock_execute_sql_pipeline.reset_mock()
+
+        linker.compute_tf_table("first_name")
+        mock_execute_sql_pipeline.assert_not_called()

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -54,6 +54,8 @@ def test_full_example_duckdb(tmp_path):
     linker.estimate_probability_two_random_records_match(
         ["l.email = r.email"], recall=0.3
     )
+    # try missingness chart again now that concat_with_tf is precomputed
+    linker.missingness_chart()
 
     blocking_rule = 'l.first_name = r.first_name and l."SUR name" = r."SUR name"'
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)


### PR DESCRIPTION
A few tests of the new caching mechanism - mainly focussed around ensuring that `_execute_sql_against_backend` is only triggered when the cache should _not_ be used, and _is_ triggered when the cache shouldn't be used.

Worth noting here that this testing approach is not currently robust against methods accidentally not being called - for instance writing `linker._initialise_df_concat_with_tf` instead of `linker._initialise_df_concat_with_tf()` and asserting that the backend-SQL call hasn't happened will pass trivially, without checking what we wish to.

In terms of areas currently using the new cache, `register_table_predict` is not tested, because as far as I can see the cache of this cache entry is not yet checked elsewhere, and `find_matches_to_new_records`, as this will require a more careful approach, and is probably best saved for future work.

In addition there are a couple of changes to the code (with tests covering):
* `missingness_data` uses the in-built linker functions for computing/cache-checking the concat tables - in the process this corrects a typo which caused this to fail when using the cache, which is a code-branch now covered by an additional line in the end-to-end duckdb test
* I have changed the cache `__setitem__` method so that items only get added if they pass the `SplinkDataFrame` type-check, and included a test to cover this, assuming that I have not misinterpreted the intention here.