### PR TITLE
Use `tmp_path` in deterministic link test

### DIFF
--- a/tests/test_full_example_deterministic_link.py
+++ b/tests/test_full_example_deterministic_link.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas as pd
 import pytest
 
@@ -12,7 +14,7 @@ from splink.spark.spark_linker import SparkLinker
         pytest.param(SparkLinker, id="Spark Deterministic Link Test"),
     ],
 )
-def test_deterministic_link_full_example(spark, Linker):
+def test_deterministic_link_full_example(tmp_path, spark, Linker):
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     settings = {
@@ -44,7 +46,7 @@ def test_deterministic_link_full_example(spark, Linker):
     linker.cluster_studio_dashboard(
         df_predict,
         clusters,
-        "test_cluster_studio.html",
+        out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
         sampling_method="by_cluster_size",
         overwrite=True,
     )


### PR DESCRIPTION
Just a small change - use `tmp_path` in test so that cluster studio file isn't written to directory, where it adds to noise and can be accidentally committed.