### PR TITLE
Postcode comparison template

### DIFF
--- a/splink/athena/athena_linker.py
+++ b/splink/athena/athena_linker.py
@@ -399,7 +399,6 @@ class AthenaLinker(Linker):
         self.ctas_query_info.pop(physical_name)
 
     def _delete_table_from_database(self, name):
-
         if name in self.ctas_query_info:
             # Use ctas metadata to delete backing data
             self._delete_table_from_s3(name)

--- a/splink/athena/athena_utils.py
+++ b/splink/athena/athena_utils.py
@@ -16,7 +16,6 @@ def athena_warning_text(database_bucket_txt, do_does_grammar):
 
 
 def _verify_athena_inputs(database, bucket, boto3_session):
-
     errors = []
 
     if (

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -12,6 +12,7 @@ from .comparison_library_utils import (
     distance_threshold_comparison_levels,
     distance_threshold_description,
 )
+from .input_column import InputColumn
 from .misc import ensure_is_iterable
 
 logger = logging.getLogger(__name__)
@@ -553,3 +554,194 @@ class NameComparisonBase(Comparison):
     @property
     def _is_distance_subclass(self):
         return False
+
+
+class PostcodeComparisonBase(Comparison):
+    def __init__(
+        self,
+        col_name: str,
+        valid_string_regex: str = None,
+        include_full_match_level=True,
+        include_sector_match_level=True,
+        include_district_match_level=True,
+        include_area_match_level=True,
+        include_distance_in_km_level=False,
+        lat_col: str = None,
+        long_col: str = None,
+        km_threshold: int | float = None,
+        term_frequency_adjustments_full=False,
+        m_probability_full_match=None,
+        m_probability_sector_match=None,
+        m_probability_district_match=None,
+        m_probability_area_match=None,
+        m_probability_distance_in_km=None,
+        m_probability_else=None,
+    ) -> Comparison:
+        """A wrapper to generate a comparison for a poscode column 'col_name'
+            with preselected defaults.
+
+        The default arguments will give a comparison with levels:\n
+        - Exact match on full postcode\n
+        - Exact match on sector\n
+        - Exact match on district\n
+        - Exact match on area\n
+        - All other comparisons
+
+        Args:
+            col_name (str): The name of the column to compare.
+            valid_string_regex (str): regular expression pattern that if not
+                matched will result in column being treated as a null.
+            include_full_match_level (bool, optional): If True, include an exact
+                match on full postcode level. Defaults to True.
+            include_sector_match_level (bool, optional): If True, include an exact
+                match on sector level. Defaults to True.
+            include_district_match_level (bool, optional): If True, include an exact
+                match on district level. Defaults to True.
+            include_area_match_level (bool, optional): If True, include an exact
+                match on area level. Defaults to True.
+            include_distance_in_km_level (bool, optional): If True, include a
+                comparison of distance between postcodes as measured in kilometers.
+                Defaults to False.
+            lat_col (str): The name of a latitude column or the respective array
+                or struct column column containing the information, plus an index.
+                For example: long_lat['lat'] or long_lat[0].
+            long_col (str): The name of a longitudinal column or the respective array
+                or struct column column containing the information, plus an index.
+                For example: long_lat['long'] or long_lat[1].
+            km_threshold (int): The total distance in kilometers to evaluate the
+                distance_in_km_level comparison against.
+            term_frequency_adjustments_full (bool, optional): If True, apply
+                term frequency adjustments to the full postcode exact match level.
+                Defaults to False.
+            m_probability_full_match (_type_, optional): Starting value for
+                full postcode match m probability. Defaults to None.
+            m_probability_sector_match (_type_, optional): Starting value for
+                sector match m probability. Defaults to None.
+            m_probability_district_match (_type_, optional): Starting value for
+                district match m probability. Defaults to None.
+            m_probability_area_match (_type_, optional): Starting value for
+                area match m probability. Defaults to None.
+            m_probability_distance_in_km (_type_, optional): Starting value for
+                'distance in km' level m probability. Defaults to None.
+            m_probability_else (_type_, optional): Starting value for
+                else level m probability. Defaults to None.
+
+        Examples:
+            === "DuckDB"
+                Basic Postcode Comparison
+                ``` python
+                import splink.duckdb.duckdb_comparison_template_library as ctl
+                ctl.postcode_comparison("postcode")
+                ```
+                Bespoke Postcode Comparison
+                ``` python
+                import splink.duckdb.duckdb_comparison_template_library as ctl
+                ctl.postcode_comparison("postcode",
+                                    valid_regex_string = "^[A-Z]{1,2}[0-9]",
+                                    include_distance_in_km_level=True,
+                                    lat_col="lat",
+                                    long_col="long",
+                                    km_threshold=5
+                                    )
+                ```
+            === "Spark"
+                Basic Postcode Comparison
+                ``` python
+                import splink.spark.spark_comparison_template_library as ctl
+                ctl.postcode_comparison("postcode")
+                ```
+                Bespoke Postcode Comparison
+                ``` python
+                import splink.spark.spark_comparison_template_library as ctl
+                ctl.postcode_comparison("postcode",
+                                    valid_regex_string = "^[A-Z]{1,2}[0-9]",
+                                    include_distance_in_km_level=True,
+                                    lat_col="lat",
+                                    long_col="long",
+                                    km_threshold=5
+                                    )
+                ```
+
+        Returns:
+            Comparison: A comparison that can be inclued in the Splink settings
+                dictionary.
+        """
+
+        postcode_col = InputColumn(col_name, sql_dialect=self._sql_dialect)
+        postcode_col_l, postcode_col_r = postcode_col.names_l_r()
+
+        comparison_levels = []
+        comparison_levels.append(self._null_level(col_name, valid_string_regex))
+
+        if include_full_match_level:
+            comparison_level = self._exact_match_level(
+                col_name,
+                regex_extract=None,
+                term_frequency_adjustments=term_frequency_adjustments_full,
+                m_probability=m_probability_full_match,
+                include_colname_in_charts_label=True,
+            )
+            comparison_levels.append(comparison_level)
+
+        if include_sector_match_level:
+            comparison_level = self._exact_match_level(
+                col_name,
+                regex_extract="^[A-Z]{1,2}[0-9][A-Z0-9]? [0-9]",
+                m_probability=m_probability_sector_match,
+            )
+            comparison_levels.append(comparison_level)
+
+        if include_district_match_level:
+            comparison_level = self._exact_match_level(
+                col_name,
+                regex_extract="^[A-Z]{1,2}[0-9][A-Z0-9]?",
+                m_probability=m_probability_district_match,
+            )
+            comparison_levels.append(comparison_level)
+
+        if include_area_match_level:
+            comparison_level = self._exact_match_level(
+                col_name,
+                regex_extract="^[A-Z]{1,2}",
+                m_probability=m_probability_area_match,
+            )
+            comparison_levels.append(comparison_level)
+
+        if include_distance_in_km_level:
+            comparison_level = self._distance_in_km_level(
+                lat_col,
+                long_col,
+                km_threshold,
+                m_probability=m_probability_distance_in_km,
+            )
+            comparison_levels.append(comparison_level)
+
+        comparison_levels.append(
+            self._else_level(m_probability=m_probability_else),
+        )
+
+        # Construct Description
+        comparison_desc = ""
+        if include_full_match_level:
+            comparison_desc += "Exact match on full postcode vs. "
+
+        if include_sector_match_level:
+            comparison_desc += "exact match on sector vs. "
+
+        if include_district_match_level:
+            comparison_desc += "exact match on district vs. "
+
+        if include_area_match_level:
+            comparison_desc += "exact match on area vs. "
+
+        if include_distance_in_km_level:
+            comparison_desc += f"distance less than {km_threshold}km vs. "
+
+        comparison_desc += "all other comparisons"
+
+        comparison_dict = {
+            "output_column_name": col_name,
+            "comparison_description": comparison_desc,
+            "comparison_levels": comparison_levels,
+        }
+        super().__init__(comparison_dict)

--- a/splink/duckdb/duckdb_comparison_template_library.py
+++ b/splink/duckdb/duckdb_comparison_template_library.py
@@ -1,6 +1,7 @@
 from ..comparison_template_library import (
     DateComparisonBase,
     NameComparisonBase,
+    PostcodeComparisonBase,
 )
 from .duckdb_comparison_level_library import distance_function_level
 from .duckdb_comparison_library import DuckDBComparisonProperties
@@ -16,3 +17,7 @@ class name_comparison(DuckDBComparisonProperties, NameComparisonBase):
     @property
     def _distance_level(self):
         return distance_function_level
+
+
+class postcode_comparison(DuckDBComparisonProperties, PostcodeComparisonBase):
+    pass

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -343,7 +343,6 @@ class Linker:
 
     @property
     def _verify_link_only_job(self):
-
         cache = self._intermediate_table_cache
         if "__splink__df_concat_with_tf" not in cache:
             return

--- a/splink/spark/spark_comparison_template_library.py
+++ b/splink/spark/spark_comparison_template_library.py
@@ -1,6 +1,7 @@
 from ..comparison_template_library import (
     DateComparisonBase,
     NameComparisonBase,
+    PostcodeComparisonBase,
 )
 from .spark_comparison_level_library import distance_function_level
 from .spark_comparison_library import SparkComparisonProperties
@@ -16,3 +17,7 @@ class name_comparison(SparkComparisonProperties, NameComparisonBase):
     @property
     def _distance_level(self):
         return distance_function_level
+
+
+class postcode_comparison(SparkComparisonProperties, PostcodeComparisonBase):
+    pass

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -294,3 +294,103 @@ def test_name_comparison_levels(spark, ctl, Linker):
                 ]["gamma_custom_first_name_first_name_metaphone"].values[0]
                 == gamma
             )
