### PR TITLE
add a bash script for linting

### DIFF
--- a/docs/dev_guides/changing_splink/lint.md
+++ b/docs/dev_guides/changing_splink/lint.md
@@ -1,0 +1,22 @@
+## Linting your code
+
+For linting, we currently make use of both [ruff](https://github.com/charliermarsh/ruff) and [black](https://github.com/psf/black).
+
+These are used to ensure we produce readable, maintainable, and more consistent code.
+
+To quickly run both linters, simply run this bash script. The *-f* flag is called to run an automatic fix with ruff.
+If you simply wish for ruff to print the errors it finds to the console, remove this flag.
+
+```sh
+source scripts/lint.sh -f  # with the fix flag
+source scripts/lint.sh  # without
+```
+
+Alternatively, you can run ruff and black separately from a terminal instance.
+
+For black, you need to run:
+`black .`
+
+and ruff requires:
+`ruff --fix .` for automatic fixes and error printouts
+or `ruff --show-source .` for a more thorough breakdown.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
   - Developers' guides:
       - Making Changes to Splink:
         - Building a Virtual Environment: "dev_guides/changing_splink/building_env_locally.md"
+        - Linting: "dev_guides/changing_splink/lint.md"
         - Building Docs: "dev_guides/changing_splink/build_docs_locally.md"
         - Running Tests: "dev_guides/changing_splink/running_tests_locally.md"
       - Caching and pipelining: "dev_guides/caching.md"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-echo "======================="
-echo "Running black to clean your files"
-echo "======================="
+line_block="=============="
+black_run="Running black to clean your files"
+echo "$line_block $black_run $line_block"
+
 black .
 
 OPTIND=1
 
-echo "======================="
-echo "Running the ruff linter"
-echo "======================="
+ruff_run="Running the ruff linter"
+echo "$line_block $ruff_run $line_block"
 
 while getopts ":f" opt; do
   case $opt in

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "======================="
+echo "Running black to clean your files"
+echo "======================="
+black .
+
+OPTIND=1
+
+echo "======================="
+echo "Running the ruff linter"
+echo "======================="
+
+while getopts ":f" opt; do
+  case $opt in
+    f)
+      echo "--fix was run for your scripts" >&2
+      ruff --fix . --quiet
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG. Only -f (fix) is accepted." >&2
+      ;;
+  esac
+done
+
+ruff --show-source .


### PR DESCRIPTION
A quick bash script to run our linters. This contains an optional `-f` flag to allows users to autofix, should they want to use that feature in ruff.