### PR TITLE
update with parametrize to test more file loading options

### DIFF
--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -2,6 +2,7 @@ import os
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.csv as pa_csv
 import pyarrow.parquet as pq
 import pytest
 from basic_settings import get_settings_dict
@@ -114,31 +115,40 @@ def test_full_example_duckdb(tmp_path):
     DuckDBLinker(df, settings_dict=path)
 
 
-def test_small_link_example_duckdb():
-
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    settings_dict = get_settings_dict()
-
-    settings_dict["link_type"] = "link_only"
-
-    linker = DuckDBLinker(
-        [df, df],
-        settings_dict,
-        connection=":memory:",
-        output_schema="splink_in_duckdb",
-    )
-
-    linker.predict()
-
-
-def test_duckdb_load_from_file():
+@pytest.mark.parametrize(
+    ("df"),
+    [
+        pytest.param(
+            pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv"),
+            id="DuckDB link from pandas df",
+        ),
+        pytest.param(
+            "./tests/datasets/fake_1000_from_splink_demos.csv",
+            id="DuckDB load from file",
+        ),
+        pytest.param(
+            pa.Table.from_pandas(
+                pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+            ),
+            id="DuckDB link - convert pandas to pyarrow df",
+        ),
+        pytest.param(
+            pa_csv.read_csv(
+                "./tests/datasets/fake_1000_from_splink_demos.csv",
+                convert_options=pa_csv.ConvertOptions(
+                    strings_can_be_null=True, null_values=["", "", "NULL"]
+                ),
+            ),
+            id="DuckDB link - read directly from filepath with pyarrow",
+        ),
+    ],
+)
+def test_duckdb_load_from_file(df):
 
     settings = get_settings_dict()
 
-    f = "./tests/datasets/fake_1000_from_splink_demos.csv"
-
     linker = DuckDBLinker(
-        f,
+        df,
         settings,
     )
 
@@ -147,7 +157,7 @@ def test_duckdb_load_from_file():
     settings["link_type"] = "link_only"
 
     linker = DuckDBLinker(
-        [f, f],
+        [df, df],
         settings,
         input_table_aliases=["testing1", "testing2"],
     )


### PR DESCRIPTION
A quick adjustment to the duckdb test to test more ways of loading in your data.

We should probably do something similar for the other linkers.

We may also want to expand this to ingest data from polars and other df packages at some point too.