### PR TITLE
Fix autoblack checkout step

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -5,7 +5,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
Moving to github actions checkout in #1133 has left the state as a detached head in the autoblack workflow, meaning the push step fails. This changes the checkout parameters to correct the git state, so that changes can be pushed.