### PR TITLE
Fix altair dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ jsonschema = ">=3.2,<5.0"
 pandas = ">=1.0.0"
 duckdb = ">=0.6.0"
 sqlglot = ">=5.1.0"
-altair = ">=4.2.0"
+altair = ">=4.2.0,<5.0"
 Jinja2 = ">=3.0.3"
 phonetics = "^1.0.5"
 


### PR DESCRIPTION
Ensures altair version 4 is installed rather than version 5 so that charts continue to render correctly.

Closes #1307 

See discussion [here](https://github.com/moj-analytical-services/splink/discussions/1247#discussioncomment-6118402) for report of problem