### PR TITLE
pretty print erroneous sql

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -599,10 +599,13 @@ class Linker:
         try:
             return self._run_sql_execution(final_sql, templated_name, physical_name)
         except Exception as e:
-            final_sql = sqlglot.parse_one(
-                final_sql,
-                read=self._sql_dialect,
-            ).sql(pretty=True)
+            try:
+                final_sql = sqlglot.parse_one(
+                    final_sql,
+                    read=self._sql_dialect,
+                ).sql(pretty=True)
+            except:  # if sqlglot produces any errors, just report the raw SQL
+                pass
 
             raise SplinkException(
                 f"Error executing the following sql for table "

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -5,12 +5,13 @@ import json
 import logging
 import os
 import re
-import sqlglot
 import warnings
 from collections import UserDict
 from copy import copy, deepcopy
 from pathlib import Path
 from statistics import median
+
+import sqlglot
 
 from splink.input_column import InputColumn, remove_quotes_from_identifiers
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import sqlglot
 import warnings
 from collections import UserDict
 from copy import copy, deepcopy
@@ -597,9 +598,14 @@ class Linker:
         try:
             return self._run_sql_execution(final_sql, templated_name, physical_name)
         except Exception as e:
+            final_sql = sqlglot.parse_one(
+                final_sql,
+                read=self._sql_dialect,
+            ).sql(pretty=True)
+
             raise SplinkException(
                 f"Error executing the following sql for table "
-                f"`{templated_name}`({physical_name}):\n{final_sql}"
+                f"`{templated_name}` ({physical_name}):\n{final_sql}"
             ) from e
 
     def register_table(self, input, table_name, overwrite=False):

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -599,12 +599,15 @@ class Linker:
         try:
             return self._run_sql_execution(final_sql, templated_name, physical_name)
         except Exception as e:
+
+            # Parse our SQL through sqlglot to pretty print
             try:
                 final_sql = sqlglot.parse_one(
                     final_sql,
                     read=self._sql_dialect,
                 ).sql(pretty=True)
-            except:  # if sqlglot produces any errors, just report the raw SQL
+                # if sqlglot produces any errors, just report the raw SQL
+            except Exception:
                 pass
 
             raise SplinkException(


### PR DESCRIPTION
Really quick PR that changes:
![Screenshot 2023-05-15 at 15 37 01](https://github.com/moj-analytical-services/splink/assets/45356472/22dba292-ee89-4e20-b949-faceb50a6215)

to:
![Screenshot 2023-05-15 at 15 36 13](https://github.com/moj-analytical-services/splink/assets/45356472/231f86c7-d621-4ae2-84ec-ada1e031d116)

Is there more we can do to give users more informative errors messages?

It might help to look through some of the error messages we've had reported and see if what could be done to improve the user experience here.