### PR TITLE
1175 deterministric clusters

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -68,7 +68,7 @@ def _sql_gen_where_condition(link_type, unique_id_cols):
 
 
 # flake8: noqa: C901
-def block_using_rules_sql(linker: Linker):
+def block_using_rules_sql(linker: Linker, deterministic_link=False):
     """Use the blocking rules specified in the linker's settings object to
     generate a SQL statement that will create pairwise record comparions
     according to the blocking rule(s).
@@ -146,6 +146,13 @@ def block_using_rules_sql(linker: Linker):
     if not blocking_rules:
         blocking_rules = [BlockingRule("1=1")]
 
+    # For Blocking rules for deterministic rules, add a match probability 
+    # column with all probabilities set to 1.
+    if deterministic_link:
+        probability = ", 1.00 as match_probability"
+    else:
+        probability= ""
+
     sqls = []
     for br in blocking_rules:
         # Apply our salted rules to resolve skew issues. If no salt was
@@ -160,6 +167,7 @@ def block_using_rules_sql(linker: Linker):
             select
             {sql_select_expr}
             , '{br.match_key}' as match_key
+            {probability}
             from {linker._input_tablename_l} as l
             inner join {linker._input_tablename_r} as r
             on

--- a/splink/connected_components.py
+++ b/splink/connected_components.py
@@ -310,7 +310,8 @@ def _cc_create_unique_id_cols(
         match_probability_threshold (int):
             The minimum match probability threshold for a link to be
             considered a match. This reduces the number of unique IDs created
-            and connected in our algorithm.
+            and connected in our algorithm. Set to None for deterministic
+            linkages.
 
     Returns:
         SplinkDataFrame: A dataframe containing two sets of unique IDs,
@@ -323,13 +324,18 @@ def _cc_create_unique_id_cols(
     uid_concat_edges_r = _composite_unique_id_from_edges_sql(uid_cols, "r")
     uid_concat_edges = _composite_unique_id_from_edges_sql(uid_cols, None)
 
+    if match_probability_threshold:
+        match_probability_condition = f"where match_probability >= {match_probability_threshold}"
+    else:
+        match_probability_condition = ""
+
     # Generate new unique IDs for our linked dataframes.
     sql = f"""
         select
         {uid_concat_edges_l} as unique_id_l,
         {uid_concat_edges_r} as unique_id_r
         from {df_predict}
-        where match_probability >= {match_probability_threshold}
+        {match_probability_condition}
 
         UNION
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1066,7 +1066,7 @@ class Linker:
                 SplinkDataFrame allow you to access the underlying data.
         """
         concat_with_tf = self._initialise_df_concat_with_tf()
-        sql = block_using_rules_sql(self)
+        sql = block_using_rules_sql(self, deterministic_link=True)
         self._enqueue_sql(sql, "__splink__df_blocked")
         return self._execute_sql_pipeline([concat_with_tf])
 
@@ -1669,7 +1669,8 @@ class Linker:
             threshold_match_probability (float): Filter the pairwise match predictions
                 to include only pairwise comparisons with a match_probability above this
                 threshold. This dataframe is then fed into the clustering
-                algorithm.
+                algorithm. 
+                For deterministic linkage, set to 1.
             pairwise_formatting (bool): Whether to output the pairwise match predictions
                 from linker.predict() with cluster IDs.
                 If this is set to false, the output will be a list of all IDs, clustered


### PR DESCRIPTION
Closes #1175 

Generates a match probability column of value 1 for a deterministic linkage. Have not currently implemented making `threshold_match_probability` an optional argument. Have just put in the docs to set it to 1 for deterministic linkage for now.

Also, linked to #1184 with a [PR already sitting in splink demos](https://github.com/moj-analytical-services/splink_demos/pull/88) for when this is merged.