### PR TITLE
Adjust table registration

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -324,6 +324,10 @@ class AthenaLinker(Linker):
             else:
                 self._delete_table_from_database(table_name)
 
+        self._table_registration(input, table_name)
+        return self._table_to_splink_dataframe(table_name, table_name)
+
+    def _table_registration(self, input, table_name):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
         elif isinstance(input, list):
@@ -331,8 +335,6 @@ class AthenaLinker(Linker):
 
         # Errors if an invalid data type is passed
         self.register_data_on_s3(input, table_name)
-
-        return self._table_to_splink_dataframe(table_name, table_name)
 
     def _random_sample_sql(self, proportion, sample_size, seed=None):
         if proportion == 1.0:

--- a/splink/duckdb/duckdb_linker.py
+++ b/splink/duckdb/duckdb_linker.py
@@ -196,6 +196,10 @@ class DuckDBLinker(Linker):
             else:
                 self._con.unregister(table_name)
 
+        self._table_registration(input, table_name)
+        return self._table_to_splink_dataframe(table_name, table_name)
+
+    def _table_registration(self, input, table_name):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
         elif isinstance(input, list):
@@ -204,7 +208,6 @@ class DuckDBLinker(Linker):
         # Registration errors will automatically
         # occur if an invalid data type is passed as an argument
         self._con.register(table_name, input)
-        return self._table_to_splink_dataframe(table_name, table_name)
 
     def _random_sample_sql(self, proportion, sample_size, seed=None):
         if proportion == 1.0:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -380,9 +380,7 @@ class Linker:
         for alias in input_aliases:
             # Check if alias is a string (indicating a table name) and that it is not
             # a file path.
-            if not isinstance(alias, str) or re.match(
-                pattern=r".*", string=alias
-            ):
+            if not isinstance(alias, str) or re.match(pattern=r".*", string=alias):
                 continue
             exists = self._table_exists_in_database(alias)
             if exists:
@@ -646,14 +644,14 @@ class Linker:
             input: The data you wish to register. This can be either a dictionary,
                 pandas dataframe, pyarrow table or a spark dataframe.
             table_name (str): The name you wish to assign to the table.
-            overwrite (bool): Overwrite the table in the underlying database if it
-                exists
 
         Returns:
             None
         """
 
-        raise NotImplementedError(f"register_table not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"_table_registration not implemented for {type(self)}"
+        )
 
     def query_sql(self, sql, output_type="pandas"):
         """

--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -440,6 +440,10 @@ class SparkLinker(Linker):
                     "Please use the 'overwrite' argument if you wish to overwrite"
                 )
 
+        self._table_registration(input, table_name)
+        return self._table_to_splink_dataframe(table_name, table_name)
+
+    def _table_registration(self, input, table_name):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
             input = self.spark.createDataFrame(input)
@@ -450,7 +454,6 @@ class SparkLinker(Linker):
             input = self.spark.createDataFrame(input)
 
         input.createOrReplaceTempView(table_name)
-        return self._table_to_splink_dataframe(table_name, table_name)
 
     def _random_sample_sql(self, proportion, sample_size, seed=None):
         if proportion == 1.0:

--- a/splink/sqlite/sqlite_linker.py
+++ b/splink/sqlite/sqlite_linker.py
@@ -147,6 +147,10 @@ class SQLiteLinker(Linker):
             else:
                 self._delete_table_from_database(table_name)
 
+        self._table_registration(input, table_name)
+        return self._table_to_splink_dataframe(table_name, table_name)
+
+    def _table_registration(self, input, table_name):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
         elif isinstance(input, list):
@@ -154,7 +158,6 @@ class SQLiteLinker(Linker):
 
         # Will error if an invalid data type is passed
         input.to_sql(table_name, self.con, index=False)
-        return self._table_to_splink_dataframe(table_name, table_name)
 
     def _random_sample_sql(self, proportion, sample_size, seed=None):
         if proportion == 1.0:


### PR DESCRIPTION
This is a quick PR to clean up the table registration code for the input tables. The idea behind this is to tell the user directly that certain input tables already exist on the database, rather than giving them the `Overwrite` warning, present within `register_table`.

This is only really useful for persistent databases (spark on databricks and athena), where the input tables may already exist within the raw database.
