### PR TITLE
[BUG] Fix source dataset issue when running link jobs

### DIFF
--- a/splink/block_from_labels.py
+++ b/splink/block_from_labels.py
@@ -32,7 +32,7 @@ def block_from_labels(
 
     unique_id_col = linker._settings_obj._unique_id_column_name
 
-    source_dataset_col = linker._settings_obj._source_dataset_column_name
+    source_dataset_col = linker._settings_obj._source_dataset_input_column
 
     sql = lower_id_to_left_hand_side(df, source_dataset_col, unique_id_col)
 

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -119,7 +119,7 @@ def block_using_rules_sql(linker: Linker):
         and not linker._find_new_matches_mode
         and not linker._compare_two_records_mode
     ):
-        source_dataset_col = linker._settings_obj._source_dataset_column_name
+        source_dataset_col = linker._source_dataset_column_name
         # Need df_l to be the one with the lowest id to preeserve the property
         # that the left dataset is the one with the lowest concatenated id
         keys = linker._input_tables_dict.keys()

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -290,11 +290,7 @@ class Linker:
 
             input_column = self._settings_obj._source_dataset_input_column
             src_ds_col = InputColumn(input_column, self).name()
-            return (
-                "__splink_source_dataset"
-                if src_ds_col in columns
-                else input_column
-            )
+            return "__splink_source_dataset" if src_ds_col in columns else input_column
         else:
             return None
 

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -68,7 +68,7 @@ def completeness_data(linker, input_tablename=None, cols=None):
     columns = linker._settings_obj._columns_used_by_comparisons
 
     if linker._settings_obj._source_dataset_column_name_is_required:
-        source_name = linker._settings_obj._source_dataset_column_name
+        source_name = linker._source_dataset_column_name
     else:
         # Set source dataset to a literal string if dedupe_only
         source_name = "'_a'"

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -153,7 +153,7 @@ class Settings:
         ]
 
     @property
-    def _source_dataset_column_name(self):
+    def _source_dataset_input_column(self):
         if self._source_dataset_column_name_is_required:
             s_else_d = self._from_settings_dict_else_default
             return s_else_d("source_dataset_column_name")
@@ -166,7 +166,7 @@ class Settings:
 
         if self._source_dataset_column_name_is_required:
             col = InputColumn(
-                self._source_dataset_column_name,
+                self._source_dataset_input_column,
                 settings_obj=self,
             )
             cols.append(col)
@@ -198,7 +198,7 @@ class Settings:
     def _columns_used_by_comparisons(self):
         cols_used = []
         if self._source_dataset_column_name_is_required:
-            cols_used.append(self._source_dataset_column_name)
+            cols_used.append(self._source_dataset_input_column)
         cols_used.append(self._unique_id_column_name)
         for cc in self.comparisons:
             cols = cc._input_columns_used_by_case_statement
@@ -428,7 +428,7 @@ class Settings:
             "comparisons": [cc._as_completed_dict() for cc in self.comparisons],
             "probability_two_random_records_match": rr_match,
             "unique_id_column_name": self._unique_id_column_name,
-            "source_dataset_column_name": self._source_dataset_column_name,
+            "source_dataset_column_name": self._source_dataset_input_column,
         }
         return {**self._settings_dict, **current_settings}
 

--- a/splink/vertically_concatenate.py
+++ b/splink/vertically_concatenate.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from .input_column import InputColumn
+
 logger = logging.getLogger(__name__)
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
@@ -51,8 +53,10 @@ def vertically_concatenate_sql(linker: Linker) -> str:
     if source_dataset_col_req:
         sqls_to_union = []
         for df_obj in linker._input_tables_dict.values():
+            source_ds_col = linker._source_dataset_column_name
             sql = f"""
-            select '{df_obj.templated_name}' as source_dataset, {select_columns_sql}
+            select '{df_obj.templated_name}' as {source_ds_col},
+            {select_columns_sql}
             {salt_sql}
             from {df_obj.physical_name}
             """

--- a/splink/vertically_concatenate.py
+++ b/splink/vertically_concatenate.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from .input_column import InputColumn
-
 logger = logging.getLogger(__name__)
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -113,6 +113,56 @@ def test_full_example_duckdb(tmp_path):
     DuckDBLinker(df, settings_dict=path)
 
 