+
+
+# postcode_comparison
+
+
+@pytest.mark.parametrize(
+    ("ctl", "Linker"),
+    [
+        pytest.param(ctld, DuckDBLinker, id="DuckDB Postcode Comparison Template Test"),
+        pytest.param(ctls, SparkLinker, id="Spark Postcode Comparison Template Test"),
+    ],
+)
+def test_postcode_comparison_levels(spark, ctl, Linker):
+    df = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "first_name": "Andy",
+                "postcode": "SE1P 0NY",
+                "lat": 53.95,
+                "long": -1.08,
+            },
+            {
+                "unique_id": 2,
+                "first_name": "Andy's twin",
+                "postcode": "SE1P 0NY",
+                "lat": 53.95,
+                "long": -1.08,
+            },
+            {
+                "unique_id": 3,
+                "first_name": "Tom",
+                "postcode": "SE1P 0PZ",
+                "lat": 53.95,
+                "long": -1.08,
+            },
+            {
+                "unique_id": 4,
+                "first_name": "Robin",
+                "postcode": "SE1P 4UY",
+                "lat": 53.95,
+                "long": -1.08,
+            },
+            {
+                "unique_id": 5,
+                "first_name": "Sam",
+                "postcode": "SE2 7TR",
+                "lat": 53.95,
+                "long": -1.08,
+            },
+            {
+                "unique_id": 6,
+                "first_name": "Zoe",
+                "postcode": "SW15 8UY",
+                "lat": 53.95,
+                "long": -1.08,
+            },
+        ]
+    )
+
+    # Generate our various settings objs
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            ctl.postcode_comparison(
+                "postcode",
+                include_distance_in_km_level=True,
+                lat_col="lat",
+                long_col="long",
+                km_threshold=5,
+            )
+        ],
+    }
+
+    if Linker == SparkLinker:
+        df = spark.createDataFrame(df)
+        df.persist()
+    linker = Linker(df, settings)
+    linker_output = linker.predict().as_pandas_dataframe()
+
+    # Check individual IDs are assigned to the correct gamma values
+    # Dict key: {gamma_level: tuple of ID pairs}
+    size_gamma_lookup = {
+        5: [(1, 2)],
+        4: [(1, 3), (2, 3)],
+        3: [(1, 4), (2, 4), (3, 4)],
+        2: [(1, 5), (2, 5), (3, 5), (4, 5)],
+        1: [(1, 6), (2, 6), (3, 6), (4, 6), (5, 6)],
+    }
+
+    for gamma, id_pairs in size_gamma_lookup.items():
+        for left, right in id_pairs:
+            print(f"Checking IDs: {left}, {right}")
+            assert (
+                linker_output.loc[
+                    (linker_output.unique_id_l == left)
+                    & (linker_output.unique_id_r == right)
+                ]["gamma_postcode"].values[0]
+                == gamma
+            )


### PR DESCRIPTION
Addresses issue #215

Comparison template for postcode column. The default arguments will give a comparison with levels:
        - Exact match on full postcode
        - Exact match on sector
        - Exact match on district
        - Exact match on area
        - All other comparisons

with an optional 'distance in km' comparison level