### PR TITLE
Simplify specific implementations of SplinkDataframe

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -50,9 +50,7 @@ def _verify_athena_inputs(database, bucket, boto3_session):
 
 
 class AthenaDataFrame(SplinkDataFrame):
-    def __init__(self, templated_name, physical_name, athena_linker):
-        super().__init__(templated_name, physical_name)
-        self.athena_linker = athena_linker
+    linker: AthenaLinker
 
     @property
     def columns(self):
@@ -60,7 +58,7 @@ class AthenaDataFrame(SplinkDataFrame):
         d = wr.catalog.get_table_types(
             database=t[0],
             table=t[1],
-            boto3_session=self.athena_linker.boto3_session,
+            boto3_session=self.linker.boto3_session,
         )
 
         cols = list(d.keys())
@@ -73,17 +71,17 @@ class AthenaDataFrame(SplinkDataFrame):
 
         self._check_drop_folder_created_by_splink(force_non_splink_table)
         self._check_drop_table_created_by_splink(force_non_splink_table)
-        self.athena_linker.drop_table_from_database_if_exists(self.physical_name)
-        self.athena_linker.delete_table_from_s3(self.physical_name)
+        self.linker.drop_table_from_database_if_exists(self.physical_name)
+        self.linker.delete_table_from_s3(self.physical_name)
 
     def _check_drop_folder_created_by_splink(self, force_non_splink_table=False):
 
-        filepath = self.athena_linker.boto_utils.s3_output
+        filepath = self.linker.boto_utils.s3_output
         filename = self.physical_name
         # Validate that the folder is a splink generated folder...
         files = wr.s3.list_objects(
             path=os.path.join(filepath, filename),
-            boto3_session=self.athena_linker.boto3_session,
+            boto3_session=self.linker.boto3_session,
             ignore_empty=True,
         )
 
