### PR TITLE
update linting bash script

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,7 +15,8 @@ while getopts ":f" opt; do
   case $opt in
     f)
       echo "--fix was run for your scripts" >&2
-      ruff --fix . --quiet
+      ruff --fix splink/ --quiet &&\
+      ruff --fix tests/ --quiet &&
       ;;
     \?)
       echo "Invalid option: -$OPTARG. Only -f (fix) is accepted." >&2
@@ -23,4 +24,6 @@ while getopts ":f" opt; do
   esac
 done
 
-ruff --show-source .
+ruff --show-source splink/ &&\
+  ruff --show-source tests/ &&\
+  ruff --show-source benchmarking/


### PR DESCRIPTION
A quick change to the paths in which we point our linter (this time without touching the ruff versioning). 

Supposedly we can add [include](https://beta.ruff.rs/docs/settings/#include) to the pyproject.toml file if we update to the latest version of ruff, but this is refusing to work on my end and updating the shell script is sufficient.