### PR TITLE
Add comparison template library functions for simple name column

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/docs/comparison_level_library.md
+++ b/docs/comparison_level_library.md
@@ -14,12 +14,26 @@ tags:
 # Documentation for `comparison_level_library` 
 
 The `comparison_level_library` contains pre-made comparison levels available for use to
-construct custom comparisons [as described in this topic guide](../topic_guides/customising_comparisons.html#method-3-comparisonlevels).
-However, not every comparison level is available for every [Splink-compatible SQL backend](../topic_guides/backends.html).
+construct custom comparisons [as described in this topic guide](./topic_guides/customising_comparisons.html#method-3-comparisonlevels).
+However, not every comparison level is available for every [Splink-compatible SQL backend](./topic_guides/backends.html).
 
 The pre-made Splink comparison levels available for each SQL dialect are as given in this table:
 
-{% include-markdown "./includes/generated_files/comparison_level_library_dialect_table.md" %}
+||spark|duckdb|athena|sqlite|
+|-|-|-|-|-|
+|`array_intersect_level`|✓|✓|✓||
+|`columns_reversed_level`|✓|✓|✓|✓|
+|`datediff_level`|✓|✓|||
+|`distance_function_level`|✓|✓|✓|✓|
+|`distance_in_km_level`|✓|✓|✓||
+|`else_level`|✓|✓|✓|✓|
+|`exact_match_level`|✓|✓|✓|✓|
+|`jaccard_level`|✓|✓|||
+|`jaro_winkler_level`|✓|✓|||
+|`levenshtein_level`|✓|✓|✓||
+|`null_level`|✓|✓|✓|✓|
+|`percentage_difference_level`|✓|✓|✓|✓|
+
 
 
 The detailed API for each of these are outlined below.

--- a/docs/comparison_level_library.md
+++ b/docs/comparison_level_library.md
@@ -19,20 +19,7 @@ However, not every comparison level is available for every [Splink-compatible SQ
 
 The pre-made Splink comparison levels available for each SQL dialect are as given in this table:
 
-||spark|duckdb|athena|sqlite|
-|-|-|-|-|-|
-|`array_intersect_level`|✓|✓|✓||
-|`columns_reversed_level`|✓|✓|✓|✓|
-|`datediff_level`|✓|✓|||
-|`distance_function_level`|✓|✓|✓|✓|
-|`distance_in_km_level`|✓|✓|✓||
-|`else_level`|✓|✓|✓|✓|
-|`exact_match_level`|✓|✓|✓|✓|
-|`jaccard_level`|✓|✓|||
-|`jaro_winkler_level`|✓|✓|||
-|`levenshtein_level`|✓|✓|✓||
-|`null_level`|✓|✓|✓|✓|
-|`percentage_difference_level`|✓|✓|✓|✓|
+{% include-markdown "./includes/generated_files/comparison_level_library_dialect_table.md" %}
 
 
 

--- a/docs/comparison_library.md
+++ b/docs/comparison_library.md
@@ -16,15 +16,8 @@ However, not every comparison is available for every [Splink-compatible SQL back
 
 The pre-made Splink comparisons available for each SQL dialect are as given in this table:
 
-||spark|duckdb|athena|sqlite|
-|-|-|-|-|-|
-|`array_intersect_at_sizes`|✓|✓|✓||
-|`datediff_at_thresholds`|✓|✓|||
-|`distance_function_at_thresholds`|✓|✓|✓|✓|
-|`exact_match`|✓|✓|✓|✓|
-|`jaccard_at_thresholds`|✓|✓|||
-|`jaro_winkler_at_thresholds`|✓|✓|||
-|`levenshtein_at_thresholds`|✓|✓|✓||
+{% include-markdown "./includes/generated_files/comparison_library_dialect_table.md" %}
+
 
 
 

--- a/docs/comparison_library.md
+++ b/docs/comparison_library.md
@@ -11,12 +11,21 @@ tags:
 ---
 # Documentation for `comparison_library` 
 
-The `comparison_library` contains pre-made comparisons available for use directly [as described in this topic guide](../topic_guides/customising_comparisons.html#method-1-using-the-comparisonlibrary).
-However, not every comparison is available for every [Splink-compatible SQL backend](../topic_guides/backends.html).
+The `comparison_library` contains pre-made comparisons available for use directly [as described in this topic guide](./topic_guides/customising_comparisons.html#method-1-using-the-comparisonlibrary).
+However, not every comparison is available for every [Splink-compatible SQL backend](./topic_guides/backends.html).
 
 The pre-made Splink comparisons available for each SQL dialect are as given in this table:
 
-{% include-markdown "./includes/generated_files/comparison_library_dialect_table.md" %}
+||spark|duckdb|athena|sqlite|
+|-|-|-|-|-|
+|`array_intersect_at_sizes`|✓|✓|✓||
+|`datediff_at_thresholds`|✓|✓|||
+|`distance_function_at_thresholds`|✓|✓|✓|✓|
+|`exact_match`|✓|✓|✓|✓|
+|`jaccard_at_thresholds`|✓|✓|||
+|`jaro_winkler_at_thresholds`|✓|✓|||
+|`levenshtein_at_thresholds`|✓|✓|✓||
+
 
 
 The detailed API for each of these are outlined below.

--- a/docs/comparison_template_library.md
+++ b/docs/comparison_template_library.md
@@ -8,13 +8,25 @@ tags:
 # Documentation for `comparison_template_library` 
 
 The `comparison_template_library` contains pre-made comparisons with pre-defined parameters available for use directly [as described in this topic guide](../topic_guides/customising_comparisons.html#method-2-using-the-comparisontemplatelibrary).
-However, not every comparison is available for every [Splink-compatible SQL backend](../topic_guides/backends.html). More detail on creating comparisons for specific types is also [included in the topic guide.](../topic_guides/customising_comparisons.html#creating-comparisons-for-specific-data-types)
+However, not every comparison is available for every [Splink-compatible SQL backend](./topic_guides/backends.html). More detail on creating comparisons for specific data types is also [included in the topic guide.](./topic_guides/customising_comparisons.html#creating-comparisons-for-specific-data-types)
 
 The detailed API for each of these are outlined below.
 
 ## Library comparison APIs
 
 ::: splink.comparison_template_library.DateComparisonBase
+    handler: python
+    selection:
+      members:
+        -  __init__
+    rendering:
+      show_root_heading: true
+      show_source: false
+      heading_level: 2
+
+---
+
+::: splink.comparison_template_library.NameComparisonBase
     handler: python
     selection:
       members:

--- a/docs/topic_guides/customising_comparisons.ipynb
+++ b/docs/topic_guides/customising_comparisons.ipynb
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
        " 'comparison_description': 'Exact match vs. anything else'}"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,14 +227,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Comparison 'Exact match vs. Dates within the following thresholds Year(s): 1, Year(s): 10 vs. anything else' of \"date_of_birth\".\n",
+      "Comparison 'Exact match vs. Dates within levenshtein thresholds 1, 2 vs. Dates within the following thresholds Year(s): 1, Year(s): 10 vs. anything else' of \"date_of_birth\".\n",
       "Similarity is assessed using the following ComparisonLevels:\n",
       "    - 'Null' with SQL rule: \"date_of_birth_l\" IS NULL OR \"date_of_birth_r\" IS NULL\n",
       "    - 'Exact match' with SQL rule: \"date_of_birth_l\" = \"date_of_birth_r\"\n",
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,12 +442,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Creating Comparisons for specific data types\n",
     "\n",
-    "Similarity is defined defferently for types of data (e.g. names, dates of birth, postcodes, addresses, ids). Below are examples of how to structure comparisons for a variety of data types."
+    "Similarity is defined differently for types of data (e.g. names, dates of birth, postcodes, addresses, ids). Below are examples of how to structure comparisons for a variety of data types."
    ]
   },
   {
@@ -469,14 +470,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Comparison 'Exact match vs. Dates within the following thresholds Year(s): 1, Year(s): 10 vs. anything else' of \"date_of_birth\".\n",
+      "Comparison 'Exact match vs. Dates within levenshtein thresholds 1, 2 vs. Dates within the following thresholds Year(s): 1, Year(s): 10 vs. anything else' of \"date_of_birth\".\n",
       "Similarity is assessed using the following ComparisonLevels:\n",
       "    - 'Null' with SQL rule: \"date_of_birth_l\" IS NULL OR \"date_of_birth_r\" IS NULL\n",
       "    - 'Exact match' with SQL rule: \"date_of_birth_l\" = \"date_of_birth_r\"\n",
@@ -513,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -547,19 +548,200 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see this as a specifications dictionary you can call"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'output_column_name': 'date_of_birth',\n",
+       " 'comparison_levels': [{'sql_condition': '\"date_of_birth_l\" IS NULL OR \"date_of_birth_r\" IS NULL',\n",
+       "   'label_for_charts': 'Null',\n",
+       "   'is_null_level': True},\n",
+       "  {'sql_condition': '\"date_of_birth_l\" = \"date_of_birth_r\"',\n",
+       "   'label_for_charts': 'Exact match'},\n",
+       "  {'sql_condition': 'jaro_winkler_similarity(\"date_of_birth_l\", \"date_of_birth_r\") >= 0.88',\n",
+       "   'label_for_charts': 'Jaro_winkler_similarity >= 0.88'},\n",
+       "  {'sql_condition': '\\n        abs(date_diff(\\'month\\', \"date_of_birth_l\", \"date_of_birth_r\")) <= 1\\n    ',\n",
+       "   'label_for_charts': 'Within 1 month'},\n",
+       "  {'sql_condition': '\\n        abs(date_diff(\\'year\\', \"date_of_birth_l\", \"date_of_birth_r\")) <= 1\\n    ',\n",
+       "   'label_for_charts': 'Within 1 year'},\n",
+       "  {'sql_condition': 'ELSE', 'label_for_charts': 'All other comparisons'}],\n",
+       " 'comparison_description': 'Exact match vs. Dates within jaro_winkler threshold 0.88 vs. Dates within the following thresholds Month(s): 1, Year(s): 1 vs. anything else'}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "date_of_birth_comparison.as_dict()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which can be used as the basis for a more custom comparison, as in [Method 4](#method-4-providing-the-spec-as-a-dictionary), if desired."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Name Comparisons\n",
     "\n",
-    "Name comparisons are generally structured as: \n",
+    "Name comparisons for an individual name column (e.g. forename, surname) are generally structured as: \n",
     "\n",
-    "UPDATE FOR NAMES\n",
     "- Null level  \n",
     "- Exact match  \n",
     "- Fuzzy match ([using metric of choice](comparators.md))  \n",
-    "- Interval match (within X days/months/years)  \n",
-    "- Else level"
+    "- Else level\n",
+    "\n",
+    "The [comparison_template_library](#method-2-using-the-comparisontemplatelibrary) contains the `name_comparison` function which gives this structure, with some pre-defined parameters, out-of-the-box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparison 'Exact match vs. Names within jaro_winkler thresholds 0.95, 0.88 vs. anything else' of \"first_name\".\n",
+      "Similarity is assessed using the following ComparisonLevels:\n",
+      "    - 'Null' with SQL rule: \"first_name_l\" IS NULL OR \"first_name_r\" IS NULL\n",
+      "    - 'Exact match first_name' with SQL rule: \"first_name_l\" = \"first_name_r\"\n",
+      "    - 'Jaro_winkler_similarity >= 0.95' with SQL rule: jaro_winkler_similarity(\"first_name_l\", \"first_name_r\") >= 0.95\n",
+      "    - 'Jaro_winkler_similarity >= 0.88' with SQL rule: jaro_winkler_similarity(\"first_name_l\", \"first_name_r\") >= 0.88\n",
+      "    - 'All other comparisons' with SQL rule: ELSE\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from splink.duckdb.duckdb_comparison_template_library import (\n",
+    "    name_comparison\n",
+    ")\n",
+    "\n",
+    "first_name_comparison = name_comparison(\"first_name\")\n",
+    "print(first_name_comparison.human_readable_description)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While also allowing flexibility to change the paramaters and/or fuzzy matching comparison level.\n",
+    "\n",
+    "For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparison 'Exact match vs. Names with phonetic exact match vs. Dates within levenshtein threshold 2 vs. Names within jaccard threshold 1 vs. anything else' of \"surname\" and \"surname_dm\".\n",
+      "Similarity is assessed using the following ComparisonLevels:\n",
+      "    - 'Null' with SQL rule: \"surname_l\" IS NULL OR \"surname_r\" IS NULL\n",
+      "    - 'Exact match surname' with SQL rule: \"surname_l\" = \"surname_r\"\n",
+      "    - 'Exact match surname_dm' with SQL rule: \"surname_dm_l\" = \"surname_dm_r\"\n",
+      "    - 'Levenshtein <= 2' with SQL rule: levenshtein(\"surname_l\", \"surname_r\") <= 2\n",
+      "    - 'Jaccard >= 1' with SQL rule: jaccard(\"surname_l\", \"surname_r\") >= 1\n",
+      "    - 'All other comparisons' with SQL rule: ELSE\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "surname_comparison = name_comparison(\n",
+    "                                    \"surname\",\n",
+    "                                    phonetic_col_name = \"surname_dm\",\n",
+    "                                    term_frequency_adjustments_name = True,\n",
+    "                                    levenshtein_thresholds=[2],\n",
+    "                                    jaro_winkler_thresholds=[],\n",
+    "                                    jaccard_thresholds=[1]\n",
+    "                                    )\n",
+    "print(surname_comparison.human_readable_description)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where `surname_dm` refers to a column which has used the DoubleMetaphone algorithm on `surname` to give a phonetic spelling. This helps to catch names which sounds the same but have different spellings (e.g. Stephens vs Stevens). For more on Phonetic Transformations, see the [topic guide](phonetic.md)."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see this as a specifications dictionary you can call"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'output_column_name': 'custom_surname_surname_dm',\n",
+       " 'comparison_levels': [{'sql_condition': '\"surname_l\" IS NULL OR \"surname_r\" IS NULL',\n",
+       "   'label_for_charts': 'Null',\n",
+       "   'is_null_level': True},\n",
+       "  {'sql_condition': '\"surname_l\" = \"surname_r\"',\n",
+       "   'label_for_charts': 'Exact match surname',\n",
+       "   'tf_adjustment_column': 'surname',\n",
+       "   'tf_adjustment_weight': 1.0},\n",
+       "  {'sql_condition': '\"surname_dm_l\" = \"surname_dm_r\"',\n",
+       "   'label_for_charts': 'Exact match surname_dm'},\n",
+       "  {'sql_condition': 'levenshtein(\"surname_l\", \"surname_r\") <= 2',\n",
+       "   'label_for_charts': 'Levenshtein <= 2'},\n",
+       "  {'sql_condition': 'jaccard(\"surname_l\", \"surname_r\") >= 1',\n",
+       "   'label_for_charts': 'Jaccard >= 1'},\n",
+       "  {'sql_condition': 'ELSE', 'label_for_charts': 'All other comparisons'}],\n",
+       " 'comparison_description': 'Exact match vs. Names with phonetic exact match vs. Dates within levenshtein threshold 2 vs. Names within jaccard threshold 1 vs. anything else'}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "surname_comparison.as_dict()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which can be used as the basis for a more custom comparison, as in [Method 4](#method-4-providing-the-spec-as-a-dictionary), if desired."
    ]
   }
  ],

--- a/docs/topic_guides/customising_comparisons.ipynb
+++ b/docs/topic_guides/customising_comparisons.ipynb
@@ -464,7 +464,7 @@
     "- Interval match (within X days/months/years)  \n",
     "- Else level\n",
     "\n",
-    "The [comparison_template_library](#method-2-using-the-comparisontemplatelibrary) contains the `date_comparison` function which gives this structure out-of-the-box."
+    "The [comparison_template_library](#method-2-using-the-comparisontemplatelibrary) contains the `date_comparison` function which gives this structure, with some pre-defined parameters, out-of-the-box."
    ]
   },
   {
@@ -544,6 +544,22 @@
     "                                    datediff_thresholds=[1, 1],\n",
     "                                    datediff_metrics=[\"month\", \"year\"])\n",
     "print(date_of_birth_comparison.human_readable_description)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Name Comparisons\n",
+    "\n",
+    "Name comparisons are generally structured as: \n",
+    "\n",
+    "UPDATE FOR NAMES\n",
+    "- Null level  \n",
+    "- Exact match  \n",
+    "- Fuzzy match ([using metric of choice](comparators.md))  \n",
+    "- Interval match (within X days/months/years)  \n",
+    "- Else level"
    ]
   }
  ],

--- a/docs/topic_guides/phonetic.md
+++ b/docs/topic_guides/phonetic.md
@@ -10,7 +10,13 @@ tags:
 
 # Phonetic transformation algorithms
 
-Soundex and Double Metaphone are phonetic matching algorithms that can be used to identify words that sound similar, even if they are spelled differently. These algorithms are often used in a preprocessing step for data linking and can assist in the blocking process. By incorporating them into blocking rules, it allows for possible candidate pairs of entities with phonetically similar transforms to be considered for linking. This can result in a "fuzzier" blocking process, which may be beneficial for certain projects.
+Phonetic transformation algorithms can be used to identify words that sound similar, even if they are spelled differently. These algorithms are often used in a preprocessing step for data linking and can assist in the blocking and comparison process. 
+
+By incorporating them into blocking rules, it allows for possible candidate pairs of entities with phonetically similar transforms to be considered for linking. This can result in a "fuzzier" blocking process, which may be beneficial for certain projects.
+
+Similarly, phonetically similar transforms offer another way to do fuzzy-matching within a comparison.
+
+Below are some examples of well known phonetic transformation algorithmns.
 
 ## Soundex
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ nav:
       - Link type - linkings vs deduping: "topic_guides/link_type.md"
       - Defining and customising comparisons: "topic_guides/customising_comparisons.ipynb"
       - Comparators: "topic_guides/comparators.md"
-      - Phonetic transformations for blocking: "topic_guides/phonetic.md"
+      - Phonetic transformations: "topic_guides/phonetic.md"
       - Blocking rules for prediction vs estimation: "topic_guides/blocking_rules.md"
       - Run times, performance and linking large data: "topic_guides/drivers_of_performance.md"
       - Optimising Spark performance: "topic_guides/optimising_spark.md"

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -30,7 +30,6 @@ class DateComparisonBase(Comparison):
         m_probability_or_probabilities_jw: float | list = None,
         m_probability_or_probabilities_datediff: float | list = None,
         m_probability_else=None,
-        include_colname_in_charts_label=False,
     ):
         """A wrapper to generate a comparison for a date column the data in
         `col_name` with preselected defaults.
@@ -60,7 +59,7 @@ class DateComparisonBase(Comparison):
                 for jaro_winkler similarity level(s).
                 We recommend use of either levenshtein or jaro_winkler for fuzzy
                 matching, but not both.
-                Defaults to [2]
+                Defaults to []
             datediff_thresholds (Union[int, list], optional): The thresholds to use
                 for datediff similarity level(s).
                 Defaults to [1, 1].
@@ -71,10 +70,13 @@ class DateComparisonBase(Comparison):
                 default m probability for the exact match level. Defaults to None.
             m_probability_or_probabilities_lev (Union[float, list], optional):
                 _description_. If provided, overrides the default m probabilities
-                for the thresholds specified. Defaults to None.
+                for the levenshtein thresholds specified. Defaults to None.
+            m_probability_or_probabilities_jw (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the jaro winkler thresholds specified. Defaults to None.
             m_probability_or_probabilities_datediff (Union[float, list], optional):
                 _description_. If provided, overrides the default m probabilities
-                for the thresholds specified. Defaults to None.
+                for the datediff thresholds specified. Defaults to None.
             m_probability_else (_type_, optional): If provided, overrides the
                 default m probability for the 'anything else' level. Defaults to None.
 
@@ -235,7 +237,7 @@ class NameComparisonBase(Comparison):
         term_frequency_adjustments_name=False,
         term_frequency_adjustments_phonetic_name=False,
         levenshtein_thresholds=[],
-        jaro_winkler_thresholds=[0.88],
+        jaro_winkler_thresholds=[0.95, 0.88],
         jaccard_thresholds=[],
         m_probability_exact_match_name=None,
         m_probability_exact_match_phonetic_name=None,
@@ -243,45 +245,44 @@ class NameComparisonBase(Comparison):
         m_probability_or_probabilities_jw: float | list = None,
         m_probability_or_probabilities_jac: float | list = None,
         m_probability_else=None,
-        include_colname_in_charts_label=False,
     ):
-        """A wrapper to generate a comparison for a date column the data in
+        """A wrapper to generate a comparison for a name column the data in
         `col_name` with preselected defaults.
 
         The default arguments will give a comparison with comparison levels:\n
-        - Exact match (1st of January only)\n
-        - Exact match (all other dates)\n
-        - Levenshtein distance <= 2\n
-        - Date difference <= 1 year\n
-        - Date difference <= 10 years \n
+        - Exact match \n
+        - Jaro Winkler similarity >= 0.88\n
         - Anything else
 
         Args:
             col_name (str): The name of the column to compare
             include_exact_match_level (bool, optional): If True, include an exact match
-                level. Defaults to True.
-            term_frequency_adjustments (bool, optional): If True, apply term frequency
-                adjustments to the exact match level. Defaults to False.
-            separate_1st_january (bool, optional): If True, include a separate
-                exact match comparison level when date is 1st January.
+                level for col_name. Defaults to True.
+            phonetic_col_name (str): The name of the column with phonetic reduction
+                (such as dmetaphone) of col_name. Including parameter will create
+                an exact match level for  phonetic_col_name. Defaults to None
+            term_frequency_adjustments_name (bool, optional): If True, apply term
+                frequency adjustments to the exact match level for "col_name".
+                Defaults to False.
+            term_frequency_adjustments_phonetic_name (bool, optional): If True, apply
+                term frequency adjustments to the exact match level for
+                "phonetic_col_name".
+                Defaults to False.
             levenshtein_thresholds (Union[int, list], optional): The thresholds to use
                 for levenshtein similarity level(s).
-                We recommend use of either levenshtein or jaro_winkler for fuzzy
-                matching, but not both.
-                Defaults to [2]
+                Defaults to []
             jaro_winkler_thresholds (Union[int, list], optional): The thresholds to use
                 for jaro_winkler similarity level(s).
-                We recommend use of either levenshtein or jaro_winkler for fuzzy
-                matching, but not both.
-                Defaults to [2]
-            datediff_thresholds (Union[int, list], optional): The thresholds to use
-                for datediff similarity level(s).
-                Defaults to [1, 1].
-            datediff_metrics (Union[str, list], optional): The metrics to apply
-                thresholds to for datediff similarity level(s).
-                Defaults to ["month", "year"].
-            m_probability_exact_match (_type_, optional): If provided, overrides the
-                default m probability for the exact match level. Defaults to None.
+                Defaults to [0.88]
+            jaccard_thresholds (Union[int, list], optional): The thresholds to use
+                for jaccard similarity level(s).
+                Defaults to []
+            m_probability_exact_match_name (_type_, optional): If provided, overrides
+                the default m probability for the exact match level for col_name.
+                Defaults to None.
+            m_probability_exact_match_phonetic_name (_type_, optional): If provided,
+                overrides the default m probability for the exact match level for
+                phonetic_col_name. Defaults to None.
             m_probability_or_probabilities_lev (Union[float, list], optional):
                 _description_. If provided, overrides the default m probabilities
                 for the thresholds specified. Defaults to None.
@@ -378,12 +379,6 @@ class NameComparisonBase(Comparison):
                 )
                 comparison_levels.append(level_dict)
 
-        if len(levenshtein_thresholds) > 0 and len(jaro_winkler_thresholds) > 0:
-            logger.warning(
-                "You have included a comparison level for both Levenshtein and "
-                "Jaro-Winkler similarity. We recommend choosing one or the other."
-            )
-
         comparison_levels.append(
             self._else_level(m_probability=m_probability_else),
         )
@@ -394,7 +389,7 @@ class NameComparisonBase(Comparison):
             comparison_desc += "Exact match vs. "
 
         if phonetic_col_name is not None:
-            comparison_desc += f"Names with phonetic exact match vs. "
+            comparison_desc += "Names with phonetic exact match vs. "
 
         if len(levenshtein_thresholds) > 0:
             lev_desc = ", ".join([str(d) for d in levenshtein_thresholds])
@@ -422,25 +417,3 @@ class NameComparisonBase(Comparison):
             "comparison_levels": comparison_levels,
         }
         super().__init__(comparison_dict)
-
-
-class FullNameComparisonBase(Comparison):
-    def __init__(
-        self,
-        col_name,
-        include_exact_match_level=True,
-        include_forename_surname_inversion=True,
-        include_dmetaphone=False,
-        term_frequency_adjustments_forename=False,
-        term_frequency_adjustments_surname=False,
-        term_frequency_adjustments_fullname=False,
-        levenshtein_thresholds=[1, 2],
-        jaro_winkler_thresholds=[],
-        m_probability_exact_match=None,
-        m_probability_or_probabilities_lev: float | list = None,
-        m_probability_or_probabilities_jw: float | list = None,
-        m_probability_or_probabilities_datediff: float | list = None,
-        m_probability_else=None,
-        include_colname_in_charts_label=False,
-    ):
-        pass

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -216,3 +216,228 @@ class DateComparisonBase(Comparison):
             "comparison_levels": comparison_levels,
         }
         super().__init__(comparison_dict)
+
+class NameComparisonBase(Comparison):
+    def __init__(
+        self,
+        col_name,
+        include_exact_match_level=True,
+        include_forename_surname_inversion=True,
+        include_dmetaphone = False,
+        term_frequency_adjustments_forename=False,
+        term_frequency_adjustments_surname=False,
+        term_frequency_adjustments_fullname=False,
+        levenshtein_thresholds=[1, 2],
+        jaro_winkler_thresholds=[],
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_lev: float | list = None,
+        m_probability_or_probabilities_jw: float | list = None,
+        m_probability_or_probabilities_datediff: float | list = None,
+        m_probability_else=None,
+        include_colname_in_charts_label=False,
+    ):
+        """A wrapper to generate a comparison for a date column the data in
+        `col_name` with preselected defaults.
+
+        The default arguments will give a comparison with comparison levels:\n
+        - Exact match (1st of January only)\n
+        - Exact match (all other dates)\n
+        - Levenshtein distance <= 2\n
+        - Date difference <= 1 year\n
+        - Date difference <= 10 years \n
+        - Anything else
+
+        Args:
+            col_name (str): The name of the column to compare
+            include_exact_match_level (bool, optional): If True, include an exact match
+                level. Defaults to True.
+            term_frequency_adjustments (bool, optional): If True, apply term frequency
+                adjustments to the exact match level. Defaults to False.
+            separate_1st_january (bool, optional): If True, include a separate
+                exact match comparison level when date is 1st January.
+            levenshtein_thresholds (Union[int, list], optional): The thresholds to use
+                for levenshtein similarity level(s).
+                We recommend use of either levenshtein or jaro_winkler for fuzzy
+                matching, but not both.
+                Defaults to [2]
+            jaro_winkler_thresholds (Union[int, list], optional): The thresholds to use
+                for jaro_winkler similarity level(s).
+                We recommend use of either levenshtein or jaro_winkler for fuzzy
+                matching, but not both.
+                Defaults to [2]
+            datediff_thresholds (Union[int, list], optional): The thresholds to use
+                for datediff similarity level(s).
+                Defaults to [1, 1].
+            datediff_metrics (Union[str, list], optional): The metrics to apply
+                thresholds to for datediff similarity level(s).
+                Defaults to ["month", "year"].
+            m_probability_exact_match (_type_, optional): If provided, overrides the
+                default m probability for the exact match level. Defaults to None.
+            m_probability_or_probabilities_lev (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the thresholds specified. Defaults to None.
+            m_probability_or_probabilities_datediff (Union[float, list], optional):
+                _description_. If provided, overrides the default m probabilities
+                for the thresholds specified. Defaults to None.
+            m_probability_else (_type_, optional): If provided, overrides the
+                default m probability for the 'anything else' level. Defaults to None.
+
+        Returns:
+            Comparison: A comparison that can be inclued in the Splink settings
+                dictionary.
+        """
+
+        comparison_levels = []
+        comparison_levels.append(self._null_level(col_name))
+
+        # Validate user inputs
+        datediff_error_logger(thresholds=datediff_thresholds, metrics=datediff_metrics)
+
+        if separate_1st_january:
+            level_dict = {
+                "sql_condition": f"""{col_name}_l = {col_name}_r AND
+                                    substr({col_name}_l, 6, 5) = '01-01'""",
+                "label_for_charts": "Matching and 1st Jan",
+            }
+            if m_probability_1st_january:
+                level_dict["m_probability"] = m_probability_1st_january
+            if term_frequency_adjustments:
+                level_dict["tf_adjustment_column"] = col_name
+            comparison_levels.append(level_dict)
+
+        if include_exact_match_level:
+            level_dict = self._exact_match_level(
+                col_name,
+                term_frequency_adjustments=term_frequency_adjustments,
+                m_probability=m_probability_exact_match,
+            )
+            comparison_levels.append(level_dict)
+
+        if len(levenshtein_thresholds) > 0:
+            levenshtein_thresholds = ensure_is_iterable(levenshtein_thresholds)
+
+            if m_probability_or_probabilities_lev is None:
+                m_probability_or_probabilities_lev = [None] * len(
+                    levenshtein_thresholds
+                )
+            m_probability_or_probabilities_lev = ensure_is_iterable(
+                m_probability_or_probabilities_lev
+            )
+
+            for thres, m_prob in zip(
+                levenshtein_thresholds, m_probability_or_probabilities_lev
+            ):
+                level_dict = self._levenshtein_level(
+                    col_name,
+                    distance_threshold=thres,
+                    m_probability=m_prob,
+                )
+                comparison_levels.append(level_dict)
+
+        if len(jaro_winkler_thresholds) > 0:
+            jaro_winkler_thresholds = ensure_is_iterable(jaro_winkler_thresholds)
+
+            if m_probability_or_probabilities_jw is None:
+                m_probability_or_probabilities_jw = [None] * len(
+                    jaro_winkler_thresholds
+                )
+            m_probability_or_probabilities_jw = ensure_is_iterable(
+                m_probability_or_probabilities_jw
+            )
+
+            for thres, m_prob in zip(
+                jaro_winkler_thresholds, m_probability_or_probabilities_jw
+            ):
+                level_dict = self._jaro_winkler_level(
+                    col_name,
+                    distance_threshold=thres,
+                    m_probability=m_prob,
+                )
+                comparison_levels.append(level_dict)
+
+        if len(levenshtein_thresholds) > 0 and len(jaro_winkler_thresholds) > 0:
+            logger.warning(
+                "You have included a comparison levels for both Levenshtein and"
+                "Jaro-Winkler similarity. We recommend choosing one or the other."
+            )
+
+        if len(datediff_thresholds) > 0:
+            datediff_thresholds = ensure_is_iterable(datediff_thresholds)
+            datediff_metrics = ensure_is_iterable(datediff_metrics)
+
+            if m_probability_or_probabilities_datediff is None:
+                m_probability_or_probabilities_datediff = [None] * len(
+                    datediff_thresholds
+                )
+            m_probability_or_probabilities_datediff = ensure_is_iterable(
+                m_probability_or_probabilities_datediff
+            )
+
+            for thres, metric, m_prob in zip(
+                datediff_thresholds,
+                datediff_metrics,
+                m_probability_or_probabilities_datediff,
+            ):
+                level_dict = self._datediff_level(
+                    col_name,
+                    date_threshold=thres,
+                    date_metric=metric,
+                    m_probability=m_prob,
+                )
+                comparison_levels.append(level_dict)
+
+            comparison_levels.append(
+                self._else_level(m_probability=m_probability_else),
+            )
+
+            comparison_desc = ""
+            if include_exact_match_level:
+                comparison_desc += "Exact match vs. "
+
+            if len(jaro_winkler_thresholds) > 0:
+                lev_desc = ", ".join([str(d) for d in jaro_winkler_thresholds])
+                plural = "" if len(jaro_winkler_thresholds) == 1 else "s"
+                comparison_desc += (
+                    f"Dates within jaro_winkler threshold{plural} {lev_desc} vs. "
+                )
+
+        if len(datediff_thresholds) > 0:
+            datediff_desc = ", ".join(
+                [
+                    f"{m.title()}(s): {v}"
+                    for v, m in zip(datediff_thresholds, datediff_metrics)
+                ]
+            )
+            plural = "" if len(datediff_thresholds) == 1 else "s"
+            comparison_desc += (
+                f"Dates within the following threshold{plural} {datediff_desc} vs. "
+            )
+
+        comparison_desc += "anything else"
+
+        comparison_dict = {
+            "comparison_description": comparison_desc,
+            "comparison_levels": comparison_levels,
+        }
+        super().__init__(comparison_dict)
+
+
+class FullNameComparisonBase(Comparison):
+    def __init__(
+        self,
+        col_name,
+        include_exact_match_level=True,
+        include_forename_surname_inversion=True,
+        include_dmetaphone = False,
+        term_frequency_adjustments_forename=False,
+        term_frequency_adjustments_surname=False,
+        term_frequency_adjustments_fullname=False,
+        levenshtein_thresholds=[1, 2],
+        jaro_winkler_thresholds=[],
+        m_probability_exact_match=None,
+        m_probability_or_probabilities_lev: float | list = None,
+        m_probability_or_probabilities_jw: float | list = None,
+        m_probability_or_probabilities_datediff: float | list = None,
+        m_probability_else=None,
+        include_colname_in_charts_label=False,
+    ):

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -92,24 +92,24 @@ class DateComparisonBase(Comparison):
         datediff_error_logger(thresholds=datediff_thresholds, metrics=datediff_metrics)
 
         if separate_1st_january:
-            level_dict = {
+            comparison_level = {
                 "sql_condition": f"""{col_name}_l = {col_name}_r AND
                                     substr({col_name}_l, 6, 5) = '01-01'""",
                 "label_for_charts": "Matching and 1st Jan",
             }
             if m_probability_1st_january:
-                level_dict["m_probability"] = m_probability_1st_january
+                comparison_level["m_probability"] = m_probability_1st_january
             if term_frequency_adjustments:
-                level_dict["tf_adjustment_column"] = col_name
-            comparison_levels.append(level_dict)
+                comparison_level["tf_adjustment_column"] = col_name
+            comparison_levels.append(comparison_level)
 
         if include_exact_match_level:
-            level_dict = self._exact_match_level(
+            comparison_level = self._exact_match_level(
                 col_name,
                 term_frequency_adjustments=term_frequency_adjustments,
                 m_probability=m_probability_exact_match,
             )
-            comparison_levels.append(level_dict)
+            comparison_levels.append(comparison_level)
 
         if len(levenshtein_thresholds) > 0:
             levenshtein_thresholds = ensure_is_iterable(levenshtein_thresholds)
@@ -125,12 +125,12 @@ class DateComparisonBase(Comparison):
             for thres, m_prob in zip(
                 levenshtein_thresholds, m_probability_or_probabilities_lev
             ):
-                level_dict = self._levenshtein_level(
+                comparison_level = self._levenshtein_level(
                     col_name,
                     distance_threshold=thres,
                     m_probability=m_prob,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
         if len(jaro_winkler_thresholds) > 0:
             jaro_winkler_thresholds = ensure_is_iterable(jaro_winkler_thresholds)
@@ -146,12 +146,12 @@ class DateComparisonBase(Comparison):
             for thres, m_prob in zip(
                 jaro_winkler_thresholds, m_probability_or_probabilities_jw
             ):
-                level_dict = self._jaro_winkler_level(
+                comparison_level = self._jaro_winkler_level(
                     col_name,
                     distance_threshold=thres,
                     m_probability=m_prob,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
         if len(levenshtein_thresholds) > 0 and len(jaro_winkler_thresholds) > 0:
             logger.warning(
@@ -176,13 +176,13 @@ class DateComparisonBase(Comparison):
                 datediff_metrics,
                 m_probability_or_probabilities_datediff,
             ):
-                level_dict = self._datediff_level(
+                comparison_level = self._datediff_level(
                     col_name,
                     date_threshold=thres,
                     date_metric=metric,
                     m_probability=m_prob,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
             comparison_levels.append(
                 self._else_level(m_probability=m_probability_else),
@@ -296,7 +296,7 @@ class NameComparisonBase(Comparison):
                 default m probability for the 'anything else' level. Defaults to None.
 
         Returns:
-            Comparison: A comparison that can be inclued in the Splink settings
+            Comparison: A comparison that can be included in the Splink settings
                 dictionary.
         """
         # Construct Comparison
@@ -304,22 +304,22 @@ class NameComparisonBase(Comparison):
         comparison_levels.append(self._null_level(col_name))
 
         if include_exact_match_level:
-            level_dict = self._exact_match_level(
+            comparison_level = self._exact_match_level(
                 col_name,
                 term_frequency_adjustments=term_frequency_adjustments_name,
                 m_probability=m_probability_exact_match_name,
                 include_colname_in_charts_label=True,
             )
-            comparison_levels.append(level_dict)
+            comparison_levels.append(comparison_level)
 
             if phonetic_col_name is not None:
-                level_dict = self._exact_match_level(
+                comparison_level = self._exact_match_level(
                     phonetic_col_name,
                     term_frequency_adjustments=term_frequency_adjustments_phonetic_name,
                     m_probability=m_probability_exact_match_phonetic_name,
                     include_colname_in_charts_label=True,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
         if len(levenshtein_thresholds) > 0:
             levenshtein_thresholds = ensure_is_iterable(levenshtein_thresholds)
@@ -335,12 +335,12 @@ class NameComparisonBase(Comparison):
             for thres, m_prob in zip(
                 levenshtein_thresholds, m_probability_or_probabilities_lev
             ):
-                level_dict = self._levenshtein_level(
+                comparison_level = self._levenshtein_level(
                     col_name,
                     distance_threshold=thres,
                     m_probability=m_prob,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
         if len(jaro_winkler_thresholds) > 0:
             jaro_winkler_thresholds = ensure_is_iterable(jaro_winkler_thresholds)
@@ -356,12 +356,12 @@ class NameComparisonBase(Comparison):
             for thres, m_prob in zip(
                 jaro_winkler_thresholds, m_probability_or_probabilities_jw
             ):
-                level_dict = self._jaro_winkler_level(
+                comparison_level = self._jaro_winkler_level(
                     col_name,
                     distance_threshold=thres,
                     m_probability=m_prob,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
         if len(jaccard_thresholds) > 0:
             jaccard_thresholds = ensure_is_iterable(jaccard_thresholds)
@@ -375,12 +375,12 @@ class NameComparisonBase(Comparison):
             for thres, m_prob in zip(
                 jaccard_thresholds, m_probability_or_probabilities_jac
             ):
-                level_dict = self._jaccard_level(
+                comparison_level = self._jaccard_level(
                     col_name,
                     distance_threshold=thres,
                     m_probability=m_prob,
                 )
-                comparison_levels.append(level_dict)
+                comparison_levels.append(comparison_level)
 
         comparison_levels.append(
             self._else_level(m_probability=m_probability_else),

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -157,7 +157,6 @@ class DateComparisonBase(Comparison):
                 "Jaro-Winkler similarity. We recommend choosing one or the other."
             )
 
-
         if len(datediff_thresholds) > 0:
             datediff_thresholds = ensure_is_iterable(datediff_thresholds)
             datediff_metrics = ensure_is_iterable(datediff_metrics)
@@ -232,7 +231,7 @@ class NameComparisonBase(Comparison):
         self,
         col_name,
         include_exact_match_level=True,
-        phonetic_col_name = None,
+        phonetic_col_name=None,
         term_frequency_adjustments_name=False,
         term_frequency_adjustments_phonetic_name=False,
         levenshtein_thresholds=[],
@@ -305,7 +304,7 @@ class NameComparisonBase(Comparison):
                 col_name,
                 term_frequency_adjustments=term_frequency_adjustments_name,
                 m_probability=m_probability_exact_match_name,
-                include_colname_in_charts_label=True
+                include_colname_in_charts_label=True,
             )
             comparison_levels.append(level_dict)
 
@@ -314,10 +313,9 @@ class NameComparisonBase(Comparison):
                     phonetic_col_name,
                     term_frequency_adjustments=term_frequency_adjustments_phonetic_name,
                     m_probability=m_probability_exact_match_phonetic_name,
-                    include_colname_in_charts_label=True
+                    include_colname_in_charts_label=True,
                 )
                 comparison_levels.append(level_dict)
-
 
         if len(levenshtein_thresholds) > 0:
             levenshtein_thresholds = ensure_is_iterable(levenshtein_thresholds)
@@ -365,9 +363,7 @@ class NameComparisonBase(Comparison):
             jaccard_thresholds = ensure_is_iterable(jaccard_thresholds)
 
             if m_probability_or_probabilities_jac is None:
-                m_probability_or_probabilities_jac = [None] * len(
-                    jaccard_thresholds
-                )
+                m_probability_or_probabilities_jac = [None] * len(jaccard_thresholds)
             m_probability_or_probabilities_jac = ensure_is_iterable(
                 m_probability_or_probabilities_jac
             )
@@ -389,8 +385,8 @@ class NameComparisonBase(Comparison):
             )
 
         comparison_levels.append(
-                self._else_level(m_probability=m_probability_else),
-            )
+            self._else_level(m_probability=m_probability_else),
+        )
 
         # Construct Description
         comparison_desc = ""
@@ -417,9 +413,7 @@ class NameComparisonBase(Comparison):
         if len(jaccard_thresholds) > 0:
             lev_desc = ", ".join([str(d) for d in jaccard_thresholds])
             plural = "" if len(jaccard_thresholds) == 1 else "s"
-            comparison_desc += (
-                f"Names within jaccard threshold{plural} {lev_desc} vs. "
-            )
+            comparison_desc += f"Names within jaccard threshold{plural} {lev_desc} vs. "
 
         comparison_desc += "anything else"
 
@@ -436,7 +430,7 @@ class FullNameComparisonBase(Comparison):
         col_name,
         include_exact_match_level=True,
         include_forename_surname_inversion=True,
-        include_dmetaphone = False,
+        include_dmetaphone=False,
         term_frequency_adjustments_forename=False,
         term_frequency_adjustments_surname=False,
         term_frequency_adjustments_fullname=False,

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -251,6 +251,7 @@ class NameComparisonBase(Comparison):
 
         The default arguments will give a comparison with comparison levels:\n
         - Exact match \n
+        - Jaro Winkler similarity >= 0.95\n
         - Jaro Winkler similarity >= 0.88\n
         - Anything else
 
@@ -260,7 +261,9 @@ class NameComparisonBase(Comparison):
                 level for col_name. Defaults to True.
             phonetic_col_name (str): The name of the column with phonetic reduction
                 (such as dmetaphone) of col_name. Including parameter will create
-                an exact match level for  phonetic_col_name. Defaults to None
+                an exact match level for  phonetic_col_name. The phonetic column must 
+                be present in the dataset to use this parameter.
+                Defaults to None
             term_frequency_adjustments_name (bool, optional): If True, apply term
                 frequency adjustments to the exact match level for "col_name".
                 Defaults to False.

--- a/splink/duckdb/duckdb_comparison_library.py
+++ b/splink/duckdb/duckdb_comparison_library.py
@@ -50,6 +50,18 @@ class DuckDBComparisonProperties(DuckDBBase):
     def _distance_in_km_level(self):
         return distance_in_km_level
 
+    @property
+    def _levenshtein_level(self):
+        return levenshtein_level
+
+    @property
+    def _jaro_winkler_level(self):
+        return jaro_winkler_level
+
+    @property
+    def _jaccard_level(self):
+        return jaccard_level
+
 
 class exact_match(DuckDBComparisonProperties, ExactMatchBase):
     pass

--- a/splink/duckdb/duckdb_comparison_template_library.py
+++ b/splink/duckdb/duckdb_comparison_template_library.py
@@ -1,8 +1,4 @@
-from ..comparison_template_library import (
-    DateComparisonBase,
-    NameComparisonBase,
-    FullNameComparisonBase,
-)
+from ..comparison_template_library import DateComparisonBase, NameComparisonBase
 from .duckdb_comparison_library import DuckDBComparisonProperties
 
 
@@ -11,8 +7,4 @@ class date_comparison(DuckDBComparisonProperties, DateComparisonBase):
 
 
 class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
-    pass
-
-
-class fullname_comparison(DuckDBComparisonProperties, FullNameComparisonBase):
     pass

--- a/splink/duckdb/duckdb_comparison_template_library.py
+++ b/splink/duckdb/duckdb_comparison_template_library.py
@@ -1,13 +1,16 @@
-from ..comparison_template_library import DateComparisonBase
-from .duckdb_comparison_level_library import jaro_winkler_level, levenshtein_level
+from ..comparison_template_library import (
+    DateComparisonBase, 
+    NameComparisonBase, 
+    FullNameComparisonBase
+    )
 from .duckdb_comparison_library import DuckDBComparisonProperties
 
 
 class date_comparison(DuckDBComparisonProperties, DateComparisonBase):
-    @property
-    def _levenshtein_level(self):
-        return levenshtein_level
+    pass
 
-    @property
-    def _jaro_winkler_level(self):
-        return jaro_winkler_level
+class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
+    pass
+
+class fullname_comparison(DuckDBComparisonProperties, FullNameComparisonBase):
+    pass

--- a/splink/duckdb/duckdb_comparison_template_library.py
+++ b/splink/duckdb/duckdb_comparison_template_library.py
@@ -1,16 +1,18 @@
 from ..comparison_template_library import (
-    DateComparisonBase, 
-    NameComparisonBase, 
-    FullNameComparisonBase
-    )
+    DateComparisonBase,
+    NameComparisonBase,
+    FullNameComparisonBase,
+)
 from .duckdb_comparison_library import DuckDBComparisonProperties
 
 
 class date_comparison(DuckDBComparisonProperties, DateComparisonBase):
     pass
 
+
 class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
     pass
+
 
 class fullname_comparison(DuckDBComparisonProperties, FullNameComparisonBase):
     pass

--- a/splink/spark/spark_comparison_library.py
+++ b/splink/spark/spark_comparison_library.py
@@ -50,6 +50,18 @@ class SparkComparisonProperties(SparkBase):
     def _distance_in_km_level(self):
         return distance_in_km_level
 
+    @property
+    def _levenshtein_level(self):
+        return levenshtein_level
+
+    @property
+    def _jaro_winkler_level(self):
+        return jaro_winkler_level
+
+    @property
+    def _jaccard_level(self):
+        return jaccard_level
+
 
 class exact_match(SparkComparisonProperties, ExactMatchBase):
     pass

--- a/splink/spark/spark_comparison_template_library.py
+++ b/splink/spark/spark_comparison_template_library.py
@@ -1,13 +1,16 @@
-from ..comparison_template_library import DateComparisonBase
-from .spark_comparison_level_library import jaro_winkler_level, levenshtein_level
+from ..comparison_template_library import (
+    DateComparisonBase, 
+    NameComparisonBase, 
+    FullNameComparisonBase
+    )
 from .spark_comparison_library import SparkComparisonProperties
 
 
 class date_comparison(SparkComparisonProperties, DateComparisonBase):
-    @property
-    def _levenshtein_level(self):
-        return levenshtein_level
+    pass
 
-    @property
-    def _jaro_winkler_level(self):
-        return jaro_winkler_level
+class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
+    pass
+
+class fullname_comparison(DuckDBComparisonProperties, FullNameComparisonBase):
+    pass

--- a/splink/spark/spark_comparison_template_library.py
+++ b/splink/spark/spark_comparison_template_library.py
@@ -1,7 +1,6 @@
 from ..comparison_template_library import (
     DateComparisonBase,
     NameComparisonBase,
-    FullNameComparisonBase,
 )
 from .spark_comparison_library import SparkComparisonProperties
 
@@ -10,9 +9,5 @@ class date_comparison(SparkComparisonProperties, DateComparisonBase):
     pass
 
 
-class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
-    pass
-
-
-class fullname_comparison(DuckDBComparisonProperties, FullNameComparisonBase):
+class name_comparison(SparkComparisonProperties, NameComparisonBase):
     pass

--- a/splink/spark/spark_comparison_template_library.py
+++ b/splink/spark/spark_comparison_template_library.py
@@ -1,16 +1,18 @@
 from ..comparison_template_library import (
-    DateComparisonBase, 
-    NameComparisonBase, 
-    FullNameComparisonBase
-    )
+    DateComparisonBase,
+    NameComparisonBase,
+    FullNameComparisonBase,
+)
 from .spark_comparison_library import SparkComparisonProperties
 
 
 class date_comparison(SparkComparisonProperties, DateComparisonBase):
     pass
 
+
 class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
     pass
+
 
 class fullname_comparison(DuckDBComparisonProperties, FullNameComparisonBase):
     pass

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -176,7 +176,7 @@ def test_date_comparison_error_logger(ctl):
     ],
 )
 def test_name_comparison_run(ctl):
-    ctl.name_comparison("date")
+    ctl.name_comparison("first_name")
 
 
 @pytest.mark.parametrize(
@@ -247,6 +247,11 @@ def test_name_comparison_levels(spark, ctl, Linker):
 
     # # Dict key: {gamma_level value: size}
     size_gamma_lookup = {0: 8, 1: 4, 2: 0, 3: 2, 4: 1}
+    # 4: exact_match
+    # 3: dmetaphone exact match
+    # 2: jaro_winkler > 0.95
+    # 1: jaro_winkler > 0.8
+    # 0: else
 
     # Check gamma sizes are as expected
     for gamma, expected_size in size_gamma_lookup.items():

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -7,6 +7,7 @@ from splink.duckdb.duckdb_linker import DuckDBLinker
 from splink.spark.spark_linker import SparkLinker
 
 
+## date_comparison
 @pytest.mark.parametrize(
     ("ctl"),
     [
@@ -162,3 +163,118 @@ def test_date_comparison_error_logger(ctl):
     # Metric len == 0
     with pytest.raises(ValueError):
         ctl.date_comparison("date", datediff_thresholds=[1], datediff_metrics=[])
+
+
+## name_comparison
+
+
+@pytest.mark.parametrize(
+    ("ctl"),
+    [
+        pytest.param(ctld, id="DuckDB Name Comparison Simple Run Test"),
+        pytest.param(ctls, id="Spark Name Comparison Simple Run Test"),
+    ],
+)
+def test_name_comparison_run(ctl):
+    ctl.name_comparison("date")
+
+
+@pytest.mark.parametrize(
+    ("ctl", "Linker"),
+    [
+        pytest.param(ctld, DuckDBLinker, id="DuckDB Date Comparison Integration Tests"),
+        pytest.param(ctls, SparkLinker, id="Spark Date Comparison Integration Tests"),
+    ],
+)
+def test_name_comparison_levels(spark, ctl, Linker):
+
+    df = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "first_name": "Robert",
+                "first_name_metaphone": "RBRT",
+                "dob": "1996-03-25",
+            },
+            {
+                "unique_id": 2,
+                "first_name": "Rob",
+                "first_name_metaphone": "RB",
+                "dob": "1996-03-25",
+            },
+            {
+                "unique_id": 3,
+                "first_name": "Robbie",
+                "first_name_metaphone": "RB",
+                "dob": "1999-12-28",
+            },
+            {
+                "unique_id": 4,
+                "first_name": "Bobert",
+                "first_name_metaphone": "BB",
+                "dob": "2000-01-01",
+            },
+            {
+                "unique_id": 5,
+                "first_name": "Bobby",
+                "first_name_metaphone": "BB",
+                "dob": "2000-10-20",
+            },
+            {
+                "unique_id": 6,
+                "first_name": "Robert",
+                "first_name_metaphone": "RBRT",
+                "dob": "1996-03-25",
+            },
+        ]
+    )
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            ctl.name_comparison(
+                "first_name",
+                phonetic_col_name="first_name_metaphone",
+            )
+        ],
+    }
+
+    if Linker == SparkLinker:
+        df = spark.createDataFrame(df)
+        df.persist()
+    linker = Linker(df, settings)
+    linker_output = linker.predict().as_pandas_dataframe()
+
+    # # Dict key: {gamma_level value: size}
+    size_gamma_lookup = {0: 8, 1: 4, 2: 0, 3: 2, 4: 1}
+
+    # Check gamma sizes are as expected
+    for gamma, expected_size in size_gamma_lookup.items():
+        print(f"gamma={gamma} and gamma_lookup={expected_size}")
+
+        assert (
+            sum(linker_output["gamma_custom_first_name_first_name_metaphone"] == gamma)
+            == expected_size
+        )
+
+    # Check individual IDs are assigned to the correct gamma values
+    # Dict key: {gamma_value: tuple of ID pairs}
+    size_gamma_lookup = {
+        4: [[1, 6]],
+        3: [(2, 3), (4, 5)],
+        2: [],
+        1: [(1, 2), (4, 6)],
+        0: [(2, 4), (5, 6)],
+    }
+
+    for gamma, id_pairs in size_gamma_lookup.items():
+        for left, right in id_pairs:
+            print(f"Checking IDs: {left}, {right}")
+
+            assert (
+                linker_output.loc[
+                    (linker_output.unique_id_l == left)
+                    & (linker_output.unique_id_r == right)
+                ]["gamma_custom_first_name_first_name_metaphone"].values[0]
+                == gamma
+            )


### PR DESCRIPTION
Comparison template library Function `name_comparison` to give a simple interface for comparing individual name columns. Plan to create a first name and surname comparison, but this is a bit more fiddly so will do in a separate PR.

Default values give the same output as `jaro_winkler_at_thresholds([0.95, 0.88])` but gives more flexibility with dmetaphone cols and other string distance metrics in the parameters. Releasing  for only spark and duckdb at this stage. Need to think about a more general solution for the likes of AthenaLinker as not all the comparator functions are available.