### PR TITLE
Create `_register_input_tables` method in our main linker class

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -126,8 +126,14 @@ class DuckDBLinker(Linker):
             input_table_or_tables, input_table_aliases
         )
 
-        # These are currently given as strings so we don't have to import pyarrow
-        accepted_df_dtypes = ["DataFrame", "Table"]
+        accepted_df_dtypes = [pd.DataFrame]
+        try:
+            # If pyarrow is installed, add to the accepted list
+            import pyarrow as pa
+
+            accepted_df_dtypes.append(pa.lib.Table)
+        except ImportError:
+            pass
 
         super().__init__(
             input_tables,

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -11,7 +11,6 @@ from ..input_column import InputColumn
 from ..linker import Linker
 from ..logging_messages import execute_sql_logging_message_info, log_sql
 from ..misc import (
-    all_letter_combos,
     ensure_is_list,
 )
 from ..splink_dataframe import SplinkDataFrame
@@ -118,40 +117,33 @@ class DuckDBLinker(Linker):
         # If user has provided pandas dataframes, need to register
         # them with the database, using user-provided aliases
         # if provided or a created alias if not
-
         input_tables = ensure_is_list(input_table_or_tables)
+        input_tables = [
+            duckdb_load_from_file(t) if isinstance(t, str) else t for t in input_tables
+        ]
 
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases
         )
 
-        # 'homogenised' means all entries are strings representing tables
-        homogenised_tables = []
-        homogenised_aliases = []
-
-        default_aliases = all_letter_combos(len(input_tables))
-
-        for table, alias, default_alias in zip(
-            input_tables, input_aliases, default_aliases
-        ):
-            if type(alias).__name__ in ["DataFrame", "Table"]:
-                alias = f"_{default_alias}"
-
-            if type(table).__name__ in ["DataFrame", "Table"]:
-                con.register(alias, table)
-                if isinstance(table, pd.DataFrame):
-                    self._check_cast_error(alias)
-                table = alias
-
-            homogenised_tables.append(duckdb_load_from_file(table))
-            homogenised_aliases.append(alias)
+        # These are currently given as strings so we don't have to import pyarrow
+        accepted_df_dtypes = ["DataFrame", "Table"]
 
         super().__init__(
-            homogenised_tables,
+            input_tables,
             settings_dict,
+            accepted_df_dtypes,
             set_up_basic_logging,
-            input_table_aliases=homogenised_aliases,
+            input_table_aliases=input_aliases,
         )
