### PR TITLE
Adds the ability to read directly from a settings filepath

### DIFF
--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -109,6 +109,7 @@ def test_full_example_duckdb(tmp_path):
 
     linker_2 = DuckDBLinker(df, connection=":memory:")
     linker_2.load_settings_from_json(path)
+    DuckDBLinker(df, settings_dict=path)
 
 
 def test_small_link_example_duckdb():


### PR DESCRIPTION
Simply adds the ability to read your settings dictionary directly form a filepath, rather than having to initialise the linker and then run `load_settings_from_json`.