### PR TITLE
Adjust the outputs of `truth_space_table_from_labels_with_predictions_sqls` to be lowercase

### DIFF
--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -111,21 +111,21 @@ def truth_space_table_from_labels_with_predictions_sqls(
         power(2, truth_threshold) / (1 + power(2, truth_threshold))
             as match_probability,
         row_count,
-        P,
-        N,
-        TP,
-        TN,
-        FP,
-        FN,
+        P as p,
+        N as n,
+        TP as tp,
+        TN as tn,
+        FP as fp,
+        FN as fn,
         P/row_count as P_rate,
         cast(N as float)/row_count as N_rate,
-        cast(TP as float)/P as TP_rate,
-        cast(TN as float)/N as TN_rate,
-        cast(FP as float)/N as FP_rate,
-        cast(FN as float)/P as FN_rate,
+        cast(TP as float)/P as tp_rate,
+        cast(TN as float)/N as tn_rate,
+        cast(FP as float)/N as fp_rate,
+        cast(FN as float)/P as fn_rate,
         cast(TP as float)/(TP+FP) as precision,
         cast(TP as float)/(TP+FN) as recall,
-        cast(TP as float)/(TP + (FP + FN)/2) as F1
+        cast(TP as float)/(TP + (FP + FN)/2) as f1
     from __splink__labels_with_pos_neg_grouped_with_truth_stats
     """
 

--- a/splink/files/chart_defs/precision_recall.json
+++ b/splink/files/chart_defs/precision_recall.json
@@ -7,15 +7,15 @@
     "tooltip": [
       { "type": "quantitative", "field": "truth_threshold", "format": ".4f" },
       { "type": "quantitative", "field": "match_probability", "format": ".4%" },
-      { "type": "quantitative", "field": "FP_rate", "format": ".4f" },
-      { "type": "quantitative", "field": "TP_rate", "format": ".4f" },
-      { "type": "quantitative", "field": "TP", "format": ",.0f" },
-      { "type": "quantitative", "field": "TN", "format": ",.0f" },
-      { "type": "quantitative", "field": "FP", "format": ",.0f" },
-      { "type": "quantitative", "field": "FN", "format": ",.0f" },
+      { "type": "quantitative", "field": "fp_rate", "format": ".4f", "title": "FP_rate" },
+      { "type": "quantitative", "field": "tp_rate", "format": ".4f", "title": "TP_rate" },
+      { "type": "quantitative", "field": "tp", "format": ",.0f", "title": "TP" },
+      { "type": "quantitative", "field": "tn", "format": ",.0f", "title": "TN" },
+      { "type": "quantitative", "field": "fp", "format": ",.0f", "title": "FP" },
+      { "type": "quantitative", "field": "fn", "format": ",.0f", "title": "FN" },
       { "type": "quantitative", "field": "precision", "format": ".4f" },
       { "type": "quantitative", "field": "recall", "format": ".4f" },
-      { "type": "quantitative", "field": "F1", "format": ".4f" }
+      { "type": "quantitative", "field": "f1", "format": ".4f", "title": "F1" }
     ],
     "x": {
       "type": "quantitative",

--- a/splink/files/chart_defs/roc.json
+++ b/splink/files/chart_defs/roc.json
@@ -9,25 +9,25 @@
     "tooltip": [
       { "type": "quantitative", "field": "truth_threshold", "format": ".4f" },
       { "type": "quantitative", "field": "match_probability", "format": ".4%" },
-      { "type": "quantitative", "field": "FP_rate", "format": ".4f" },
-      { "type": "quantitative", "field": "TP_rate", "format": ".4f" },
-      { "type": "quantitative", "field": "TP", "format": ",.0f" },
-      { "type": "quantitative", "field": "TN", "format": ",.0f" },
-      { "type": "quantitative", "field": "FP", "format": ",.0f" },
-      { "type": "quantitative", "field": "FN", "format": ",.0f" },
+      { "type": "quantitative", "field": "fp_rate", "format": ".4f", "title": "FP_rate" },
+      { "type": "quantitative", "field": "tp_rate", "format": ".4f", "title": "TP_rate" },
+      { "type": "quantitative", "field": "tp", "format": ",.0f", "title": "TP" },
+      { "type": "quantitative", "field": "tn", "format": ",.0f", "title": "TN" },
+      { "type": "quantitative", "field": "fp", "format": ",.0f", "title": "FP" },
+      { "type": "quantitative", "field": "fn", "format": ",.0f", "title": "FN" },
       { "type": "quantitative", "field": "precision", "format": ".4f" },
       { "type": "quantitative", "field": "recall", "format": ".4f" },
-      { "type": "quantitative", "field": "F1", "format": ".4f" }
+      { "type": "quantitative", "field": "f1", "format": ".4f", "title": "F1" }
     ],
     "x": {
       "type": "quantitative",
-      "field": "FP_rate",
+      "field": "fp_rate",
       "sort": ["truth_threshold"],
       "title": "False Positive Rate amongst clerically reviewed records"
     },
     "y": {
       "type": "quantitative",
-      "field": "TP_rate",
+      "field": "tp_rate",
       "sort": ["truth_threshold"],
       "title": "True Positive Rate amongst clerically reviewed records"
     },

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -1,4 +1,3 @@
-import itertools
 import json
 import random
 import string

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -150,7 +150,7 @@ def test_truth_space_table():
     # 2,12 is a P at 40% against a clerical N (45%) so is a FP
     # 3,13 is a FP as well
 
-    assert pytest.approx(row["FP_rate"]) == 2 / 3
+    assert pytest.approx(row["fp_rate"]) == 2 / 3
 
     # Precision = TP/TP+FP
     assert row["precision"] == 0.0
@@ -456,18 +456,18 @@ def test_truth_space_table_from_labels_column_dedupe_only():
     tt = linker.truth_space_table_from_labels_column("cluster").as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
-    assert truth_dict["TP"] == 4
-    assert truth_dict["FP"] == 11
-    assert truth_dict["TN"] == 0
-    assert truth_dict["FN"] == 0
+    assert truth_dict["tp"] == 4
+    assert truth_dict["fp"] == 11
+    assert truth_dict["tn"] == 0
+    assert truth_dict["fn"] == 0
 
     # Truth threshold 3.17, meaning only comparisons where forename match get classified
     # as positive
     truth_dict = tt[1]
-    assert truth_dict["TP"] == 3
-    assert truth_dict["FP"] == 3
-    assert truth_dict["TN"] == 8
-    assert truth_dict["FN"] == 1
+    assert truth_dict["tp"] == 3
+    assert truth_dict["fp"] == 3
+    assert truth_dict["tn"] == 8
+    assert truth_dict["fn"] == 1
 
 
 def test_truth_space_table_from_labels_column_link_only():
@@ -523,15 +523,15 @@ def test_truth_space_table_from_labels_column_link_only():
     tt = linker.truth_space_table_from_labels_column("ground_truth").as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
-    assert truth_dict["TP"] == 3
-    assert truth_dict["FP"] == 6
-    assert truth_dict["TN"] == 0
-    assert truth_dict["FN"] == 0
+    assert truth_dict["tp"] == 3
+    assert truth_dict["fp"] == 6
+    assert truth_dict["tn"] == 0
+    assert truth_dict["fn"] == 0
 
     # Truth threshold 3.17, meaning only comparisons where forename match get classified
     # as positive
     truth_dict = tt[1]
-    assert truth_dict["TP"] == 1
-    assert truth_dict["FP"] == 1
-    assert truth_dict["TN"] == 5
-    assert truth_dict["FN"] == 2
+    assert truth_dict["tp"] == 1
+    assert truth_dict["fp"] == 1
+    assert truth_dict["tn"] == 5
+    assert truth_dict["fn"] == 2


### PR DESCRIPTION
A really quick PR that just adjusts the table names of `truth_space_table_from_labels_with_predictions_sqls` to be lowercased.

This change is required to get these charts working with Athena, which for some reason automatically converts pandas column headers to lowercase.

This change should only impact the two accuracy charts:
* `precision_recall_chart_from_labels_column`
* `roc_chart_from_labels_column`