@@ -91,7 +89,7 @@ class AthenaDataFrame(SplinkDataFrame):
             if not force_non_splink_table:
                 raise ValueError(
                     f"You've asked to drop data housed under the filepath "
-                    f"{self.athena_linker.boto_utils.s3_output} from your "
+                    f"{self.linker.boto_utils.s3_output} from your "
                     "s3 output bucket, which is not a folder created by "
                     "Splink. If you really want to delete this data, you "
                     "can do so by setting force_non_splink_table=True."
@@ -100,7 +98,7 @@ class AthenaDataFrame(SplinkDataFrame):
         # validate that the ctas_query_info is for the given table
         # we're interacting with
         if (
-            self.athena_linker.ctas_query_info[self.physical_name]["ctas_table"]
+            self.linker.ctas_query_info[self.physical_name]["ctas_table"]
             != self.physical_name
         ):
             raise ValueError(
@@ -121,12 +119,12 @@ class AthenaDataFrame(SplinkDataFrame):
 
         out_df = wr.athena.read_sql_query(
             sql=sql,
-            database=self.athena_linker.output_schema,
-            s3_output=self.athena_linker.boto_utils.s3_output,
+            database=self.linker.output_schema,
+            s3_output=self.linker.boto_utils.s3_output,
             keep_files=False,
             ctas_approach=True,
             use_threads=True,
-            boto3_session=self.athena_linker.boto3_session,
+            boto3_session=self.linker.boto3_session,
         )
         return out_df
 
@@ -137,9 +135,7 @@ class AthenaDataFrame(SplinkDataFrame):
 
     def get_schema_info(self, input_table):
         t = input_table.split(".")
-        return (
-            t if len(t) > 1 else [self.athena_linker.output_schema, self.physical_name]
-        )
+        return t if len(t) > 1 else [self.linker.output_schema, self.physical_name]
 
 
 class AthenaLinker(Linker):

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -25,9 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class DuckDBLinkerDataFrame(SplinkDataFrame):
-    def __init__(self, templated_name, physical_name, duckdb_linker):
-        super().__init__(templated_name, physical_name)
-        self.duckdb_linker = duckdb_linker
+    linker: DuckDBLinker
 
     @property
     def columns(self) -> list[InputColumn]:
@@ -43,7 +41,7 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
 
         self._check_drop_table_created_by_splink(force_non_splink_table)
 
-        self.duckdb_linker._delete_table_from_database(self.physical_name)
+        self.linker._delete_table_from_database(self.physical_name)
 
     def as_record_dict(self, limit=None):
 
@@ -51,14 +49,14 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
 
-        return self.duckdb_linker._con.query(sql).to_df().to_dict(orient="records")
+        return self.linker._con.query(sql).to_df().to_dict(orient="records")
 
     def as_pandas_dataframe(self, limit=None):
         sql = f"select * from {self.physical_name}"
         if limit:
             sql += f" limit {limit}"
 
-        return self.duckdb_linker._con.query(sql).to_df()
+        return self.linker._con.query(sql).to_df()
 
 
 class DuckDBLinker(Linker):

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -27,14 +27,12 @@ Dialect["customspark"]
 
 
 class SparkDataframe(SplinkDataFrame):
-    def __init__(self, templated_name, physical_name, spark_linker):
-        super().__init__(templated_name, physical_name)
-        self.spark_linker = spark_linker
+    linker: SparkLinker
 
     @property
     def columns(self) -> list[InputColumn]:
         sql = f"select * from {self.physical_name} limit 1"
-        spark_df = self.spark_linker.spark.sql(sql)
+        spark_df = self.linker.spark.sql(sql)
 
         col_strings = list(spark_df.columns)
         return [InputColumn(c, sql_dialect="spark") for c in col_strings]
@@ -48,7 +46,7 @@ class SparkDataframe(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
 
-        return self.spark_linker.spark.sql(sql).toPandas().to_dict(orient="records")
+        return self.linker.spark.sql(sql).toPandas().to_dict(orient="records")
 
     def drop_table_from_database(self, force_non_splink_table=False):
 
@@ -63,10 +61,10 @@ class SparkDataframe(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
 
-        return self.spark_linker.spark.sql(sql).toPandas()
+        return self.linker.spark.sql(sql).toPandas()
 
     def as_spark_dataframe(self):
-        return self.spark_linker.spark.table(self.physical_name)
+        return self.linker.spark.table(self.physical_name)
 
 
 class SparkLinker(Linker):

--- a/splink/splink_dataframe.py
+++ b/splink/splink_dataframe.py
@@ -1,19 +1,26 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
+
+# https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
+if TYPE_CHECKING:
+    from .linker import Linker
 
 
 class SplinkDataFrame:
     """Abstraction over dataframe to handle basic operations like retrieving data and
     retrieving column names, which need different implementations depending on whether
     it's a spark dataframe, sqlite table etc.
-
     Uses methods like `as_pandas_dataframe()` and `as_record_dict()` to retrieve data
     """
 
-    def __init__(self, templated_name, physical_name):
+    def __init__(self, templated_name: str, physical_name: str, linker: Linker):
         self.templated_name = templated_name
         self.physical_name = physical_name
+        self.linker = linker
 
     @property
     def columns(self):

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -21,16 +21,14 @@ def dict_factory(cursor, row):
 
 
 class SQLiteDataFrame(SplinkDataFrame):
-    def __init__(self, templated_name, physical_name, sqlite_linker):
-        super().__init__(templated_name, physical_name)
-        self.sqlite_linker = sqlite_linker
+    linker: SQLiteLinker
 
     @property
     def columns(self) -> list[InputColumn]:
         sql = f"""
         PRAGMA table_info({self.physical_name});
         """
-        pragma_result = self.sqlite_linker.con.execute(sql).fetchall()
+        pragma_result = self.linker.con.execute(sql).fetchall()
         cols = [r["name"] for r in pragma_result]
 
         return [InputColumn(c, sql_dialect="sqlite") for c in cols]
@@ -51,7 +49,7 @@ class SQLiteDataFrame(SplinkDataFrame):
         AND name='{self.physical_name}';
         """
 
-        res = self.sqlite_linker.con.execute(sql).fetchall()
+        res = self.linker.con.execute(sql).fetchall()
         if len(res) == 0:
             raise ValueError(
                 f"{self.physical_name} does not exist in the sqlite db provided.\n"
@@ -66,7 +64,7 @@ class SQLiteDataFrame(SplinkDataFrame):
 
         drop_sql = f"""
         DROP TABLE IF EXISTS {self.physical_name}"""
-        cur = self.sqlite_linker.con.cursor()
+        cur = self.linker.con.cursor()
         cur.execute(drop_sql)
 
     def as_record_dict(self, limit=None):
@@ -77,7 +75,7 @@ class SQLiteDataFrame(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
         sql += ";"
-        cur = self.sqlite_linker.con.cursor()
+        cur = self.linker.con.cursor()
         return cur.execute(sql).fetchall()
 
 

--- a/tests/cc_testing_utils.py
+++ b/tests/cc_testing_utils.py
@@ -50,7 +50,7 @@ def register_cc_df(G):
 
 def run_cc_implementation(predict_df):
 
-    linker = predict_df.duckdb_linker
+    linker = predict_df.linker
     concat_with_tf = linker._initialise_df_concat_with_tf()
 
     # finally, run our connected components algorithm
@@ -69,7 +69,7 @@ def run_cc_implementation(predict_df):
 def benchmark_cc_implementation(linker_df):
 
     # add a schema so we don't need to re-register our df
-    linker_df.duckdb_linker._con.execute(
+    linker_df.linker._con.execute(
         """
         create schema if not exists con_comp;
         set schema 'con_comp';
@@ -77,7 +77,7 @@ def benchmark_cc_implementation(linker_df):
     )
 
     df = run_cc_implementation(linker_df)
-    linker_df.duckdb_linker._con.execute("drop schema con_comp cascade")
+    linker_df.linker._con.execute("drop schema con_comp cascade")
 
     return df
 


### PR DESCRIPTION
In Splink, each backend specific SplinkDataFrame is passed a reference to the corresponding backend specific linker.

e.g. the `AthenaDataframe` has a property `self.athena_linker`

We could instead call this `self.linker`, and run this code in the `super()` method.

That would eliminate the need for a `def __init__()` method to be written on each backend-specific linker

e.g. at the moment we have:
```    
def __init__(self, templated_name, physical_name, athena_linker: AthenaLinker):
        super().__init__(templated_name, physical_name, athena_linker)

        # This alias is used to make it clearer when we are using
        # linker methods specific to the AthenaLinker
        self.athena_linker = self.linker
```

But we can get rid of the entire init if we have `self.linker` rather than `self.athena_linker`