### PR TITLE
Workflow test multiple python versions

### DIFF
--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ "3.7.16", "3.8.16", "3.9.10", "3.10.10" ]
+        python-version: [ "3.7.15", "3.8.16", "3.9.10", "3.10.10" ]
     name: Test python ${{ matrix.python-version }}
     steps:
       #----------------------------------------------

--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [ "3.7.16", "3.8.16", "3.9.10", "3.10.10" ]
+    name: Test python ${{ matrix.python-version }}
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -17,7 +21,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.10
+          python-version: ${{ matrix.python-version }}
       #----------------------------------------------
       #  -- save a few section by caching poetry --
       #----------------------------------------------

--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ "3.7.15", "3.8.16", "3.9.10", "3.10.10" ]
-    name: Test python ${{ matrix.python-version }}
+        python-version: [ "3.7.15", "3.8.16", "3.9.10" ]
+    name: Run tests with python verion ${{ matrix.python-version }}
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python


### PR DESCRIPTION
As we have encountered a couple of issues around version compatibility I thought it might be useful to include automatic running of the tests across the minor python versions we support - the actual versions can be adjusted as needed. I realise this adds a few more checks, but as they run independently and are not hugely time-consuming it seemed to me to be a reasonable trade-off to help catch compatibility issues earlier.

3.10+ not currently included as the unmodified requirements cause some issues with these as things stand - will be easy to add in once resolved.

Feel free to close if this has already been discussed+dismissed/is not wanted.