### PR TITLE
Update parameter_estimate_comparisons.json

### DIFF
--- a/splink/files/chart_defs/parameter_estimate_comparisons.json
+++ b/splink/files/chart_defs/parameter_estimate_comparisons.json
@@ -2,14 +2,14 @@
   "$schema": "https://vega.github.io/schema/vega-lite/v5.2.0.json",
   "title": {
     "text": "Comparison of parameter estimates across training sessions",
-    "subtitle": "Use mousewheeel to zoom"
+    "subtitle": "Use mousewheel to zoom"
   },
   "data": {
     "values": []
   },
   "config": {
     "view": { "continuousWidth": 400, "continuousHeight": 300 },
-    "title": { "anchor": "middle" }
+    "title": {"anchor": "middle", "fontSize":18, "subtitleFontSize":14}
   },
 
   "mark": { "type": "point", "filled": false, "opacity": 0.7, "size": 100 },
@@ -22,12 +22,21 @@
       "header": {
         "labelAlign": "left",
         "labelAnchor": "middle",
-        "labelAngle": 0
+        "labelAngle": 0,
+        "labelFontWeight": "bold",
+        "labelFontSize": 12
       },
       "sort": { "field": "comparison_sort_order" },
-      "title": null
+      "title": null,
+      "align": "each"
     },
-    "column": { "type": "nominal", "field": "m_or_u", "title": null },
+    "column": { 
+      "type": "nominal", 
+      "field": "col_header", 
+      "title": null,
+      "align": "each",
+      "header": {"labelFontSize":14, "labelFontWeight":"bold"}
+    },
     "shape": {
       "type": "nominal",
       "field": "estimate_description",
@@ -40,7 +49,28 @@
     ],
     "x": {
       "type": "quantitative",
-      "field": "estimated_probability_as_log_odds"
+      "field": "estimated_probability_as_log_odds",
+      "title": "Estimated probability as log odds",
+      "axis": {
+        "gridColor": {
+          "condition": {
+            "test": "abs(datum.value / 10)  <= 1 & datum.value % 10 === 0",
+            "value": "#aaa"
+          },
+          "value": "#ddd"
+        },
+        "gridDash": {
+          "condition": {"test": "abs(datum.value / 10) == 1", "value": [3]},
+          "value": null
+        },
+        "gridWidth": {
+          "condition": {
+            "test": "abs(datum.value / 10)  <= 1 & datum.value % 10 === 0",
+            "value": 2
+          },
+          "value": 1
+        }
+      }
     },
     "y": {
       "type": "nominal",
@@ -49,6 +79,12 @@
       "sort": { "field": "comparison_vector_value", "order": "descending" }
     }
   },
+  "transform": [
+    {
+      "calculate": "datum.m_or_u + '-probability (as log odds)'", 
+      "as": "col_header"
+    }
+  ],
   "resolve": {
     "scale": {
       "y": "independent"
@@ -58,7 +94,7 @@
     "selection_zoom": {
       "type": "interval",
       "bind": "scales",
-      "encodings": ["x"]
+      "encodings": ["x", "column"]
     }
   }
 }


### PR DESCRIPTION
This keeps irritating me every time I try to use these charts so I've made a few schema-only changes to cover the main points required to fix #1014 

- Descriptive column headers
- Clearer row headers
- Zero line
- Dotted lines to highlight +10/-10 log odds to help gauge scale when axis labels aren't visible
- Independent x scales (and interactivity) for m (left column) and u (right column)
- Properly aligned rows (no big gaps)

## Before
![image](https://github.com/moj-analytical-services/splink/assets/7570107/476eedb2-d6dd-48c4-9433-884b9135c1b7)
## After
![image](https://github.com/moj-analytical-services/splink/assets/7570107/e221366b-ed7b-4710-8125-c6465fa2f860)

