### PR TITLE
Merge load settings methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.docs-venv
 env/
 venv/
 ENV/

--- a/docs/linker.md
+++ b/docs/linker.md
@@ -25,6 +25,7 @@ tags:
         - estimate_probability_two_random_records_match
         - estimate_u_using_random_sampling
         - find_matches_to_new_records
+        - load_settings
         - initialise_settings
         - load_settings_from_json
         - m_u_parameters_chart

--- a/docs/linkerpred.md
+++ b/docs/linkerpred.md
@@ -14,6 +14,7 @@ tags:
         - compute_tf_table
         - deterministic_link
         - find_matches_to_new_records
+        - load_settings
         - load_settings_from_json
         - predict
     rendering:

--- a/docs/topic_guides/salting.md
+++ b/docs/topic_guides/salting.md
@@ -64,7 +64,7 @@ df = spark.read.csv("./tests/datasets/fake_1000_from_splink_demos.csv", header=T
 linker = SparkLinker(df, settings)
 logging.getLogger("splink").setLevel(5)
 
-linker.initialise_settings(settings)
+linker.load_settings(settings)
 linker.deterministic_link()
 
 ```

--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -293,11 +293,6 @@ class AthenaLinker(Linker):
             new_filepath,
         )
 
-    def initialise_settings(self, settings_dict: dict):
-        if "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "presto"
-        super().initialise_settings(settings_dict)
-
     def register_data_on_s3(self, table, alias):
         wr.s3.to_parquet(
             df=table,

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -86,7 +86,7 @@ class DuckDBLinker(Linker):
                 database) for link_only or link_and_dedupe
             settings_dict (dict, optional): A Splink settings dictionary. If not
                 provided when the object is created, can later be added using
-                `linker.initialise_settings()` Defaults to None.
+                `linker.load_settings()` Defaults to None.
             connection (DuckDBPyConnection or str, optional):  Connection to duckdb.
                 If a a string, will instantiate a new connection.  Defaults to :memory:.
                 If the special :temporary: string is provided, an on-disk duckdb

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -218,11 +218,6 @@ class DuckDBLinker(Linker):
         self._con.register(table_name, input)
         return self._table_to_splink_dataframe(table_name, table_name)
 
-    def initialise_settings(self, settings_dict: dict):
-        if "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "duckdb"
-        super().initialise_settings(settings_dict)
-
     def _random_sample_sql(self, proportion, sample_size):
         if proportion == 1.0:
             return ""

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -840,7 +840,9 @@ class Linker:
 
         # If a uid already exists in your settings object, prioritise this
         settings_dict["linker_uid"] = settings_dict.get("linker_uid", self._cache_uid)
-        settings_dict["sql_dialect"] = settings_dict.get("sql_dialect", self._sql_dialect)
+        settings_dict["sql_dialect"] = settings_dict.get(
+            "sql_dialect", self._sql_dialect
+        )
         self._settings_dict = settings_dict
         self._settings_obj_ = Settings(settings_dict)
         self._validate_input_dfs()

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import warnings
 from collections import UserDict
 from copy import Error, copy, deepcopy
 from pathlib import Path
@@ -76,6 +77,8 @@ from .unlinkables import unlinkables_data
 from .vertically_concatenate import vertically_concatenate_sql
 
 logger = logging.getLogger(__name__)
+
+warnings.simplefilter('always', DeprecationWarning)
 
 
 class CacheDictWithLogging(UserDict):
@@ -171,7 +174,7 @@ class Linker:
             input_table_or_tables, input_table_aliases
         )
 
-        if not isinstance(settings_dict, dict | None):
+        if not isinstance(settings_dict, (dict, type(None))):
             self._setup_settings_objs(None)  # feed it a blank settings dictionary
             self.load_settings(settings_dict)
         else:
@@ -870,9 +873,12 @@ class Linker:
         self._settings_obj_ = Settings(settings_dict)
         self._validate_input_dfs()
         self._validate_dialect()
-        logger.log(
-            "`initialise_settings` is deprecated. We advise you use ",
-            "`linker.load_settings()` when loading in your settings or a trained model.",
+
+        warnings.warn(
+            "`initialise_settings` is deprecated. We advise you use " \
+            "`linker.load_settings()` when loading in your settings or a previously " \
+            "trained model.",
+            DeprecationWarning,  # warnings.simplefilter('always', DeprecationWarning)
         )
 
     def load_settings_from_json(self, in_path: str | Path):
@@ -888,6 +894,13 @@ class Linker:
             in_path (str): Path to settings json file
         """
         self.load_settings(in_path)
+
+        warnings.warn(
+            "`load_settings_from_json` is deprecated. We advise you use " \
+            "`linker.load_settings()` when loading in your settings or a previously " \
+            "trained model.",
+            DeprecationWarning,  # warnings.simplefilter('always', DeprecationWarning)
+        )
 
     def compute_tf_table(self, column_name: str) -> SplinkDataFrame:
         """Compute a term frequency table for a given column and persist to the database

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -78,7 +78,7 @@ from .vertically_concatenate import vertically_concatenate_sql
 
 logger = logging.getLogger(__name__)
 
-warnings.simplefilter('always', DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 
 
 class CacheDictWithLogging(UserDict):
@@ -875,8 +875,8 @@ class Linker:
         self._validate_dialect()
 
         warnings.warn(
-            "`initialise_settings` is deprecated. We advise you use " \
-            "`linker.load_settings()` when loading in your settings or a previously " \
+            "`initialise_settings` is deprecated. We advise you use "
+            "`linker.load_settings()` when loading in your settings or a previously "
             "trained model.",
             DeprecationWarning,  # warnings.simplefilter('always', DeprecationWarning)
         )
@@ -896,8 +896,8 @@ class Linker:
         self.load_settings(in_path)
 
         warnings.warn(
-            "`load_settings_from_json` is deprecated. We advise you use " \
-            "`linker.load_settings()` when loading in your settings or a previously " \
+            "`load_settings_from_json` is deprecated. We advise you use "
+            "`linker.load_settings()` when loading in your settings or a previously "
             "trained model.",
             DeprecationWarning,  # warnings.simplefilter('always', DeprecationWarning)
         )

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -6,6 +6,7 @@ import logging
 import os
 from collections import UserDict
 from copy import Error, copy, deepcopy
+from pathlib import Path
 from statistics import median
 
 from splink.input_column import InputColumn, remove_quotes_from_identifiers
@@ -148,7 +149,7 @@ class Linker:
                 dataframes (Pandas and Spark respectively) rather than strings.
             settings_dict (dict, optional): A Splink settings dictionary. If not
                 provided when the object is created, can later be added using
-                `linker.initialise_settings()` Defaults to None.
+                `linker.load_settings()` Defaults to None.
             set_up_basic_logging (bool, optional): If true, sets ups up basic logging
                 so that Splink sends messages at INFO level to stdout. Defaults to True.
             input_table_aliases (Union[str, list], optional): Labels assigned to
@@ -170,12 +171,9 @@ class Linker:
             input_table_or_tables, input_table_aliases
         )
 
-        if isinstance(settings_dict, str):
-            if settings_dict.endswith(".json"):
-                self._setup_settings_objs(None)  # feed it a blank settings dictionary
-                self.load_settings(settings_dict)
-            else:
-                raise ValueError("Invalid settings dictionary provided.")
+        if not isinstance(settings_dict, dict | None):
+            self._setup_settings_objs(None)  # feed it a blank settings dictionary
+            self.load_settings(settings_dict)
         else:
             settings_dict = deepcopy(settings_dict)
             self._setup_settings_objs(settings_dict)
@@ -216,8 +214,8 @@ class Linker:
             raise ValueError(
                 "You did not provide a settings dictionary when you "
                 "created the linker.  To continue, you need to provide a settings "
-                "dictionary using the `initialise_settings()` method on your linker "
-                "object. i.e. linker.initialise_settings(settings_dict)"
+                "dictionary using the `load_settings()` method on your linker "
+                "object. i.e. linker.load_settings(settings_dict)"
             )
         return self._settings_obj_
 
@@ -813,7 +811,7 @@ class Linker:
                 "Please re-run your linkage with it set to True."
             )
 
-    def load_settings(self, settings_dict: dict | str):
+    def load_settings(self, settings_dict: dict | str | Path):
         """Initialise settings for the linker.  To be used if settings were
         not passed to the linker on creation. This can either be in the form
         of a settings dictionary or a filepath to a json file containing a
@@ -822,21 +820,23 @@ class Linker:
         Examples:
             >>> linker = DuckDBLinker(df, connection=":memory:")
             >>> linker.profile_columns(["first_name", "surname"])
-            >>> linker.initialise_settings(settings_dict)
+            >>> linker.load_settings(settings_dict)
 
-            >>> linker.load_settings_from_json("my_settings.json")
+            >>> linker.load_settings("my_settings.json")
 
         Args:
-            settings_dict (dict | str): A Splink settings dictionary or
+            settings_dict (dict | str | Path): A Splink settings dictionary or
                 the path to your settings json file.
         """
 
-        if isinstance(settings_dict, str):
-            if settings_dict.endswith(".json"):
-                with open(settings_dict) as f:
-                    settings_dict = json.load(f)
-            else:
-                raise ValueError("Invalid settings dictionary provided.")
+        if not isinstance(settings_dict, dict):
+            p = Path(settings_dict)
+            if not p.is_file():  # check if it's a valid file/filepath
+                raise ValueError(
+                    "The filepath you have provided is either not a valid file "
+                    "or doesn't exist along the path provided."
+                )
+            settings_dict = json.loads(p.read_text())
 
         # If a uid already exists in your settings object, prioritise this
         settings_dict["linker_uid"] = settings_dict.get("linker_uid", self._cache_uid)
@@ -848,6 +848,47 @@ class Linker:
         self._validate_input_dfs()
         self._validate_dialect()
 
+    def initialise_settings(self, settings_dict: dict):
+        """*This method is now deprecated. Please use `load_settings`
+        when loading existing settings or a pre-trained model.*
+
+        Initialise settings for the linker.  To be used if settings were
+        not passed to the linker on creation.
+        Examples:
+            >>> linker = DuckDBLinker(df, connection=":memory:")
+            >>> linker.profile_columns(["first_name", "surname"])
+            >>> linker.initialise_settings(settings_dict)
+        Args:
+            settings_dict (dict): A Splink settings dictionary
+        """
+        # If a uid already exists in your settings object, prioritise this
+        settings_dict["linker_uid"] = settings_dict.get("linker_uid", self._cache_uid)
+        settings_dict["sql_dialect"] = settings_dict.get(
+            "sql_dialect", self._sql_dialect
+        )
+        self._settings_dict = settings_dict
+        self._settings_obj_ = Settings(settings_dict)
+        self._validate_input_dfs()
+        self._validate_dialect()
+        logger.log(
+            "`initialise_settings` is deprecated. We advise you use ",
+            "`linker.load_settings()` when loading in your settings or a trained model.",
+        )
+
+    def load_settings_from_json(self, in_path: str | Path):
+        """*This method is now deprecated. Please use `load_settings`
+        when loading existing settings or a pre-trained model.*
+
+        Load settings from a `.json` file.
+        This `.json` file would usually be the output of
+        `linker.save_settings_to_json()`
+        Examples:
+            >>> linker.load_settings_from_json("my_settings.json")
+        Args:
+            in_path (str): Path to settings json file
+        """
+        self.load_settings(in_path)
+
     def compute_tf_table(self, column_name: str) -> SplinkDataFrame:
         """Compute a term frequency table for a given column and persist to the database
 
@@ -858,7 +899,7 @@ class Linker:
         Examples:
             >>> # Example 1: Real time linkage
             >>> linker = DuckDBLinker(df, connection=":memory:")
-            >>> linker.load_settings_from_json("saved_settings.json")
+            >>> linker.load_settings("saved_settings.json")
             >>> linker.compute_tf_table("surname")
             >>> linker.compare_two_records(record_left, record_right)
 
@@ -1192,7 +1233,7 @@ class Linker:
 
         Examples:
             >>> linker = DuckDBLinker(df, connection=":memory:")
-            >>> linker.load_settings_from_json("saved_settings.json")
+            >>> linker.load_settings("saved_settings.json")
             >>> df = linker.predict(threshold_match_probability=0.95)
             >>> df.as_pandas_dataframe(limit=5)
 
@@ -1267,7 +1308,7 @@ class Linker:
 
         Examples:
             >>> linker = DuckDBLinker(df)
-            >>> linker.load_settings_from_json("saved_settings.json")
+            >>> linker.load_settings("saved_settings.json")
             >>> # Pre-compute tf tables for any tables with
             >>> # term frequency adjustments
             >>> linker.compute_tf_table("first_name")
@@ -1380,7 +1421,7 @@ class Linker:
 
         Examples:
             >>> linker = DuckDBLinker(df)
-            >>> linker.load_settings_from_json("saved_settings.json")
+            >>> linker.load_settings("saved_settings.json")
             >>> linker.compare_two_records(record_left, record_right)
 
         Returns:
@@ -2053,7 +2094,7 @@ class Linker:
             >>> # and run this against the test data.
             >>> df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
             >>> linker = DuckDBLinker(df)
-            >>> linker.load_settings_from_json("saved_settings.json")
+            >>> linker.load_settings("saved_settings.json")
             >>> linker.unlinkables_chart()
             >>>
             >>> # For more complex code pipelines, you can run an entire pipeline
@@ -2345,7 +2386,7 @@ class Linker:
 
         Examples:
             >>> linker = DuckDBLinker(df, connection=":memory:")
-            >>> linker.load_settings_from_json("saved_settings.json")
+            >>> linker.load_settings("saved_settings.json")
             >>> df_predict = linker.predict(threshold_match_probability=0.95)
             >>> count_pairwise = linker.count_num_comparisons_from_blocking_rules_for_prediction(df_predict)
             >>> count_pairwise.as_pandas_dataframe(limit=5)
@@ -2480,7 +2521,7 @@ class Linker:
     ) -> dict:
         """Save the configuration and parameters of the linkage model to a `.json` file.
 
-        The model can later be loaded back in using `linker.load_settings_from_json()`.
+        The model can later be loaded back in using `linker.load_settings()`.
         The settings dict is also returned in case you want to save it a different way.
 
         Examples:

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -93,7 +93,7 @@ class SparkLinker(Linker):
                 registered in the Spark catalog
             settings_dict (dict, optional): A Splink settings dictionary. If not
                 provided when the object is created, can later be added using
-                `linker.initialise_settings()` Defaults to None.
+                `linker.load_settings()` Defaults to None.
             break_lineage_method (str, optional): Method to use to cache intermediate
                 results.  Can be "checkpoint", "persist", "parquet", "delta_lake_files",
                 "delta_lake_table". Defaults to "parquet".

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -282,11 +282,6 @@ class SparkLinker(Linker):
     def _table_to_splink_dataframe(self, templated_name, physical_name):
         return SparkDataframe(templated_name, physical_name, self)
 
-    def initialise_settings(self, settings_dict: dict):
-        if "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "spark"
-        super().initialise_settings(settings_dict)
-
     def _repartition_if_needed(self, spark_df, templated_name):
         # Repartitioning has two effects:
         # 1. When we persist out results to disk, it results in a predictable

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -108,11 +108,6 @@ class SQLiteLinker(Linker):
     def _table_to_splink_dataframe(self, templated_name, physical_name):
         return SQLiteDataFrame(templated_name, physical_name, self)
 
-    def initialise_settings(self, settings_dict: dict):
-        if "sql_dialect" not in settings_dict:
-            settings_dict["sql_dialect"] = "sqlite"
-        super().initialise_settings(settings_dict)
-
     def _execute_sql_against_backend(self, sql, templated_name, physical_name):
 
         # In the case of a table already existing in the database,

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -46,7 +46,7 @@ def test_cache_id(tmp_path):
     )
     prior = linker._cache_uid
 
-    linker.initialise_settings(get_settings_dict())
+    linker.load_settings(get_settings_dict())
     assert prior == linker._cache_uid
 
     # Test uid from settings

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -36,7 +36,7 @@ def test_cache_id(tmp_path):
     linker.save_settings_to_json(path, overwrite=True)
 
     linker_2 = DuckDBLinker(df, connection=":memory:")
-    linker_2.load_settings_from_json(path)
+    linker_2.load_settings(path)
 
     assert linker_2._settings_obj._cache_uid == prior
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -108,6 +108,7 @@ def test_full_example_duckdb(tmp_path):
 
     linker_2 = DuckDBLinker(df, connection=":memory:")
     linker_2.load_settings(path)
+    linker_2.load_settings_from_json(path)
     DuckDBLinker(df, settings_dict=path)
 
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -28,10 +28,10 @@ def test_full_example_duckdb(tmp_path):
 
     linker = DuckDBLinker(
         df,
-        settings_dict,
         connection=os.path.join(tmp_path, "duckdb.db"),
         output_schema="splink_in_duckdb",
     )
+    linker.load_settings(settings_dict)
 
     linker.count_num_comparisons_from_blocking_rule(
         'l.first_name = r.first_name and l."SUR name" = r."SUR name"'
@@ -107,7 +107,7 @@ def test_full_example_duckdb(tmp_path):
     linker.save_settings_to_json(path)
 
     linker_2 = DuckDBLinker(df, connection=":memory:")
-    linker_2.load_settings_from_json(path)
+    linker_2.load_settings(path)
     DuckDBLinker(df, settings_dict=path)
 
 


### PR DESCRIPTION
This PR is in a response to [#issue 1076](https://github.com/moj-analytical-services/splink/issues/1076) and simply merges `load_settings_from_json()` and `initialise_settings()` into a single method.

If you'd rather keep the methods separated, please close the existing issue and this PR.