+
+        # Quickly check for casting error in duckdb/pandas
+        for i, (table, alias) in enumerate(zip(input_tables, input_aliases)):
+            if isinstance(table, pd.DataFrame):
+                if isinstance(alias, pd.DataFrame):
+                    alias = f"__splink__input_table_{i}"
+
+                self._check_cast_error(alias)
 
         if output_schema:
             self._con.execute(

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -55,6 +55,7 @@ from .misc import (
     ascii_uid,
     bayes_factor_to_prob,
     ensure_is_list,
+    ensure_is_tuple,
     prob_to_bayes_factor,
 )
 from .missingness import completeness_data, missingness_data
@@ -322,12 +323,13 @@ class Linker:
         # 'homogenised' means all entries are strings representing tables
         homogenised_tables = []
         homogenised_aliases = []
+        accepted_df_dtypes = ensure_is_tuple(accepted_df_dtypes)
 
         for i, (table, alias) in enumerate(zip(input_tables, input_aliases)):
-            if type(alias).__name__ in accepted_df_dtypes:
+            if isinstance(alias, accepted_df_dtypes):
                 alias = f"__splink__input_table_{i}"
 
-            if type(table).__name__ in accepted_df_dtypes:
+            if isinstance(table, accepted_df_dtypes):
                 self.register_table(table, alias)
                 table = alias
 

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -90,17 +90,6 @@ class EverythingEncoder(json.JSONEncoder):
             return obj.__str__()
 
 
-def all_letter_combos(n):
-    """a,b,....,z,aa,ab,...,aaa"""
-
-    combos = []
-    for size in itertools.count(1):
-        for s in itertools.product(string.ascii_lowercase, repeat=size):
-            combos.append("".join(s))
-            if len(combos) >= n:
-                return combos
-
-
 def calculate_cartesian(df_rows, link_type):
     """
     Calculates the cartesian product for the input df(s).

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -48,6 +48,15 @@ def ensure_is_list(a):
     return a if isinstance(a, list) else [a]
 
 
+def ensure_is_tuple(a):
+    if isinstance(a, tuple):
+        return a
+    elif isinstance(a, list):
+        return tuple(a)
+    else:
+        return (a,)
+
+
 def join_list_with_commas_final_and(lst):
     if len(lst) == 1:
         return lst[0]

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -124,6 +124,9 @@ class SparkLinker(Linker):
             input_table_or_tables, input_table_aliases
         )
 
+        # These are currently given as strings so we don't have to import pyarrow
+        accepted_df_dtypes = ["DataFrame"]
+
         self._get_spark_from_input_tables_if_not_provided(spark, input_tables)
 
         if num_partitions_on_repartition is None:
@@ -149,25 +152,12 @@ class SparkLinker(Linker):
 
         self._drop_splink_cached_tables()
 
-        homogenised_tables = []
-        homogenised_aliases = []
-
-        for i, (table, alias) in enumerate(zip(input_tables, input_aliases)):
-            if type(alias).__name__ == "DataFrame":
-                alias = f"__splink__input_table_{i}"
-
-            if type(table).__name__ == "DataFrame":
-                self.register_table(table, alias)
-                table = alias
-
-            homogenised_tables.append(table)
-            homogenised_aliases.append(alias)
-
         super().__init__(
-            homogenised_tables,
+            input_tables,
             settings_dict,
+            accepted_df_dtypes,
             set_up_basic_logging,
-            input_table_aliases=homogenised_aliases,
+            input_table_aliases=input_aliases,
         )
 
         self.in_databricks = "DATABRICKS_RUNTIME_VERSION" in os.environ

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -124,8 +124,7 @@ class SparkLinker(Linker):
             input_table_or_tables, input_table_aliases
         )
 
-        # These are currently given as strings so we don't have to import pyarrow
-        accepted_df_dtypes = ["DataFrame"]
+        accepted_df_dtypes = (pd.DataFrame, spark_df)
 
         self._get_spark_from_input_tables_if_not_provided(spark, input_tables)
 

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -99,8 +99,7 @@ class SQLiteLinker(Linker):
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases
         )
-        # These are currently given as strings so we don't have to import pyarrow
-        accepted_df_dtypes = ["DataFrame"]
+        accepted_df_dtypes = pd.DataFrame
 
         super().__init__(
             input_tables,

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -8,6 +8,7 @@ import pandas as pd
 from ..input_column import InputColumn
 from ..linker import Linker
 from ..logging_messages import execute_sql_logging_message_info, log_sql
+from ..misc import ensure_is_list
 from ..splink_dataframe import SplinkDataFrame
 
 logger = logging.getLogger(__name__)
@@ -94,11 +95,19 @@ class SQLiteLinker(Linker):
         self.con.create_function("log2", 1, log2)
         self.con.create_function("pow", 2, pow)
 
+        input_tables = ensure_is_list(input_table_or_tables)
+        input_aliases = self._ensure_aliases_populated_and_is_list(
+            input_table_or_tables, input_table_aliases
+        )
+        # These are currently given as strings so we don't have to import pyarrow
+        accepted_df_dtypes = ["DataFrame"]
+
         super().__init__(
-            input_table_or_tables,
+            input_tables,
             settings_dict,
+            accepted_df_dtypes,
             set_up_basic_logging,
-            input_table_aliases=input_table_aliases,
+            input_table_aliases=input_aliases,
         )
 
     def _table_to_splink_dataframe(self, templated_name, physical_name):

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -68,7 +68,7 @@ def test_splink_converges_to_known_params():
     # CREATE TABLE __splink__df_comparison_vectors_abc123
     # and modify the following line to include the value of the hash (abc123 above)
 
-    cvv_hashed_tablename = "__splink__df_comparison_vectors_44a6648a2"
+    cvv_hashed_tablename = "__splink__df_comparison_vectors_729ee0809"
     linker.register_table(df, cvv_hashed_tablename)
 
     em_training_session = EMTrainingSession(


### PR DESCRIPTION
A quick PR that centralises our input table registration process. We now have a main `_register_input_tables` method, which uses `register_table` to add any pandas or pyarrow dfs supplied by the user to the database during the init step.

This is a necessary adjustment to get the Athena linker updated. I'll add the changes to that linker once this has been approved and merged.

Remind me to check that the `try` statement I've added for pyarrow works.