### PR TITLE
Benchmark timeseries commit workflow to run only in upstream repo

### DIFF
--- a/.github/workflows/pytest_benchmark_commit.yml
+++ b/.github/workflows/pytest_benchmark_commit.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    # only run this workflow on the upstream
+    if: github.repository == 'moj-analytical-services/splink'
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python


### PR DESCRIPTION
This stops this workflow running on the `master` branch in fork repos that have enabled actions to run. These may be enabled (as in my case) when working on modifying the actions themselves. With this workflow running you end up with many spurious commits which are out of sync with upstream (for instance it runs after you sync your fork you get an extra benchmark commit), and involves a lot of fiddling about to ensure they do not end up polluting the main repo. As in these cases we do not need the extra timeseries info, it would be nice to not generate them at all, to save needing to manually delete commits/fiddle with branches and all that stuff that is prone to causing mischiefs.

The workflow should still run properly on **this** repo.