### PR TITLE
add the ability to pass pandas df into the `SparkLinker`

### DIFF
--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -120,3 +120,13 @@ def test_full_example_spark(df_spark, tmp_path):
     linker.find_matches_to_new_records(
         [record], blocking_rules=[], match_weight_threshold=-10000
     )
+
+    # Test differing inputs are accepted
+    settings["link_type"] = "link_only"
+
+    linker = SparkLinker(
+        [df_spark, df_spark.toPandas()],
+        settings,
+        break_lineage_method="checkpoint",
+        num_partitions_on_repartition=2,
+    )


### PR DESCRIPTION
A quick PR in response to [#Issue 1067](https://github.com/moj-analytical-services/splink/issues/1067).

This simply allows the spark linker to accept a pandas df as an input table.

I've also edited `_get_spark_from_input_tables_if_not_provided` to accept `[df, spark_df]` and still function, without explicitly passing the spark session.
