### PR TITLE
Fix benchmark comment action to work better with forks

### DIFF
--- a/.github/workflows/pytest_benchmark_comment.yml
+++ b/.github/workflows/pytest_benchmark_comment.yml
@@ -13,8 +13,6 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v2


### PR DESCRIPTION
The benchmark comment action currently fails on the checkout step when the PR is from a fork (see e.g. [this job](https://github.com/moj-analytical-services/splink/actions/runs/4389831981/jobs/7783831938) ) - however various other actions use this step and run fine. The issue is that using a git `ref` fails as the `ref` is on the fork only, and not found on the main repo. The default value is the PR branch head, which is what we want anyway, and is what we use in other workflows (e.g. tests). See [this comment](https://github.com/WeblateOrg/weblate/issues/6240#issuecomment-869715886).

The workflow may still fail at the comment step (as not sure how the permissions work with that), but at least we can see whether the important part of the workflow runs okay or fails by manually inspecting, if we want to.