+# Create some dummy dataframes for the link only test
+df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+df_l = df.copy()
+df_r = df.copy()
+df_l["source_dataset"] = "my_left_ds"
+df_r["source_dataset"] = "my_right_ds"
+df_final = df_l.append(df_r)
+# Tests link only jobs under different inputs:
+# * A single dataframe with a `source_dataset` column
+# * Two input dataframes with no specified `source_dataset` column
+# * Two input dataframes with a specified `source_dataset` column
+@pytest.mark.parametrize(
+    ("input", "source_l", "source_r"),
+    [
+        pytest.param(
+            [df, df],  # no source_dataset col
+            {"__splink__input_table_0"},
+            {"__splink__input_table_1"},
+            id="No source dataset column",
+        ),
+        pytest.param(
+            df_final,  # source_dataset col
+            {"my_left_ds"},
+            {"my_right_ds"},
+            id="Source dataset column in a single df",
+        ),
+        pytest.param(
+            [df_l, df_r],  # source_dataset col
+            {"my_left_ds"},
+            {"my_right_ds"},
+            id="Source dataset column in two dfs",
+        ),
+    ],
+)
+def test_link_only(input, source_l, source_r):
+    settings = get_settings_dict()
+    settings["link_type"] = "link_only"
+    settings["source_dataset_column_name"] = "source_dataset"
+
+    linker = DuckDBLinker(
+        input,
+        settings,
+    )
+    df_predict = linker.predict().as_pandas_dataframe()
+
+    assert len(df_predict) == 7257
+    assert set(df_predict.source_dataset_l.values) == source_l
+    assert set(df_predict.source_dataset_r.values) == source_r
+
+
 @pytest.mark.parametrize(
     ("df"),
     [
@@ -238,29 +288,13 @@ def test_small_example_duckdb(tmp_path):
         "retain_intermediate_calculation_columns": True,
     }
 
-    linker = DuckDBLinker(
-        df,
-        connection=os.path.join(tmp_path, "duckdb.db"),
-        output_schema="splink_in_duckdb",
-    )
-    linker.load_settings(settings_dict)
+    linker = DuckDBLinker(df, settings_dict)
 
     linker.estimate_u_using_random_sampling(max_pairs=1e6)
-    linker.estimate_probability_two_random_records_match(
-        ["l.email = r.email"], recall=0.3
-    )
     blocking_rule = "l.full_name = r.full_name"
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
     blocking_rule = "l.dob = r.dob"
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
-    df_predict = linker.predict()
-    linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.1)
-
-    path = os.path.join(tmp_path, "model.json")
-    linker.save_settings_to_json(path)
-
-    linker_2 = DuckDBLinker(df, connection=":memory:")
-    linker_2.load_settings(path)
-    DuckDBLinker(df, settings_dict=path)
+    linker.predict()

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -1,6 +1,6 @@
 import os
 
-from pyspark.sql.functions import array
+import pyspark.sql.functions as f
 from pyspark.sql.types import StringType, StructField, StructType
 
 import splink.spark.spark_comparison_level_library as cll
@@ -13,7 +13,7 @@ from .linker_utils import _test_table_registration, register_roc_data
 
 def test_full_example_spark(df_spark, tmp_path):
     # Convert a column to an array to enable testing intersection
-    df_spark = df_spark.withColumn("email", array("email"))
+    df_spark = df_spark.withColumn("email", f.array("email"))
     settings_dict = get_settings_dict()
 
     # Only needed because the value can be overwritten by other tests
@@ -128,3 +128,25 @@ def test_full_example_spark(df_spark, tmp_path):
         break_lineage_method="checkpoint",
         num_partitions_on_repartition=2,
     )
+
+
+def test_link_only(df_spark):
+    settings = get_settings_dict()
+    settings["link_type"] = "link_only"
+    settings["source_dataset_column_name"] = "source_dataset"
+
+    df_spark_a = df_spark.withColumn("source_dataset", f.lit("my_left_ds"))
+    df_spark_b = df_spark.withColumn("source_dataset", f.lit("my_right_ds"))
+
+
+    linker = SparkLinker(
+        [df_spark_a, df_spark_b],
+        settings,
+        break_lineage_method="checkpoint",
+        num_partitions_on_repartition=2,
+    )
+    df_predict = linker.predict().as_pandas_dataframe()
+
+    assert len(df_predict) == 7257
+    assert set(df_predict.source_dataset_l.values) == {"my_left_ds"}
+    assert set(df_predict.source_dataset_r.values) == {"my_right_ds"}

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -138,7 +138,6 @@ def test_link_only(df_spark):
     df_spark_a = df_spark.withColumn("source_dataset", f.lit("my_left_ds"))
     df_spark_b = df_spark.withColumn("source_dataset", f.lit("my_right_ds"))
 
-
     linker = SparkLinker(
         [df_spark_a, df_spark_b],
         settings,


### PR DESCRIPTION
### Quick Summary

It looks as if there was a bug in [vertically_concatenate.py](https://github.com/moj-analytical-services/splink/compare/fix_source_dataset_bug?expand=1#diff-a8c6894424969f52697767b9a5d1e6902a5d5882a3351e14eb802b75c933ce27) that was causing two `source_dataset` columns to be produced in various steps, where `source_dataset` was outlined in the settings object.

This was causing issues in DuckDB, where I couldn't use a vertically concatenated dataframe with a `source_dataset` column for a link job -- i.e. a single df with `source_dataset` which outlines which dataset a record belongs to.

But, more troubling than this, it appears that this was just outright breaking link only jobs in spark. I'll post some code that breaks below.

Essentially though, it was causing this behaviour in `concat_with_tf`, which was causing spark to throw a wobbly.

![Screenshot 2023-04-18 at 22 25 58](https://user-images.githubusercontent.com/45356472/232909463-f0a00148-2f16-4547-8451-2d87b005e928.png)

This code fixes the issue by migrating `_source_dataset_column_name` to the linker class and checking whether the column already exists within the user's database.

<hr>

### Internals and why I opted to go down this path:
To start - these changes don't adjust the underlying SQL/logic that's being used wherever I've replaced `linker._settings_obj_source_dataset_column_name` with `linker._source_dataset_column_name`.

The workflow is still:
1. Use the alias table name provided by the user to create a new column in `concat_with_tf`
2. Use this to filter where required

The change is in the naming convention used and what we output in `predict()`. 

Now if the users provides a dataframe that already contains `source_dataset`, splink will adjust step 1 to use the alias `__splink_source_dataset`. This will then be scrapped when it's no longer needed and the user will be left with their original `source_dataset` in the output.

If the users provides a df without `source_dataset`, splink won't fall over and will just call step 1 `source_dataset`.

**Why this way?**
1. It doesn't fall over in the no `source_dataset`case
2. It means we don't need any over the top adjustments to the splink internals
3. It means that even if the users hasn't supplied a truly unique `source_dataset` column, the link job will still run. 

On point 3 - We may want to check the source dataset column in preprocessing and establish if it's valid. 