### PR TITLE
Added error message to catch pandas null casting issue when read into duckdb

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -144,6 +144,8 @@ class DuckDBLinker(Linker):
 
             if type(table).__name__ in ["DataFrame", "Table"]:
                 con.register(alias, table)
+                if isinstance(table, pd.DataFrame):
+                    self._check_cast_error(alias)
                 table = alias
 
             homogenised_tables.append(duckdb_load_from_file(table))
@@ -246,6 +248,22 @@ class DuckDBLinker(Linker):
         except error:
             return False
         return True
+
+    def _check_cast_error(self, alias):
+        from duckdb import InvalidInputException
+
+        error = InvalidInputException
+
+        try:
+            # fetch df is required as otherwise lazily evaluated and it breaks
+            # other queries.
+            self._con.execute(f"select * from {alias} limit 1").fetch_df()
+        except error as e:
+            raise InvalidInputException(
+                "DuckDB cannot infer datatypes of one or more "
+                "columns. Try converting dataframes "
+                "to pyarrow tables before adding to your linker."
+            ) from e
 
     def _delete_table_from_database(self, name):
         drop_sql = f"""

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -1,7 +1,9 @@
 import os
 
 import pandas as pd
+import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 from basic_settings import get_settings_dict
 from linker_utils import _test_table_registration, register_roc_data
 
@@ -180,3 +182,18 @@ def test_duckdb_arrow_array():
     )
     df = linker.deterministic_link().as_pandas_dataframe()
     assert len(df) == 2
+
+
+def test_cast_error():
+    from duckdb import InvalidInputException
+
+    forenames = [None, "jack", None] * 1000
+    data = {"id": range(0, len(forenames)), "forename": forenames}
+    df = pd.DataFrame(data)
+
+    with pytest.raises(InvalidInputException):
+        DuckDBLinker(df)
+
+    # convert to pyarrow table
+    df = pa.Table.from_pandas(df)
+    DuckDBLinker(df)


### PR DESCRIPTION
Addresses [issue #1024](https://github.com/moj-analytical-services/splink/issues/1024).

This PR adds a simple error message to prompt users to convert a pandas dataframe to a pyarrow table if they encounter the casting data type error mentioned in the above issue.

When pandas 2.0 is released, we can see if the new pyarrow backend functionality fixes this issue.