### PR TITLE
Postgres bug fixes

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1755,7 +1755,7 @@ class Linker:
             uid = ascii_uid(8)
             new_records_tablename = f"__splink__df_new_records_{uid}"
             self.register_table(
-                records_or_tablename, new_records_tablename , overwrite=True
+                records_or_tablename, new_records_tablename, overwrite=True
             )
 
         else:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1753,10 +1753,11 @@ class Linker:
 
         if not isinstance(records_or_tablename, str):
             uid = ascii_uid(8)
-            self.register_table(
-                records_or_tablename, f"__splink__df_new_records_{uid}", overwrite=True
-            )
             new_records_tablename = f"__splink__df_new_records_{uid}"
+            self.register_table(
+                records_or_tablename, new_records_tablename , overwrite=True
+            )
+
         else:
             new_records_tablename = records_or_tablename
 

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -161,7 +161,8 @@ def major_minor_version_greater_equal_than(this_version, base_comparison_version
 
 
 def ascii_uid(len):
-    return "".join(random.choices(string.ascii_letters + string.digits, k=len))
+    # use only lowercase as case-sensitivity is an issue in e.g. postgres
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=len))
 
 
 def find_unique_source_dataset(src_ds):

--- a/splink/postgres/linker.py
+++ b/splink/postgres/linker.py
@@ -224,6 +224,16 @@ class PostgresLinker(Linker):
         """
         self._run_sql_execution(sql)
 
+    def _extend_round_function(self):
+        # extension of round to double
+        sql = """
+        CREATE OR REPLACE FUNCTION round(n float8, dp integer)
+        RETURNS numeric AS $$
+        SELECT round(n::numeric, dp);
+        $$ LANGUAGE SQL IMMUTABLE;
+        """
+        self._run_sql_execution(sql)
+
     def _create_datediff_function(self):
         sql = """
         CREATE OR REPLACE FUNCTION datediff(x date, y date)
@@ -285,6 +295,8 @@ class PostgresLinker(Linker):
         self._create_months_between_function()
         # need for array_intersect levels
         self._create_array_intersect_function()
+        # extension of round to handle doubles - used in unlinkables
+        self._extend_round_function()
 
     def _register_extensions(self):
         sql = """

--- a/splink/postgres/linker.py
+++ b/splink/postgres/linker.py
@@ -72,7 +72,7 @@ class PostgresDataFrame(SplinkDataFrame):
             sql += f" LIMIT {limit}"
         sql += ";"
         res = self.linker._run_sql_execution(sql).mappings().all()
-        return res
+        return [dict(r) for r in res]
 
 
 class PostgresLinker(Linker):

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -124,7 +124,7 @@ def _get_df_top_bottom_n(expressions, limit=20, value_order="desc"):
     from __splink__df_all_column_value_frequencies
     where group_name = '{gn}'
     order by value_count {value_order}
-    limit {limit})
+    limit {limit}) top_bottom_freqs
     """
 
     to_union = [
@@ -172,7 +172,7 @@ def _col_or_expr_frequencies_raw_data_sql(cols_or_exprs, table_name):
         from {table_name}
         where {col_or_expr} is not null
         group by {col_or_expr}
-        order by count(*) desc)
+        order by count(*) desc) column_stats
         """
         sqls.append(sql)
 

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -79,8 +79,7 @@ def test_full_example_postgres(tmp_path, pg_engine):
         out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
     )
 
-    # TODO: fix bug and restore:
-    # linker.unlinkables_chart(source_dataset="Testing")
+    linker.unlinkables_chart(source_dataset="Testing")
 
     _test_table_registration(linker)
 

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -32,15 +32,14 @@ def test_full_example_postgres(tmp_path, pg_engine):
         ]
     )
 
-    # TODO: fix bug and restore:
-    # linker.profile_columns(
-    #     [
-    #         "first_name",
-    #         '"surname"',
-    #         'first_name || "surname"',
-    #         "concat(city, first_name)",
-    #     ]
-    # )
+    linker.profile_columns(
+        [
+            "first_name",
+            '"surname"',
+            'first_name || "surname"',
+            "concat(city, first_name)",
+        ]
+    )
     linker.missingness_chart()
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -83,20 +83,19 @@ def test_full_example_postgres(tmp_path, pg_engine):
 
     _test_table_registration(linker)
 
-    # record = {
-    #     "unique_id": 1,
-    #     "first_name": "John",
-    #     "surname": "Smith",
-    #     "dob": "1971-05-24",
-    #     "city": "London",
-    #     "email": "john@smith.net",
-    #     "group": 10000,
-    # }
+    record = {
+        "unique_id": 1,
+        "first_name": "John",
+        "surname": "Smith",
+        "dob": "1971-05-24",
+        "city": "London",
+        "email": "john@smith.net",
+        "group": 10000,
+    }
 
-    # TODO: fix bug and restore:
-    # linker.find_matches_to_new_records(
-    #     [record], blocking_rules=[], match_weight_threshold=-10000
-    # )
+    linker.find_matches_to_new_records(
+        [record], blocking_rules=[], match_weight_threshold=-10000
+    )
 
     # Test saving and loading
     path = os.path.join(tmp_path, "model.json")

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -102,8 +102,7 @@ def test_u_train_link_only(test_helpers, dialect):
     assert cl_no.u_probability == (denom - 3) / denom
 
 
-# TODO: restore postgres backend once bug fixed
-@mark_with_dialects_excluding("postgres")
+@mark_with_dialects_excluding()
 def test_u_train_link_only_sample(test_helpers, dialect):
     helper = test_helpers[dialect]
     df_l = (


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Close #1327 (`profile_columns`).
Closes #1328 (`unlinkables`).
Closes #1329 (`find_matches_to_new_records`).

Fixes the main remaining linker functionality not covered by #1251.


### Give a brief description for the solution you have provided
* Restored postgres to a u-training test that was fixed by #1312.
* Named subqueries used in `profile_columns`, as postgres doesn't like them unnamed
* explicitly cast record rows to `dict`
* Define a version of `round()` which takes `double precision` arguments - default does not accept this type
* modified `ascii_uid` to not use uppercase characters. This is due to the fact that identifiers in postgres are not case-sensitive (see 4.1.1. [in the postgres docs](https://www.postgresql.org/docs/15/sql-syntax-lexical.html)), and so tables are not correctly looked up without quoting table names

On the latter point I felt that lowercase-only should still be fine for our purposes. If there is disagreement a couple of other options:
* only using lowercase versions in methods where this causes an issue
* quoting table-names in the relevant queries - although this will need some care around backend-compatibility

### PR Checklist

- [NA] Added documentation for changes
- [NA] Added feature to example notebooks at tutorials in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


