### PR TITLE
Issue 1227 - Allow materialisation of df_representatives with no _ suffix

### DIFF
--- a/splink/spark/spark_linker.py
+++ b/splink/spark/spark_linker.py
@@ -343,7 +343,7 @@ class SparkLinker(Linker):
             r"__splink__df_concat_with_tf",
             r"__splink__df_predict",
             r"__splink__df_tf_.+",
-            r"__splink__df_representatives.+",
+            r"__splink__df_representatives.*",
             r"__splink__df_neighbours",
             r"__splink__df_connected_components_df",
         ]


### PR DESCRIPTION
Bug reported here:
https://github.com/moj-analytical-services/splink/issues/1227

The final table is called (templated name):
`__splink__df_representatives`
whereas intermedaite tables are called e.g.
`__splink__df_representatives_1`
`__splink__df_representatives_2` etc.

This modifies the regex so `__splink__df_representatives` is also materialised