### PR TITLE
Make the example notebooks run faster

### DIFF
--- a/.github/workflows/run_demos_examples.yml
+++ b/.github/workflows/run_demos_examples.yml
@@ -49,6 +49,7 @@ jobs:
               fi
             done
             find . -type f -name 'example_*ipynb' -exec grep -H 'max_pairs' {} \;
+            sed -i 's/display(ui,out)/pass/' example_real_time_record_linkage.ipynb
             sed -i 's/display(linker.waterfall_chart(recs, filter_nulls=False))/pass/' example_real_time_record_linkage.ipynb
             python -m pytest --nbmake --nbmake-kernel=python3 example_*ipynb
 

--- a/.github/workflows/run_demos_examples.yml
+++ b/.github/workflows/run_demos_examples.yml
@@ -25,6 +25,14 @@ jobs:
           ref: master
           path: "splink_demos/"
 
+      - name: Set up cache for pip packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install environment and check notebooks
         run: |
             cd splink_demos
@@ -41,6 +49,6 @@ jobs:
               fi
             done
             find . -type f -name 'example_*ipynb' -exec grep -H 'max_pairs' {} \;
-            sed -i '/display(linker.waterfall_chart(recs, filter_nulls=False))/d' example_real_time_record_linkage.ipynb
+            sed -i 's/display(linker.waterfall_chart(recs, filter_nulls=False))/pass/' example_real_time_record_linkage.ipynb
             python -m pytest --nbmake --nbmake-kernel=python3 example_*ipynb
 

--- a/.github/workflows/run_demos_examples.yml
+++ b/.github/workflows/run_demos_examples.yml
@@ -41,5 +41,6 @@ jobs:
               fi
             done
             find . -type f -name 'example_*ipynb' -exec grep -H 'max_pairs' {} \;
+            sed -i '/display(linker.waterfall_chart(recs, filter_nulls=False))/d' example_real_time_record_linkage.ipynb
             python -m pytest --nbmake --nbmake-kernel=python3 example_*ipynb
 


### PR DESCRIPTION
This has been very irritating to fix!

For some reason, the test runner hung for like 4 minutes when testing notebooks with an interactive widget component

I've also added a caching layer for the dependencies.

Further gains probably possible, but this test is now faster than the main tests, so it's probably good enough