### PR TITLE
Write splinkdf to csv parquet

### DIFF
--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -67,7 +67,9 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
             )
 
         # create the directories recursively if they don't exist
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        path = os.path.dirname(filepath)
+        if path:
+            os.makedirs(path, exist_ok=True)
 
         sql = f"COPY {self.physical_name} TO '{filepath}' (FORMAT PARQUET);"
         self.linker._con.query(sql)
@@ -84,7 +86,9 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
             )
 
         # create the directories recursively if they don't exist
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        path = os.path.dirname(filepath)
+        if path:
+            os.makedirs(path, exist_ok=True)
 
         sql = f"COPY {self.physical_name} TO '{filepath}' (HEADER, DELIMITER ',');"
         self.linker._con.query(sql)

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from tempfile import TemporaryDirectory
 
 import duckdb
@@ -53,6 +54,40 @@ class DuckDBLinkerDataFrame(SplinkDataFrame):
             sql += f" limit {limit}"
 
         return self.linker._con.query(sql).to_df()
+
+    def to_parquet(self, filepath, overwrite=False):
+        if not overwrite:
+            self.check_file_exists(filepath)
+
+        if not filepath.endswith(".parquet"):
+            raise SyntaxError(
+                f"The filepath you've entered to '{filepath}' is "
+                "not a parquet file. Please ensure that the filepath "
+                "ends with `.parquet` before retrying."
+            )
+
+        # create the directories recursively if they don't exist
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+        sql = f"COPY {self.physical_name} TO '{filepath}' (FORMAT PARQUET);"
+        self.linker._con.query(sql)
+
+    def to_csv(self, filepath, overwrite=False):
+        if not overwrite:
+            self.check_file_exists(filepath)
+
+        if not filepath.endswith(".csv"):
+            raise SyntaxError(
+                f"The filepath you've entered '{filepath}' is "
+                "not a csv file. Please ensure that the filepath "
+                "ends with `.csv` before retrying."
+            )
+
+        # create the directories recursively if they don't exist
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+        sql = f"COPY {self.physical_name} TO '{filepath}' (HEADER, DELIMITER ',');"
+        self.linker._con.query(sql)
 
 
 class DuckDBLinker(Linker):

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -898,7 +898,7 @@ class Linker:
         if not isinstance(settings_dict, dict):
             p = Path(settings_dict)
             if not p.is_file():  # check if it's a valid file/filepath
-                raise ValueError(
+                raise FileNotFoundError(
                     "The filepath you have provided is either not a valid file "
                     "or doesn't exist along the path provided."
                 )

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -73,12 +73,9 @@ class SparkDataframe(SplinkDataFrame):
         if not overwrite:
             self.check_file_exists(filepath)
 
-        # We can also use:
-        # spark_df.write.format("csv").option(
-        #     "header", "true").save(filepath)
-        # but this partitions the data and means pandas can't load it in
-
-        self.as_pandas_dataframe().to_csv(filepath, index=False)
+        spark_df = self.as_spark_dataframe()
+        spark_df.write.format("csv").option(
+            "header", "true").save(filepath)
 
 
 class SparkLinker(Linker):

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -74,8 +74,7 @@ class SparkDataframe(SplinkDataFrame):
             self.check_file_exists(filepath)
 
         spark_df = self.as_spark_dataframe()
-        spark_df.write.format("csv").option(
-            "header", "true").save(filepath)
+        spark_df.write.format("csv").option("header", "true").save(filepath)
 
 
 class SparkLinker(Linker):

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -62,6 +62,24 @@ class SparkDataframe(SplinkDataFrame):
     def as_spark_dataframe(self):
         return self.linker.spark.table(self.physical_name)
 
+    def to_parquet(self, filepath, overwrite=False):
+        if not overwrite:
+            self.check_file_exists(filepath)
+
+        spark_df = self.as_spark_dataframe()
+        spark_df.write.mode("overwrite").format("parquet").save(filepath)
+
+    def to_csv(self, filepath, overwrite=False):
+        if not overwrite:
+            self.check_file_exists(filepath)
+
+        # We can also use:
+        # spark_df.write.format("csv").option(
+        #     "header", "true").save(filepath)
+        # but this partitions the data and means pandas can't load it in
+
+        self.as_pandas_dataframe().to_csv(filepath, index=False)
+
 
 class SparkLinker(Linker):
     def __init__(

--- a/splink/splink_dataframe.py
+++ b/splink/splink_dataframe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
@@ -90,3 +91,18 @@ class SplinkDataFrame:
             f"{self.templated_name}"
         )
         p.text(msg)
+
+    def to_parquet(self, filepath, overwrite=False):
+        raise NotImplementedError("`to_parquet` not implemented for this linker")
+
+    def to_csv(self, filepath, overwrite=False):
+        raise NotImplementedError("`to_csv` not implemented for this linker")
+
+    def check_file_exists(self, filepath):
+        p = Path(filepath)
+        if p.exists():
+            raise FileExistsError(
+                "The filepath you've supplied already exists. Please use "
+                "either `overwrite = True` or manually move or delete the "
+                "existing file."
+            )

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 
 import pandas as pd
@@ -85,9 +86,12 @@ def register_roc_data(linker):
     linker.register_table(df_labels, "labels")
 
 
-def _test_write_functionality(linker):
+def _test_write_functionality(linker, read_csv_func):
 
     root = "__splink_tests"
+    # delete the folder and its contents
+    if os.path.exists(root):
+        shutil.rmtree(root)
 
     parquet_f = f"{root}/tmp_files/test.parquet"
     linker.predict().to_parquet(parquet_f)
@@ -98,7 +102,7 @@ def _test_write_functionality(linker):
 
     csv_f = f"{root}/tmp_files/test.csv"
     linker.predict().to_csv(csv_f)
-    assert len(pd.read_csv(csv_f)) == 3167
+    assert len(read_csv_func(csv_f)) == 3167
     # Duplicate table name (check for error)
     with pytest.raises(FileExistsError):
         linker.predict().to_csv(csv_f)

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pandas as pd
 import pytest
 
@@ -81,3 +83,25 @@ def register_roc_data(linker):
     )
 
     linker.register_table(df_labels, "labels")
