### PR TITLE
Sqlite - fix default connect and levenshtein

### DIFF
--- a/docs/topic_guides/backends.md
+++ b/docs/topic_guides/backends.md
@@ -80,3 +80,22 @@ the [comparison library API page](../comparison_library.html) and the [compariso
 
     ```
 
+## Information for specific backends
+
+### SQLite
+
+[**SQLite**](https://www.sqlite.org/index.html) does not have native support for [fuzzy string-matching](./comparators.html) functions.
+However, some are available for Splink users as python [user-defined functions (UDFs)](../dev_guides/udfs.html#sqlite):
+
+* [`levenshtein`](../comparison_level_library.html#splink.comparison_level_library.LevenshteinLevelBase)
+* [`damerau_levenshtein`](../comparison_level_library.html#splink.comparison_level_library.DamerauLevenshteinLevelBase)
+* [`jaro`](../comparison_level_library.html#splink.comparison_level_libraryJaroLevelBase)
+* [`jaro_winkler`](../comparison_level_library.html#splink.comparison_level_library.JaroWinklerLevelBase)
+
+However, there are a couple of points to note:
+
+* These functions are implemented using the [rapidfuzz](https://maxbachmann.github.io/RapidFuzz/) package, which must be installed if you wish to make use of them, via e.g. `pip install rapidfuzz`. If you do not wish to do so you can disable the use of these functions when creating your linker:
+```py
+linker = SQLiteLinker(df, settings, ..., register_udfs=False)
+```
+* As these functions are implemented in python they will be considerably slower than any native-SQL comparisons. If you find that your model-training or predictions are taking a large time to run, you may wish to consider instead switching to DuckDB (or some other backend).

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -332,6 +332,14 @@ class DistanceFunctionLevelBase(ComparisonLevel):
                                             "levenshtein_distance",
                                             2,
                                             False)
+            === "SQLite
+                Apply the `levenshtein` function to a comparison level
+                ``` python
+                import splink.sqlite.comparison_level_library as cll
+                cll.distance_function_level("name",
+                                            "levenshtein",
+                                            2,
+                                            False)
             === "PostgreSQL"
                 Apply the `levenshtein` function to a comparison level
                 ``` python
@@ -466,6 +474,12 @@ class LevenshteinLevelBase(DistanceFunctionLevelBase):
                 ```python
                 import splink.athena.comparison_level_library as cll
                 cll.levenshtein_level("name", 1, regex_extract="^[A-Z]{1,4}")
+            === "SQLite"
+                Comparison level with levenshtein distance score less than (or equal
+                 to) 1
+                ``` python
+                import splink.sqlite.comparison_level_library as cll
+                cll.levenshtein_level("name", 1)
             === "PostgreSQL"
                 Comparison level with levenshtein distance score less than (or equal
                  to) 1
@@ -549,6 +563,12 @@ class DamerauLevenshteinLevelBase(DistanceFunctionLevelBase):
                 ```python
                 import splink.spark.comparison_level_library as cll
                 cll.damerau_levenshtein_level("name", 1, regex_extract="^[A-Z]{1,4}")
+            === "SQLite"
+                Comparison level with damerau-levenshtein distance score less than
+                (or equal to) 1
+                ``` python
+                import splink.sqlite.comparison_level_library as cll
+                cll.damerau_levenshtein_level("name", 1)
                 ```
 
         Returns:
@@ -621,6 +641,12 @@ class JaroLevelBase(DistanceFunctionLevelBase):
                 import splink.spark.comparison_level_library as cll
                 cll.jaro_level("name", 0.9, regex_extract="^[A-Z]{1,4}")
                 ```
+            === "SQLite"
+                Comparison level with jaro score greater than 0.9
+                ``` python
+                import splink.sqlite.comparison_level_library as cll
+                cll.jaro_level("name", 0.9)
+                ```
 
         Returns:
             ComparisonLevel: A comparison level that evaluates the
@@ -690,6 +716,12 @@ class JaroWinklerLevelBase(DistanceFunctionLevelBase):
                 ``` python
                 import splink.spark.comparison_level_library as cll
                 cll.jaro_winkler_level("name", 0.9, regex_extract="^[A-Z]{1,4}")
+                ```
+            === "SQLite"
+                Comparison level with jaro-winkler score greater than 0.9
+                ``` python
+                import splink.sqlite.comparison_level_library as cll
+                cll.jaro_winkler_level("name", 0.9)
                 ```
 
         Returns:

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -231,6 +231,17 @@ class DistanceFunctionAtThresholdsComparisonBase(Comparison):
                                    distance_threshold_or_thresholds = [0.9, 0.7],
                                    regex_extract="^[A-Z]{1,4}
                                    )
+            === "SQLite"
+                Apply the `levenshtein` function in a comparison with
+                levels 1 and 2
+                ``` python
+                import splink.sqlite.comparison_library as cl
+                cl.distance_function_at_thresholds("name",
+                                   distance_function_name = 'levenshtein',
+                                   distance_threshold_or_thresholds = [1, 2],
+                                   higher_is_more_similar = False
+                                   )
+                ```
             === "PostgreSQL"
                 Apply the `levenshtein` function in a comparison with
                 levels 1 and 2
@@ -395,6 +406,13 @@ class LevenshteinAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparis
                 ``` python
                 import splink.athena.comparison_library as cl
                 cl.levenshtein_at_thresholds("first_name", [1,2], regex_extract="^A|B")
+            === "SQLite"
+                Create comparison with levenshtein match levels with distance <=1
+                and <=2
+                ``` python
+                import splink.athena.comparison_library as cl
+                cl.levenshtein_at_thresholds("first_name", [1,2])
+                ```
             === "PostgreSQL"
                 Create comparison with levenshtein match levels with distance <=1
                 and <=2
@@ -477,7 +495,7 @@ class DamerauLevenshteinAtThresholdsComparisonBase(
         Examples:
             === "DuckDB"
                 Create comparison with damerau-levenshtein match levels with
-                distance <= 1
+                distance <= 1, 2
                 ``` python
                 import splink.duckdb.comparison_library as cl
                 cl.damerau_levenshtein_at_thresholds("first_name", [1,2])
@@ -493,19 +511,26 @@ class DamerauLevenshteinAtThresholdsComparisonBase(
                 ```
             === "Spark"
                 Create comparison with damerau-levenshtein match levels with
-                distance <= 1
+                distance <= 1, 2
                 ``` python
                 import splink.spark.comparison_library as cl
                 cl.damerau_levenshtein_at_thresholds("first_name", [1,2])
                 ```
                 Create comparison with damerau-evenshtein match levels with
-                distance <= 1
+                distance <= 1, 2
                 on a substring of name column as determined by a regular expression
                 ``` python
                 import splink.spark.comparison_library as cl
                 cl.damerau_levenshtein_at_thresholds("first_name",
                                                      [1,2],
                                                      regex_extract="^A|B")
+                ```
+            === "SQLite"
+                Create comparison with damerau-levenshtein match levels with
+                distance <= 1, 2
+                ``` python
+                import splink.sqlite.comparison_library as cl
+                cl.damerau_levenshtein_at_thresholds("first_name", [1,2])
                 ```
 
         Returns:
@@ -707,6 +732,13 @@ class JaroAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparisonBase)
                 import splink.spark.comparison_library as cl
                 cl.jaro_at_thresholds("first_name", [0.9, 0.7], regex_extract="^[A-Z]")
                 ```
+            === "SQLite"
+                Create comparison with jaro match levels with similarity score >=0.9
+                and >=0.7
+                ``` python
+                import splink.sqlite.comparison_library as cl
+                cl.jaro_at_thresholds("first_name", [0.9, 0.7])
+                ```
 
         Returns:
             Comparison:
@@ -812,6 +844,13 @@ class JaroWinklerAtThresholdsComparisonBase(DistanceFunctionAtThresholdsComparis
                                               [0.9, 0.7],
                                               regex_extract="^[A-Z]"
                                               )
+                ```
+            === "SQLite"
+                Create comparison with jaro_winkler match levels with similarity
+                score >=0.9 and >=0.7
+                ``` python
+                import splink.sqlite.comparison_library as cl
+                cl.jaro_winkler_at_thresholds("first_name", [0.9, 0.7])
                 ```
 
         Returns:

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -424,6 +424,22 @@ class NameComparisonBase(Comparison):
                                     jaro_winkler_thresholds=[],
                                     jaccard_thresholds=[1]
                                     )
