### PR TITLE
[MAINT] Backend agnostic comparison composition tests

### DIFF
--- a/tests/test_comparison_level_composition.py
+++ b/tests/test_comparison_level_composition.py
@@ -1,10 +1,9 @@
 import pandas as pd
 import pytest
 
-from .decorator import mark_with_dialects_excluding
 import splink.duckdb.comparison_level_library as cll
-import splink.duckdb.comparison_level_library as scll
-from splink.duckdb.linker import DuckDBLinker
+
+from .decorator import mark_with_dialects_excluding
 
 
 def binary_composition_internals(clause, c_fun):

--- a/tests/test_comparison_level_composition.py
+++ b/tests/test_comparison_level_composition.py
@@ -59,21 +59,20 @@ def binary_composition_internals(clause, c_fun, cll, q):
         c_fun()
 
 
-@mark_with_dialects_excluding("postgres")
+@mark_with_dialects_excluding()
 def test_binary_composition_internals_OR(test_helpers, dialect):
     cll = test_helpers[dialect].cll
     quo, _ = _get_dialect_quotes(dialect)
     binary_composition_internals("OR", cll.or_, cll, quo)
 
 
-@mark_with_dialects_excluding("postgres")
+@mark_with_dialects_excluding()
 def test_binary_composition_internals_AND(test_helpers, dialect):
     cll = test_helpers[dialect].cll
     quo, _ = _get_dialect_quotes(dialect)
     binary_composition_internals("AND", cll.and_, cll, quo)
 
 
-@mark_with_dialects_including("duckdb")
 def test_not():
     import splink.duckdb.duckdb_comparison_level_library as cll
 
@@ -88,7 +87,7 @@ def test_not():
         cll.not_()
 
 
-@mark_with_dialects_excluding("postgres")
+@mark_with_dialects_excluding()
 def test_composition_outputs(test_helpers, dialect):
     helper = test_helpers[dialect]
     cll = helper.cll

--- a/tests/test_comparison_level_composition.py
+++ b/tests/test_comparison_level_composition.py
@@ -1,8 +1,9 @@
 import pandas as pd
 import pytest
 
-from .decorator import mark_with_dialects_excluding, mark_with_dialects_including
 from splink.input_column import _get_dialect_quotes
+
+from .decorator import mark_with_dialects_excluding, mark_with_dialects_including
 
 
 def binary_composition_internals(clause, c_fun, cll, q):
@@ -51,7 +52,7 @@ def binary_composition_internals(clause, c_fun, cll, q):
         m_probability=0.5,
     )
 
-    exact_match_sql = f"({q}first_name_l{q} = {q}first_name_r{q}) {clause} ({q}surname_l{q} = {q}surname_r{q})"
+    exact_match_sql = f"({q}first_name_l{q} = {q}first_name_r{q}) {clause} ({q}surname_l{q} = {q}surname_r{q})"  # noqa: E501
     assert level.sql_condition == f"NOT ({exact_match_sql})"
 
     with pytest.raises(ValueError):
@@ -89,7 +90,6 @@ def test_not():
 
 @mark_with_dialects_excluding("postgres")
 def test_composition_outputs(test_helpers, dialect):
-
     helper = test_helpers[dialect]
     cll = helper.cll
 

--- a/tests/test_comparison_level_composition.py
+++ b/tests/test_comparison_level_composition.py
@@ -4,11 +4,12 @@ import pytest
 from .decorator import mark_with_dialects_excluding, mark_with_dialects_including
 from splink.input_column import _get_dialect_quotes
 
+
 def binary_composition_internals(clause, c_fun, cll, q):
     # Test what happens when only one value is fed
     # It should just report the regular outputs of our comparison level func
     level = c_fun(cll.exact_match_level("tom", include_colname_in_charts_label=True))
-    assert level.sql_condition == f'({q}tom_l{q} = {q}tom_r{q})'
+    assert level.sql_condition == f"({q}tom_l{q} = {q}tom_r{q})"
     assert level.label_for_charts == "(Exact match tom)"
 
     # Two null levels composed
@@ -19,8 +20,8 @@ def binary_composition_internals(clause, c_fun, cll, q):
     )
 
     null_sql = (
-        f'({q}first_name_l{q} IS NULL OR {q}first_name_r{q} IS NULL) {clause} '
-        f'({q}surname_l{q} IS NULL OR {q}surname_r{q} IS NULL)'
+        f"({q}first_name_l{q} IS NULL OR {q}first_name_r{q} IS NULL) {clause} "
+        f"({q}surname_l{q} IS NULL OR {q}surname_r{q} IS NULL)"
     )
     assert level.sql_condition == null_sql
     # Default label
@@ -35,8 +36,8 @@ def binary_composition_internals(clause, c_fun, cll, q):
         m_probability=0.5,
     )
     assert (
-        level.sql_condition == f'({q}first_name_l{q} = {q}first_name_r{q}) {clause} '
-        f'({q}first_name_l{q} IS NULL OR {q}first_name_r{q} IS NULL)'
+        level.sql_condition == f"({q}first_name_l{q} = {q}first_name_r{q}) {clause} "
+        f"({q}first_name_l{q} IS NULL OR {q}first_name_r{q} IS NULL)"
     )
     # Default label
     assert level.label_for_charts == f"(Exact match first_name) {clause} (Null)"
@@ -50,9 +51,7 @@ def binary_composition_internals(clause, c_fun, cll, q):
         m_probability=0.5,
     )
 
-    exact_match_sql = (
-        f'({q}first_name_l{q} = {q}first_name_r{q}) {clause} ({q}surname_l{q} = {q}surname_r{q})'
-    )
+    exact_match_sql = f"({q}first_name_l{q} = {q}first_name_r{q}) {clause} ({q}surname_l{q} = {q}surname_r{q})"
     assert level.sql_condition == f"NOT ({exact_match_sql})"
 
     with pytest.raises(ValueError):
@@ -76,6 +75,7 @@ def test_binary_composition_internals_AND(test_helpers, dialect):
 @mark_with_dialects_including("duckdb")
 def test_not():
     import splink.duckdb.duckdb_comparison_level_library as cll
+
     level = cll.not_(cll.null_level("first_name"))
     assert level.is_null_level is False
 

--- a/tests/test_comparison_level_composition.py
+++ b/tests/test_comparison_level_composition.py
@@ -3,7 +3,7 @@ import pytest
 
 from splink.input_column import _get_dialect_quotes
 
-from .decorator import mark_with_dialects_excluding, mark_with_dialects_including
+from .decorator import mark_with_dialects_excluding
 
 
 def binary_composition_internals(clause, c_fun, cll, q):


### PR DESCRIPTION
Some quick tweaks to the comparison composition tests to make them backend agnostic.