+
+
+def _test_write_functionality(linker):
+
+    root = "__splink_tests"
+
+    parquet_f = f"{root}/tmp_files/test.parquet"
+    linker.predict().to_parquet(parquet_f)
+    assert len(pd.read_parquet(parquet_f)) == 3167
+    # Duplicate table name (check for error)
+    with pytest.raises(FileExistsError):
+        linker.predict().to_parquet(parquet_f)
+
+    csv_f = f"{root}/tmp_files/test.csv"
+    linker.predict().to_csv(csv_f)
+    assert len(pd.read_csv(csv_f)) == 3167
+    # Duplicate table name (check for error)
+    with pytest.raises(FileExistsError):
+        linker.predict().to_csv(csv_f)
+
+    # delete the folder and its contents
+    shutil.rmtree(root)

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -11,7 +11,11 @@ import splink.duckdb.duckdb_comparison_library as cl
 from splink.duckdb.duckdb_linker import DuckDBLinker
 
 from .basic_settings import get_settings_dict, name_comparison
-from .linker_utils import _test_table_registration, register_roc_data
+from .linker_utils import (
+    _test_table_registration,
+    _test_write_functionality,
+    register_roc_data,
+)
 
 
 def test_full_example_duckdb(tmp_path):
@@ -111,6 +115,9 @@ def test_full_example_duckdb(tmp_path):
     linker_2.load_settings(path)
     linker_2.load_settings_from_json(path)
     DuckDBLinker(df, settings_dict=path)
+
+    # Test that writing to files works as expected
+    _test_write_functionality(linker_2)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -117,7 +117,7 @@ def test_full_example_duckdb(tmp_path):
     DuckDBLinker(df, settings_dict=path)
 
     # Test that writing to files works as expected
-    _test_write_functionality(linker_2)
+    _test_write_functionality(linker_2, pd.read_csv)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -8,7 +8,11 @@ import splink.spark.spark_comparison_library as cl
 from splink.spark.spark_linker import SparkLinker
 
 from .basic_settings import get_settings_dict, name_comparison
-from .linker_utils import _test_table_registration, register_roc_data
+from .linker_utils import (
+    _test_table_registration,
+    _test_write_functionality,
+    register_roc_data,
+)
 
 
 def test_full_example_spark(df_spark, tmp_path):
@@ -128,3 +132,6 @@ def test_full_example_spark(df_spark, tmp_path):
         break_lineage_method="checkpoint",
         num_partitions_on_repartition=2,
     )
+
+    # Test that writing to files works as expected
+    _test_write_functionality(linker)

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -9,7 +9,6 @@ from splink.spark.spark_linker import SparkLinker
 
 from .basic_settings import get_settings_dict, name_comparison
 from .linker_utils import (
-    _test_table_registration,
     _test_write_functionality,
     register_roc_data,
 )
@@ -20,7 +19,8 @@ def test_full_example_spark(df_spark, tmp_path):
     # accept arrays as inputs, which we are adding to df_spark below
     linker = SparkLinker(df_spark, get_settings_dict())
     # Test that writing to files works as expected
-    spark_csv_read = lambda x: linker.spark.read.csv(x, header=True).toPandas()
+    def spark_csv_read(x):
+        return linker.spark.read.csv(x, header=True).toPandas()
     _test_write_functionality(linker, spark_csv_read)
 
     # Convert a column to an array to enable testing intersection
@@ -102,10 +102,7 @@ def test_full_example_spark(df_spark, tmp_path):
     # _test_write_functionality(linker, spark_csv_read)
 
     # Check spark tables are being registered correctly
-    data = [
-        ("Thomas", "FakeName"),
-    ]
-    schema = StructType(
+    StructType(
         [
             StructField("firstname", StringType(), True),
             StructField("lastname", StringType(), True),

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -90,6 +90,8 @@ def test_full_example_spark(df_spark, tmp_path):
     )
 
     linker.unlinkables_chart(source_dataset="Testing")
+    # Test that writing to files works as expected
+    _test_write_functionality(linker)
 
     # Check spark tables are being registered correctly
     data = [
@@ -132,6 +134,3 @@ def test_full_example_spark(df_spark, tmp_path):
         break_lineage_method="checkpoint",
         num_partitions_on_repartition=2,
     )
-
-    # Test that writing to files works as expected
-    _test_write_functionality(linker)

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -21,6 +21,7 @@ def test_full_example_spark(df_spark, tmp_path):
     # Test that writing to files works as expected
     def spark_csv_read(x):
         return linker.spark.read.csv(x, header=True).toPandas()
+
     _test_write_functionality(linker, spark_csv_read)
 
     # Convert a column to an array to enable testing intersection


### PR DESCRIPTION
A nice quick one for you both.

This adds the ability to write SplinkDataFrames directly to csv and parquet. This should simplify some of the code in our splink3 workflows.

I've left my commented notes in for spark's `to_csv` deliberately, but can remove them if you think they're not useful.