+            === "SQLite"
+                Basic Name Comparison
+                ``` python
+                import splink.sqlite.comparison_template_library as ctl
+                ctl.name_comparison("name")
+                ```
+                Bespoke Name Comparison
+                ``` python
+                import splink.sqlite.comparison_template_library as ctl
+                ctl.name_comparison("name",
+                                    phonetic_col_name = "name_dm",
+                                    term_frequency_adjustments = True,
+                                    levenshtein_thresholds=[2],
+                                    damerau_levenshtein_thresholds=[],
+                                    jaro_winkler_thresholds=[0.8],
+                                    )
                 ```
 
         Returns:
@@ -791,6 +807,27 @@ class ForenameSurnameComparisonBase(Comparison):
                         levenshtein_thresholds=[2],
                         jaro_winkler_thresholds=[],
                         jaccard_thresholds=[1],
+                    )
+                ```
+            === "SQLite"
+                Basic Forename Surname Comparison
+                ```py
+                import splink.sqlite.comparison_template_library as ctl
+                ctl.forename_surname_comparison("first_name", "surname)
+                ```
+
+                Bespoke Forename Surname Comparison
+                ```py
+                import splink.sqlite.comparison_template_library as ctl
+                ctl.forename_surname_comparison(
+                        "forename",
+                        "surname",
+                        term_frequency_adjustments=True,
+                        tf_adjustment_col_forename_and_surname="full_name",
+                        phonetic_forename_col_name="forename_dm",
+                        phonetic_surname_col_name="surname_dm",
+                        levenshtein_thresholds=[2],
+                        jaro_winkler_thresholds=[0.8],
                     )
                 ```
 

--- a/splink/duckdb/duckdb_helpers/duckdb_comparison_imports.py
+++ b/splink/duckdb/duckdb_helpers/duckdb_comparison_imports.py
@@ -1,6 +1,7 @@
 from ...comparison_level_library import (
     ArrayIntersectLevelBase,
     ColumnsReversedLevelBase,
+    DamerauLevenshteinLevelBase,
     DateDiffLevelBase,
     DistanceFunctionLevelBase,
     DistanceInKMLevelBase,
@@ -119,7 +120,7 @@ class levenshtein_level(DuckDBBase, LevenshteinLevelBase):
     pass
 
 
-class damerau_levenshtein_level(DuckDBBase, LevenshteinLevelBase):
+class damerau_levenshtein_level(DuckDBBase, DamerauLevenshteinLevelBase):
     pass
 
 

--- a/splink/spark/spark_helpers/spark_comparison_imports.py
+++ b/splink/spark/spark_helpers/spark_comparison_imports.py
@@ -1,6 +1,7 @@
 from ...comparison_level_library import (
     ArrayIntersectLevelBase,
     ColumnsReversedLevelBase,
+    DamerauLevenshteinLevelBase,
     DateDiffLevelBase,
     DistanceFunctionLevelBase,
     DistanceInKMLevelBase,
@@ -119,7 +120,7 @@ class levenshtein_level(SparkBase, LevenshteinLevelBase):
     pass
 
 
-class damerau_levenshtein_level(SparkBase, LevenshteinLevelBase):
+class damerau_levenshtein_level(SparkBase, DamerauLevenshteinLevelBase):
     pass
 
 

--- a/splink/sqlite/comparison_level_library.py
+++ b/splink/sqlite/comparison_level_library.py
@@ -1,9 +1,12 @@
 from ..comparison_level_composition import and_, not_, or_  # noqa: F401
 from .sqlite_helpers.sqlite_comparison_imports import (  # noqa: F401
     columns_reversed_level,
+    damerau_levenshtein_level,
     distance_function_level,
     else_level,
     exact_match_level,
+    jaro_level,
+    jaro_winkler_level,
     levenshtein_level,
     null_level,
     percentage_difference_level,

--- a/splink/sqlite/comparison_library.py
+++ b/splink/sqlite/comparison_library.py
@@ -1,5 +1,8 @@
 from .sqlite_helpers.sqlite_comparison_imports import (  # noqa: F401
+    damerau_levenshtein_at_thresholds,
     distance_function_at_thresholds,
     exact_match,
+    jaro_at_thresholds,
+    jaro_winkler_at_thresholds,
     levenshtein_at_thresholds,
 )

--- a/splink/sqlite/comparison_template_library.py
+++ b/splink/sqlite/comparison_template_library.py
@@ -1,13 +1,4 @@
-# The Comparison Template Library is not currently implemented
-# for SQLite due to limited string matching capability in
-# cll.comparison_level_library
-
-import logging
-
-logger = logging.getLogger(__name__)
-
-logger.warn(
-    "The Comparison Template Library is not currently implemented "
-    "for SQLite due to limited string matching capability in "
-    "`cll.comparison_level_library`"
+from .sqlite_helpers.sqlite_comparison_imports import (  # noqa: F401
+    forename_surname_comparison,
+    name_comparison,
 )

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -96,8 +96,10 @@ class SQLiteLinker(Linker):
             connection = sqlite3.connect(connection)
         self.con = connection
         self.con.row_factory = dict_factory
+        # maths functions not always available by default depending on system
         self.con.create_function("log2", 1, log2)
         self.con.create_function("pow", 2, pow)
+        self.con.create_function("power", 2, pow)
         if register_udfs:
             self._register_udfs()
 

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -213,15 +213,17 @@ class SQLiteLinker(Linker):
         self.con.execute(drop_sql)
 
     def _register_udfs(self):
-        from rapidfuzz.distance.Levenshtein import distance as levenshtein
         from rapidfuzz.distance.DamerauLevenshtein import distance as dam_lev
         from rapidfuzz.distance.Jaro import distance as jaro
         from rapidfuzz.distance.JaroWinkler import distance as jaro_winkler
+        from rapidfuzz.distance.Levenshtein import distance as levenshtein
 
         def wrap_func_with_str(func):
             def wrapped_func(str_l, str_r):
                 return func(str(str_l), str(str_r))
+
             return wrapped_func
+
         # name in SQL : python function
         funcs_to_register = {
             "levenshtein": levenshtein,

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-from math import log2, pow
 import sqlite3
+from math import log2, pow
 
 import pandas as pd
 

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -6,6 +6,7 @@ from math import log2, pow
 
 import pandas as pd
 
+from ..exceptions import SplinkException
 from ..input_column import InputColumn
 from ..linker import Linker
 from ..misc import ensure_is_list
@@ -213,10 +214,21 @@ class SQLiteLinker(Linker):
         self.con.execute(drop_sql)
 
     def _register_udfs(self):
-        from rapidfuzz.distance.DamerauLevenshtein import distance as dam_lev
-        from rapidfuzz.distance.Jaro import distance as jaro
-        from rapidfuzz.distance.JaroWinkler import distance as jaro_winkler
-        from rapidfuzz.distance.Levenshtein import distance as levenshtein
+        try:
+            from rapidfuzz.distance.DamerauLevenshtein import distance as dam_lev
+            from rapidfuzz.distance.Jaro import distance as jaro
+            from rapidfuzz.distance.JaroWinkler import distance as jaro_winkler
+            from rapidfuzz.distance.Levenshtein import distance as levenshtein
+        except ModuleNotFoundError as e:
+            raise SplinkException(
+                "To use fuzzy string-matching udfs in SQLite you must install "
+                "the python package 'rapidfuzz'.  "
+                "If you do not wish to do so, and do not need to use any "
+                "fuzzy string-matching comparisons, you can use the linker argument "
+                "`register_udfs=False`.\n"
+                "See https://moj-analytical-services.github.io/splink/"
+                "topic_guides/backends.html#sqlite for more information"
+            ) from e
 
         def wrap_func_with_str(func):
             def wrapped_func(str_l, str_r):

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from math import log2, pow
+import sqlite3
 
 import pandas as pd
 
@@ -90,6 +91,8 @@ class SQLiteLinker(Linker):
     ):
         self._sql_dialect_ = "sqlite"
 
+        if isinstance(connection, str):
+            connection = sqlite3.connect(connection)
         self.con = connection
         self.con.row_factory = dict_factory
         self.con.create_function("log2", 1, log2)

--- a/splink/sqlite/sqlite_helpers/sqlite_base.py
+++ b/splink/sqlite/sqlite_helpers/sqlite_base.py
@@ -7,3 +7,7 @@ class SqliteBase(DialectBase):
     @property
     def _sql_dialect(self):
         return "sqlite"
+
+    @property
+    def _jaccard_name(self):
+        raise AttributeError("Jaccard similarity not implemented for SQLite")

--- a/splink/sqlite/sqlite_helpers/sqlite_comparison_imports.py
+++ b/splink/sqlite/sqlite_helpers/sqlite_comparison_imports.py
@@ -17,6 +17,10 @@ from ...comparison_library import (
     JaroWinklerAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
 )
+from ...comparison_template_library import (
+    ForenameSurnameComparisonBase,
+    NameComparisonBase,
+)
 from .sqlite_base import (
     SqliteBase,
 )
@@ -150,6 +154,15 @@ class jaro_winkler_at_thresholds(
 ###################################
 ### COMPARISON TEMPLATE LIBRARY ###
 ###################################
-# Not yet implemented
-# Currently does not support the necessary comparison levels
-# required for existing comparison templates
+class name_comparison(SqliteComparisonProperties, NameComparisonBase):
+    @property
+    def _distance_level(self):
+        return distance_function_level
+
+
+class forename_surname_comparison(
+    SqliteComparisonProperties, ForenameSurnameComparisonBase
+):
+    @property
+    def _distance_level(self):
+        return distance_function_level

--- a/splink/sqlite/sqlite_helpers/sqlite_comparison_imports.py
+++ b/splink/sqlite/sqlite_helpers/sqlite_comparison_imports.py
@@ -1,5 +1,6 @@
 from ...comparison_level_library import (
     ColumnsReversedLevelBase,
+    DamerauLevenshteinLevelBase,
     DistanceFunctionLevelBase,
     ElseLevelBase,
     ExactMatchLevelBase,
@@ -84,7 +85,7 @@ class levenshtein_level(SqliteBase, LevenshteinLevelBase):
     pass
 
 
-class damerau_levenshtein_level(SqliteBase, LevenshteinLevelBase):
+class damerau_levenshtein_level(SqliteBase, DamerauLevenshteinLevelBase):
     pass
 
 

--- a/splink/sqlite/sqlite_helpers/sqlite_comparison_imports.py
+++ b/splink/sqlite/sqlite_helpers/sqlite_comparison_imports.py
@@ -3,13 +3,18 @@ from ...comparison_level_library import (
     DistanceFunctionLevelBase,
     ElseLevelBase,
     ExactMatchLevelBase,
+    JaroLevelBase,
+    JaroWinklerLevelBase,
     LevenshteinLevelBase,
     NullLevelBase,
     PercentageDifferenceLevelBase,
 )
 from ...comparison_library import (
+    DamerauLevenshteinAtThresholdsComparisonBase,
     DistanceFunctionAtThresholdsComparisonBase,
     ExactMatchBase,
+    JaroAtThresholdsComparisonBase,
+    JaroWinklerAtThresholdsComparisonBase,
     LevenshteinAtThresholdsComparisonBase,
 )
 from .sqlite_base import (
@@ -40,6 +45,18 @@ class SqliteComparisonProperties(SqliteBase):
         return levenshtein_level
 
     @property
+    def _damerau_levenshtein_level(self):
+        return damerau_levenshtein_level
+
+    @property
+    def _jaro_level(self):
+        return jaro_level
+
+    @property
+    def _jaro_winkler_level(self):
+        return jaro_winkler_level
+
+    @property
     def _columns_reversed_level(self):
         return columns_reversed_level
 
@@ -60,6 +77,18 @@ class else_level(SqliteBase, ElseLevelBase):
 
 
 class levenshtein_level(SqliteBase, LevenshteinLevelBase):
+    pass
+
+
+class damerau_levenshtein_level(SqliteBase, LevenshteinLevelBase):
+    pass
+
+
+class jaro_level(SqliteBase, JaroLevelBase):
+    pass
+
+
+class jaro_winkler_level(SqliteBase, JaroWinklerLevelBase):
     pass
 
 
@@ -94,3 +123,33 @@ class levenshtein_at_thresholds(
     @property
     def _distance_level(self):
         return self._levenshtein_level
+
+
+class damerau_levenshtein_at_thresholds(
+    SqliteComparisonProperties, DamerauLevenshteinAtThresholdsComparisonBase
+):
+    @property
+    def _distance_level(self):
+        return self._damerau_levenshtein_level
+
+
+class jaro_at_thresholds(SqliteComparisonProperties, JaroAtThresholdsComparisonBase):
+    @property
+    def _distance_level(self):
+        return self._jaro_level
+
+
+class jaro_winkler_at_thresholds(
+    SqliteComparisonProperties, JaroWinklerAtThresholdsComparisonBase
+):
+    @property
+    def _distance_level(self):
+        return self._jaro_winkler_level
+
+
+###################################
+### COMPARISON TEMPLATE LIBRARY ###
+###################################
+# Not yet implemented
+# Currently does not support the necessary comparison levels
+# required for existing comparison templates

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -135,14 +135,7 @@ class SQLiteTestHelper(TestHelper):
     _frame_counter = 0
 
     def __init__(self):
-        from rapidfuzz.distance.Levenshtein import distance
-
-        def lev_wrap(str_l, str_r):
-            return distance(str(str_l), str(str_r))
-
-        con = sqlite3.connect(":memory:")
-        con.create_function("levenshtein", 2, lev_wrap)
-        self.con = con
+        self.con = sqlite3.connect(":memory:")
         self._frame_counter = 0
 
     @property

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -179,3 +179,88 @@ def test_levenshtein_level(test_helpers, dialect):
         )
         row = dict(df_e.query(f"id_l == 1 and id_r == {id_r}").iloc[0])
         assert row["gamma_name"] == expected_gamma_lev
+
+
+# postgres has no Damerau-Levenshtein
+@mark_with_dialects_excluding("postgres")
+def test_damerau_levenshtein_level(test_helpers, dialect):
+    helper = test_helpers[dialect]
+    cll = helper.cll
+
+    data = [
+        {"id": 1, "name": "harry"},
+        {"id": 2, "name": "harry"},
+        {"id": 3, "name": "barry"},
+        {"id": 4, "name": "gary"},
+        {"id": 5, "name": "sally"},
+        {"id": 6, "name": "sharry"},
+        {"id": 7, "name": "haryr"},
+        {"id": 8, "name": "ahryr"},
+        {"id": 9, "name": "harry12345"},
+        {"id": 10, "name": "ahrryt"},
+        {"id": 11, "name": "hy"},
+        {"id": 12, "name": "r"},
+    ]
+    # id and expected levenshtein distance from id:1 "harry"
+    id_distance_from_1 = {
+        2: 0,
+        3: 1,
+        4: 2,
+        5: 3,
+        6: 1,
+        7: 1,
+        8: 2,
+        9: 5,
+        10: 2,
+        11: 3,
+        12: 4,
+    }
+
+    settings = {
+        "unique_id_column_name": "id",
+        "link_type": "dedupe_only",
+        "comparisons": [
+            {
+                "output_column_name": "name",
+                "comparison_levels": [
+                    cll.null_level("name"),
+                    cll.damerau_levenshtein_level("name", 0),  # 4
+                    cll.damerau_levenshtein_level("name", 1),  # 3
+                    cll.damerau_levenshtein_level("name", 2),  # 2
+                    cll.damerau_levenshtein_level("name", 3),  # 1
+                    cll.else_level(),  # 0
+                ],
+            },
+        ],
+        "retain_matching_columns": True,
+        "retain_intermediate_calculation_columns": True,
+    }
+
+    def gamma_lev_from_distance(dist):
+        # which gamma value will I get for a given levenshtein distance?
+        if dist == 0:
+            return 4
+        elif dist == 1:
+            return 3
+        elif dist == 2:
+            return 2
+        elif dist == 3:
+            return 1
+        elif dist > 3:
+            return 0
+        raise ValueError(f"Invalid distance supplied ({dist})")
+
+    df = pd.DataFrame(data)
+    df = helper.convert_frame(df)
+
+    linker = helper.Linker(df, settings, **helper.extra_linker_args())
+    df_e = linker.predict().as_pandas_dataframe()
+
+    for id_r, lev_dist in id_distance_from_1.items():
+        expected_gamma_lev = gamma_lev_from_distance(lev_dist)
+        print(
+            f"id: {id_r}, expected_lev: {lev_dist}, "
+            f"expected_gamma: {expected_gamma_lev}"
+        )
+        row = dict(df_e.query(f"id_l == 1 and id_r == {id_r}").iloc[0])
+        assert row["gamma_name"] == expected_gamma_lev

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -86,3 +86,12 @@ def test_small_link_example_sqlite():
     )
 
     linker.predict()
+
+def test_default_conn_sqlite(tmp_path):
+
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    settings_dict = get_settings_dict()
+    linker = SQLiteLinker(df, settings_dict)
+
+    linker.predict()

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -10,15 +10,8 @@ from .linker_utils import _test_table_registration, register_roc_data
 
 
 def test_full_example_sqlite(tmp_path):
-    from rapidfuzz.distance.Levenshtein import distance
 
     con = sqlite3.connect(":memory:")
-    con.create_function("levenshtein", 2, distance)
-
-    def power(val, exp):
-        return val**exp
-
-    con.create_function("power", 2, power)
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
@@ -65,11 +58,8 @@ def test_full_example_sqlite(tmp_path):
 
 
 def test_small_link_example_sqlite():
-    from rapidfuzz.distance.Levenshtein import distance
 
     con = sqlite3.connect(":memory:")
-    con.create_function("levenshtein", 2, distance)
-
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     settings_dict = get_settings_dict()
@@ -86,6 +76,7 @@ def test_small_link_example_sqlite():
     )
 
     linker.predict()
+
 
 def test_default_conn_sqlite(tmp_path):
 


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Closes #1250.

Also allows registering of `levenshtein` by default in `SQLiteLinker` - see #1316.

I also notice `rapidfuzz` (which we use here for Levenshtein) also [implements all of the other string metrics we use](https://maxbachmann.github.io/RapidFuzz/Usage/distance/index.html). Realise they are obviously a relatively slow option compared to other backends but could also add these in the same way if it's something that might be useful?

### Give a brief description for the solution you have provided

### PR Checklist

- [NA] Added documentation for changes
- [NA] Added feature to example notebooks at tutorials in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


