### PR TITLE
Splink dummy data

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ For more detailed tutorial, please see [here](https://moj-analytical-services.gi
 from splink.duckdb.linker import DuckDBLinker
 import splink.duckdb.comparison_library as cl
 import splink.duckdb.comparison_template_library as ctl
+from splink.datasets import splink_datasets
 
-import pandas as pd
-
-df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+df = splink_datasets.fake_1000
 
 settings = {
     "link_type": "dedupe_only",

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -8,19 +8,19 @@ tags:
 # In-built datasets
 
 Splink has some datasets available for use to help you get up and running, test ideas, or explore Splink features.
-To use, simply import `splink_data_sets`:
+To use, simply import `splink_datasets`:
 ```py
-from splink.datasets import splink_data_sets
+from splink.datasets import splink_datasets
 
-df = splink_data_sets.fake_1000
+df = splink_datasets.fake_1000
 ```
 which you can then use to set up a linker:
 ```py
-from splink.datasets import splink_data_sets
+from splink.datasets import splink_datasets
 from splink.duckdb.linker import DuckDBLinker
 import splink.duckdb.comparison_library as cl
 
-df = splink_data_sets.fake_1000
+df = splink_datasets.fake_1000
 linker = DuckDBLinker(
     df,
     {
@@ -30,12 +30,12 @@ linker = DuckDBLinker(
 )
 ```
 
-## `splink_data_sets`
+## `splink_datasets`
 
-Each attribute of `splink_data_sets` is a dataset available for use, which exists as a pandas `DataFrame`.
+Each attribute of `splink_datasets` is a dataset available for use, which exists as a pandas `DataFrame`.
 These datasets are not packaged directly with Splink, but instead are downloaded only when they are requested.
 Once requested they are cached for future use.
-The cache can be cleared using [`splink_data_utils`](#splink_data_utils-object), 
+The cache can be cleared using [`splink_dataset_utils`](#splink_dataset_utils-object), 
 which also contains information on available datasets, and which have already been cached.
 
 ### Available datasets
@@ -44,19 +44,19 @@ The datasets available are listed below:
 
 {% include-markdown "./includes/generated_files/datasets.md" %}
 
-## `splink_data_utils` API
+## `splink_dataset_utils` API
 
-In addition to `splink_data_sets`, you can also import `splink_data_utils`, 
-which has a few functions to help managing `splink_data_sets`.
+In addition to `splink_datasets`, you can also import `splink_dataset_utils`, 
+which has a few functions to help managing `splink_datasets`.
 This can be useful if you have limited internet connection and want to see what is already cached,
 or if you need to clear cache items (e.g. if datasets were to be updated, or if space is an issue).
 
 For example:
 ```py
-from splink.datasets import splink_data_utils
+from splink.datasets import splink_dataset_utils
 
-splink_data_utils.show_downloaded_data()
-splink_data_utils.clear_cache(['fake_1000'])
+splink_dataset_utils.show_downloaded_data()
+splink_dataset_utils.clear_cache(['fake_1000'])
 ```
 
 ::: splink.datasets._SplinkDataUtils

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -42,7 +42,7 @@ which also contains information on available datasets, and which have already be
 
 The datasets available are listed below:
 
-{% include-markdown "./includes/generated_files/datasets.md" %}
+{% include-markdown "./includes/generated_files/datasets_table.md" %}
 
 ## `splink_dataset_utils` API
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,0 +1,72 @@
+---
+tags:
+  - API
+  - Datasets
+  - Examples
+---
+
+# In-built datasets
+
+Splink has some datasets available for use to help you get up and running, test ideas, or explore Splink features.
+To use, simply import `splink_data_sets`:
+```py
+from splink.datasets import splink_data_sets
+
+df = splink_data_sets.fake_1000
+```
+which you can then use to set up a linker:
+```py
+from splink.datasets import splink_data_sets
+from splink.duckdb.linker import DuckDBLinker
+import splink.duckdb.comparison_library as cl
+
+df = splink_data_sets.fake_1000
+linker = DuckDBLinker(
+    df,
+    {
+        "link_type": "dedupe_only",
+        "comparisons": [cl.exact_match("first_name"), cl.exact_match("surname")],
+    },
+)
+```
+
+## `splink_data_sets`
+
+Each attribute of `splink_data_sets` is a dataset available for use, which exists as a pandas `DataFrame`.
+These datasets are not packaged directly with Splink, but instead are downloaded only when they are requested.
+Once requested they are cached for future use.
+The cache can be cleared using [`splink_data_utils`](#splink_data_utils-object), 
+which also contains information on available datasets, and which have already been cached.
+
+### Available datasets
+
+The datasets available are listed below:
+
+{% include-markdown "./includes/generated_files/datasets.md" %}
+
+## `splink_data_utils` API
+
+In addition to `splink_data_sets`, you can also import `splink_data_utils`, 
+which has a few functions to help managing `splink_data_sets`.
+This can be useful if you have limited internet connection and want to see what is already cached,
+or if you need to clear cache items (e.g. if datasets were to be updated, or if space is an issue).
+
+For example:
+```py
+from splink.datasets import splink_data_utils
+
+splink_data_utils.show_downloaded_data()
+splink_data_utils.clear_cache(['fake_1000'])
+```
+
+::: splink.datasets._SplinkDataUtils
+    handler: python
+    options:
+      members:
+        - list_downloaded_datasets
+        - list_all_datasets
+        - show_downloaded_data
+        - clear_downloaded_data
+      show_root_heading: false
+      show_source: false
+      heading_level: 3

--- a/docs/documentation_index.md
+++ b/docs/documentation_index.md
@@ -22,6 +22,11 @@ The documentation for the Splink API is broken up into the following categories:
 
 Note: When building a Splink model, the [Linker API](./linker.md) and [Comparisons Library API](./comparison_level_library.md) will be the most useful parts of the API documentation. The other sections are primarily for reference.
 
+## In-built datasets
+Information on pre-made data tables available within Splink suitable for linking, to get up-and-running or to try out ideas.
+
+- [In-build datasets](./datasets.md) - information on included datasets, as well as how to use them, and methods for managing them.
+
 ## Splink Settings
 Reference materials for the Splink Settings dictionary:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,10 +61,9 @@ For more detailed tutorial, please see [section below](#tutorial).
     from splink.duckdb.linker import DuckDBLinker
     import splink.duckdb.comparison_library as cl
     import splink.duckdb.comparison_template_library as ctl
+    from splink.datasets import splink_datasets
 
-    import pandas as pd
-
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df = splink_datasets.fake_1000
 
     settings = {
         "link_type": "dedupe_only",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
         - Comparisons API:
             - Comparison: "comparison.md"
             - Comparison Level: "comparison_level.md"
+      - In-build datasets: "datasets.md"
       - Settings:
         - Settings Dictionary Reference: "settings_dict_guide.md"
         - Interactive Settings Editor: "settingseditor/editor.md"

--- a/scripts/generate_dataset_docs.py
+++ b/scripts/generate_dataset_docs.py
@@ -1,0 +1,32 @@
+# this script to be run at the root of the repo
+# otherwise paths for generated files are incorrect
+import importlib
+import inspect
+from pathlib import Path
+
+from splink.datasets import _datasets as datasets_info
+from splink.comparison_level import ComparisonLevel
+from splink.dialect_base import DialectBase
+
+
+def make_md_table(datasets):
+    # start table with a header row
+    table = f"|dataset name|description|rows|unique entities|link to source|\n"
+    # and a separator row
+    table += f"|-|-|-|-|-|\n"
+
+    # then rows for each level indicating which dialects support it
+    for ds in datasets:
+        table += f"|`{ds.dataset_name}`"
+        table += f"|{ds.description}"
+        table += f"|{ds.rows}"
+        table += f"|{ds.unique_entities}"
+        table += f"|[source]({ds.url})"
+        table += "|\n"
+    return table
+
+
+dataset_table = make_md_table(datasets_info)
+dataset_table_file = "datasets_table.md"
+with open(Path("docs") / "includes" / "generated_files" / dataset_table_file, "w+") as f:
+    f.write(dataset_table)

--- a/scripts/generate_dataset_docs.py
+++ b/scripts/generate_dataset_docs.py
@@ -1,19 +1,15 @@
 # this script to be run at the root of the repo
 # otherwise paths for generated files are incorrect
-import importlib
-import inspect
 from pathlib import Path
 
 from splink.datasets import _datasets as datasets_info
-from splink.comparison_level import ComparisonLevel
-from splink.dialect_base import DialectBase
 
 
 def make_md_table(datasets):
     # start table with a header row
-    table = f"|dataset name|description|rows|unique entities|link to source|\n"
+    table = "|dataset name|description|rows|unique entities|link to source|\n"
     # and a separator row
-    table += f"|-|-|-|-|-|\n"
+    table += "|-|-|-|-|-|\n"
 
     # then rows for each level indicating which dialects support it
     for ds in datasets:
@@ -28,5 +24,7 @@ def make_md_table(datasets):
 
 dataset_table = make_md_table(datasets_info)
 dataset_table_file = "datasets_table.md"
-with open(Path("docs") / "includes" / "generated_files" / dataset_table_file, "w+") as f:
+with open(
+    Path("docs") / "includes" / "generated_files" / dataset_table_file, "w+"
+) as f:
     f.write(dataset_table)

--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -22,6 +22,7 @@ then
     pip install poetry
     poetry install
     python3 scripts/generate_dialect_comparison_docs.py
+    python3 scripts/generate_dataset_docs.py
 fi
 # manually preprocess include files as include-markdown plugin clashes with mknotebooks
 # make sure not to commit changes to files with inclusions!

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from dataclasses import asdict, dataclass
 from math import floor
 from pathlib import Path
@@ -127,17 +128,42 @@ class _SplinkDataUtils:
         return filename.split(".")[0]
 
     def list_downloaded_datasets(self):
+        """Return a list of datasets that have already been pre-downloaded
+        """
         return [self._trim_suffix(f) for f in self._list_downloaded_data_files()]
 
+    def list_all_datasets(self):
+        """Return a list of all available datasets, regardless of whether
+        or note they have already been pre-downloaded
+        """
+        return [d.dataset_name for d in _datasets]
+
     def show_downloaded_data(self):
+        """Print a list of datasets that have already been pre-downloaded
+        """
         print(
-            "Datasets already downloaded and available:\n" +
-            ",\n".join(self.list_downloaded_datasets())
+            "Datasets already downloaded and available:\n"
+            + ",\n".join(self.list_downloaded_datasets())
         )
 
-    def clear_downloaded_data(self, files=None):
+    def clear_downloaded_data(self, datasets: list = None):
+        """Delete any pre-downloaded data stored locally.
+
+        Args:
+            datasets (list): A list of dataset names (without any file suffix) to delete.
+                If `None`, all datasets will be deleted. Default `None`
+        """
+        available_datasets = self.list_all_datasets()
+        if datasets is None:
+            datasets = available_datasets
+        for ds in datasets:
+            if ds not in available_datasets:
+                warnings.warn(
+                    f"Dataset '{ds}' not recognised, ignoring"
+                )
         for f in self._list_downloaded_data_files():
-            os.remove(_cache_dir / f)
+            if self._trim_suffix(f) in datasets:
+                os.remove(_cache_dir / f)
 
 
 class _SplinkDataSets(metaclass=_SplinkDataSetsMeta, datasets=_datasets):

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -57,7 +57,7 @@ class _SplinkDataSetsMeta(type):
     def __new__(cls, clsname, bases, attrs, datasets):
         cls.cache_dir.mkdir(exist_ok=True)
         attributes = {}
-        repr_text = "splink_data_sets object with datasets:"
+        repr_text = "splink_datasets object with datasets:"
         for dataset_meta in datasets:
             dataset_name = dataset_meta.dataset_name
             description = dataset_meta.description
@@ -170,5 +170,5 @@ class _SplinkDataSets(metaclass=_SplinkDataSetsMeta, datasets=_datasets):
     pass
 
 
-splink_data_sets = _SplinkDataSets()
-splink_data_utils = _SplinkDataUtils()
+splink_datasets = _SplinkDataSets()
+splink_dataset_utils = _SplinkDataUtils()

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -7,9 +7,9 @@ from urllib.request import urlretrieve
 
 import pandas as pd
 
-DATASETDIR = Path(__file__).parent
+_DATASETDIR = Path(__file__).parent
 
-valid_formats = ("csv", "parquet")
+_valid_formats = ("csv", "parquet")
 
 
 @dataclass
@@ -20,8 +20,8 @@ class _DataSetMetaData:
     data_format: str = "csv"
 
     def __post_init__(self):
-        if self.data_format not in valid_formats:
-            valid_format_str = "', '".join(valid_formats)
+        if self.data_format not in _valid_formats:
+            valid_format_str = "', '".join(_valid_formats)
             raise ValueError(
                 f"`data_format` must be one of '{valid_format_str}'.  "
                 f"Dataset '{self.dataset_name}' labelled with format: "
@@ -37,9 +37,9 @@ _datasets = [
         "fake_1000",
         f"{_splink_demo_data_dir}/fake_1000.csv",
         (
-            "Fake 1000 from splink demos.  ",
+            "Fake 1000 from splink demos.  "
             "Records are 250 simulated people, "
-            "with different numbers of duplicates, labelled.",
+            "with different numbers of duplicates, labelled."
         ),
     ),
     _DataSetMetaData(
@@ -48,7 +48,7 @@ _datasets = [
         "Fake 20000 from splink demos",
     ),
 ]
-_cache_dir = DATASETDIR / "__splinkdata_cache__"
+_cache_dir = _DATASETDIR / "__splinkdata_cache__"
 
 
 class _SplinkDataSetsMeta(type):
@@ -94,9 +94,6 @@ class _SplinkDataSetsMeta(type):
                 print(f"downloading: {url}")
                 urlretrieve(url, file_loc, reporthook=cls.progress)
                 print("")
-            # only for checking
-            else:
-                print("cached!")
 
             if data_format == "csv":
                 return pd.read_csv(file_loc)
@@ -128,8 +125,7 @@ class _SplinkDataUtils:
         return filename.split(".")[0]
 
     def list_downloaded_datasets(self):
-        """Return a list of datasets that have already been pre-downloaded
-        """
+        """Return a list of datasets that have already been pre-downloaded"""
         return [self._trim_suffix(f) for f in self._list_downloaded_data_files()]
 
     def list_all_datasets(self):
@@ -139,8 +135,7 @@ class _SplinkDataUtils:
         return [d.dataset_name for d in _datasets]
 
     def show_downloaded_data(self):
-        """Print a list of datasets that have already been pre-downloaded
-        """
+        """Print a list of datasets that have already been pre-downloaded"""
         print(
             "Datasets already downloaded and available:\n"
             + ",\n".join(self.list_downloaded_datasets())
@@ -150,7 +145,8 @@ class _SplinkDataUtils:
         """Delete any pre-downloaded data stored locally.
 
         Args:
-            datasets (list): A list of dataset names (without any file suffix) to delete.
+            datasets (list): A list of dataset names (without any file suffix)
+                to delete.
                 If `None`, all datasets will be deleted. Default `None`
         """
         available_datasets = self.list_all_datasets()
@@ -159,7 +155,8 @@ class _SplinkDataUtils:
         for ds in datasets:
             if ds not in available_datasets:
                 warnings.warn(
-                    f"Dataset '{ds}' not recognised, ignoring"
+                    f"Dataset '{ds}' not recognised, ignoring",
+                    stacklevel=2,
                 )
         for f in self._list_downloaded_data_files():
             if self._trim_suffix(f) in datasets:
@@ -170,5 +167,6 @@ class _SplinkDataSets(metaclass=_SplinkDataSetsMeta, datasets=_datasets):
     pass
 
 
+# these two singleton objects are the only user-facing portion:
 splink_datasets = _SplinkDataSets()
 splink_dataset_utils = _SplinkDataUtils()

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -16,6 +16,8 @@ _valid_formats = ("csv", "parquet")
 class _DataSetMetaData:
     dataset_name: str
     url: str
+    rows: int
+    unique_entities: int
     description: str = ""
     data_format: str = "csv"
 
@@ -36,6 +38,9 @@ _datasets = [
     _DataSetMetaData(
         "fake_1000",
         f"{_splink_demo_data_dir}/fake_1000.csv",
+        # hard code metadata to avoid needing to download to build docs
+        1000,
+        250,
         (
             "Fake 1000 from splink demos.  "
             "Records are 250 simulated people, "
@@ -45,6 +50,8 @@ _datasets = [
     _DataSetMetaData(
         "fake_20000",
         f"{_splink_demo_data_dir}/fake_20000.csv",
+        20000,
+        5726,
         "Fake 20000 from splink demos",
     ),
 ]
@@ -87,7 +94,8 @@ class _SplinkDataSetsMeta(type):
         print(display, end="")
 
     @classmethod
-    def class_attribute_factory(cls, dataset_name, url, description, data_format):
+    def class_attribute_factory(
+        cls, dataset_name, url, rows, unique_entities, description, data_format):
         def lazyload_data(self):
             file_loc = cls.cache_dir / f"{dataset_name}.{data_format}"
             if not cls.datafile_exists(file_loc):

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -88,7 +88,8 @@ class _SplinkDataSetsMeta(type):
 
     @classmethod
     def class_attribute_factory(
-        cls, dataset_name, url, rows, unique_entities, description, data_format):
+        cls, dataset_name, url, rows, unique_entities, description, data_format
+    ):
         def lazyload_data(self):
             file_loc = cls.cache_dir / f"{dataset_name}.{data_format}"
             if not cls.datafile_exists(file_loc):

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -134,7 +134,7 @@ class _SplinkDataUtils:
 
     def list_all_datasets(self):
         """Return a list of all available datasets, regardless of whether
-        or note they have already been pre-downloaded
+        or not they have already been pre-downloaded
         """
         return [d.dataset_name for d in _datasets]
 

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -47,13 +47,6 @@ _datasets = [
             "with different numbers of duplicates, labelled."
         ),
     ),
-    _DataSetMetaData(
-        "fake_20000",
-        f"{_splink_demo_data_dir}/fake_20000.csv",
-        20000,
-        5726,
-        "Fake 20000 from splink demos",
-    ),
 ]
 _cache_dir = _DATASETDIR / "__splinkdata_cache__"
 

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -138,10 +138,10 @@ class _SplinkDataUtils:
 
     def show_downloaded_data(self):
         """Print a list of datasets that have already been pre-downloaded"""
-        print(
+        print(  # noqa: T201
             "Datasets already downloaded and available:\n"
             + ",\n".join(self.list_downloaded_datasets())
-        )  # noqa: T201
+        )
 
     def clear_downloaded_data(self, datasets: list = None):
         """Delete any pre-downloaded data stored locally.

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from urllib.request import urlretrieve
 
@@ -5,30 +6,67 @@ import pandas as pd
 
 DATASETDIR = Path(__file__).parent
 
-_datasets = {
-    "fake_1000": "https://raw.githubusercontent.com/moj-analytical-services/splink_demos/master/data/fake_1000.csv",
-    "fake_20000": "https://raw.githubusercontent.com/moj-analytical-services/splink_demos/master/data/fake_20000.csv",
-}
+valid_formats = ("csv", "parquet")
+
+
+@dataclass
+class _DataSetMetaData:
+    dataset_name: str
+    url: str
+    description: str = ""
+    data_format: str = "csv"
+
+    def __post_init__(self):
+        if self.data_format not in valid_formats:
+            valid_format_str = "', '".join(valid_formats)
+            raise ValueError(
+                f"`data_format` must be one of '{valid_format_str}'.  "
+                f"Dataset '{self.dataset_name}' labelled with format: "
+                f"'{self.data_format}'"
+            )
+
+
+splink_demo_data_dir = (
+    "https://raw.githubusercontent.com/moj-analytical-services/splink_demos/master/data"
+)
+_datasets = [
+    _DataSetMetaData(
+        "fake_1000",
+        f"{splink_demo_data_dir}/fake_1000.csv",
+        "Fake 1000 from splink demos",
+    ),
+    _DataSetMetaData(
+        "fake_20000",
+        f"{splink_demo_data_dir}/fake_20000.csv",
+        "Fake 20000 from splink demos",
+    ),
+]
 
 
 class _SplinkDataSetsMeta(type):
     cache_dir = DATASETDIR / "__splinkdata_cache__"
 
-    def __new__(cls, clsname, bases, attrs, datasets_lookup):
+    def __new__(cls, clsname, bases, attrs, datasets):
         cls.cache_dir.mkdir(exist_ok=True)
         attributes = {}
         repr_text = "splink_data_sets object with datasets:"
-        for dataset_name, url in datasets_lookup.items():
-            attributes[dataset_name] = cls.class_attribute_factory(dataset_name, url)
-            repr_text += f"\n\t{dataset_name}"
+        for dataset_meta in datasets:
+            dataset_name = dataset_meta.dataset_name
+            description = dataset_meta.description
+
+            repr_text += f"\n\t{dataset_name} ({description})"
+            attributes[dataset_name] = cls.class_attribute_factory(
+                **asdict(dataset_meta)
+            )
 
         attributes["__repr__"] = lambda self: repr_text
         return super().__new__(cls, clsname, bases, attributes)
 
+    # TODO: do we want description here?
     @classmethod
-    def class_attribute_factory(cls, dataset_name, url):
+    def class_attribute_factory(cls, dataset_name, url, description, data_format):
         def lazyload_data(self):
-            file_loc = cls.cache_dir / f"{dataset_name}.csv"
+            file_loc = cls.cache_dir / f"{dataset_name}.{data_format}"
             if not cls.datafile_exists(file_loc):
                 urlretrieve(url, file_loc)
                 print(f"downloading: {url}")
@@ -36,7 +74,14 @@ class _SplinkDataSetsMeta(type):
             else:
                 print("cached!")
 
-            return pd.read_csv(file_loc)
+            if data_format == "csv":
+                return pd.read_csv(file_loc)
+            if data_format == "parquet":
+                return pd.read_parquet(file_loc)
+            # just in case we have an invalid format
+            raise ValueError(
+                f"Error retrieving dataset {dataset_name} - invalid format!"
+            )
 
         return property(lazyload_data)
 
@@ -45,7 +90,7 @@ class _SplinkDataSetsMeta(type):
         return file_loc.is_file()
 
 
-class _SplinkDataSets(metaclass=_SplinkDataSetsMeta, datasets_lookup=_datasets):
+class _SplinkDataSets(metaclass=_SplinkDataSetsMeta, datasets=_datasets):
     pass
 
 

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from urllib.request import urlretrieve
+
+import pandas as pd
+
+DATASETDIR = Path(__file__).parent
+
+_datasets = {
+    "fake_1000": "https://raw.githubusercontent.com/moj-analytical-services/splink_demos/master/data/fake_1000.csv",
+    "fake_20000": "https://raw.githubusercontent.com/moj-analytical-services/splink_demos/master/data/fake_20000.csv",
+}
+
+
+class _SplinkDataSetsMeta(type):
+    cache_dir = DATASETDIR / "__splinkdata_cache__"
+
+    def __new__(cls, clsname, bases, attrs, datasets_lookup):
+        cls.cache_dir.mkdir(exist_ok=True)
+        attributes = {}
+        repr_text = "splink_data_sets object with datasets:"
+        for dataset_name, url in datasets_lookup.items():
+            attributes[dataset_name] = cls.class_attribute_factory(dataset_name, url)
+            repr_text += f"\n\t{dataset_name}"
+
+        attributes["__repr__"] = lambda self: repr_text
+        return super().__new__(cls, clsname, bases, attributes)
+
+    @classmethod
+    def class_attribute_factory(cls, dataset_name, url):
+        def lazyload_data(self):
+            file_loc = cls.cache_dir / f"{dataset_name}.csv"
+            if not cls.datafile_exists(file_loc):
+                urlretrieve(url, file_loc)
+                print(f"downloading: {url}")
+            # only for checking
+            else:
+                print("cached!")
+
+            return pd.read_csv(file_loc)
+
+        return property(lazyload_data)
+
+    @staticmethod
+    def datafile_exists(file_loc):
+        return file_loc.is_file()
+
+
+class _SplinkDataSets(metaclass=_SplinkDataSetsMeta, datasets_lookup=_datasets):
+    pass
+
+
+splink_data_sets = _SplinkDataSets()

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -84,7 +84,7 @@ class _SplinkDataSetsMeta(type):
             else:
                 display += "."
         display += ")"
-        print(display, end="")
+        print(display, end="")  # noqa: T201
 
     @classmethod
     def class_attribute_factory(
@@ -93,9 +93,9 @@ class _SplinkDataSetsMeta(type):
         def lazyload_data(self):
             file_loc = cls.cache_dir / f"{dataset_name}.{data_format}"
             if not cls.datafile_exists(file_loc):
-                print(f"downloading: {url}")
+                print(f"downloading: {url}")  # noqa: T201
                 urlretrieve(url, file_loc, reporthook=cls.progress)
-                print("")
+                print("")  # noqa: T201
 
             if data_format == "csv":
                 return pd.read_csv(file_loc)
@@ -141,7 +141,7 @@ class _SplinkDataUtils:
         print(
             "Datasets already downloaded and available:\n"
             + ",\n".join(self.list_downloaded_datasets())
-        )
+        )  # noqa: T201
 
     def clear_downloaded_data(self, datasets: list = None):
         """Delete any pre-downloaded data stored locally.

--- a/splink/datasets/__init__.py
+++ b/splink/datasets/__init__.py
@@ -1,6 +1,6 @@
+import os
 from dataclasses import asdict, dataclass
 from math import floor
-import os
 from pathlib import Path
 from urllib.request import urlretrieve
 
@@ -38,8 +38,8 @@ _datasets = [
         (
             "Fake 1000 from splink demos.  ",
             "Records are 250 simulated people, "
-            "with different numbers of duplicates, labelled."
-        )
+            "with different numbers of duplicates, labelled.",
+        ),
     ),
     _DataSetMetaData(
         "fake_20000",
@@ -74,9 +74,9 @@ class _SplinkDataSetsMeta(type):
         prop_done = (block_count * block_size) / total_size
         if prop_done > 1:
             prop_done = 1
-        perc = round(prop_done*100)
+        perc = round(prop_done * 100)
         display = f"\r  download progress: {perc} %\t("
-        deciles_done = floor(prop_done*10)
+        deciles_done = floor(prop_done * 10)
         for i in range(10):
             if i < deciles_done:
                 display += "="
@@ -85,7 +85,6 @@ class _SplinkDataSetsMeta(type):
         display += ")"
         print(display, end="")
 
-    # TODO: do we want description here?
     @classmethod
     def class_attribute_factory(cls, dataset_name, url, description, data_format):
         def lazyload_data(self):
@@ -106,6 +105,7 @@ class _SplinkDataSetsMeta(type):
             raise ValueError(
                 f"Error retrieving dataset {dataset_name} - invalid format!"
             )
+
         # make the docstring be the description
         lazyload_data.__doc__ = description
 
@@ -116,7 +116,7 @@ class _SplinkDataSetsMeta(type):
         return file_loc.is_file()
 
 
-class _SplinkDataUtils():
+class _SplinkDataUtils:
     def __init__(self):
         pass
 

--- a/tests/test_splink_datasets.py
+++ b/tests/test_splink_datasets.py
@@ -1,0 +1,19 @@
+from splink.datasets import splink_data_sets
+
+
+def test_datasets_basic_link(test_helpers):
+    # use duckdb as a backend just to check data is roughly as expected
+    # don't need to check other backends as that's not what we're testing
+    helper = test_helpers["duckdb"]
+    cl = helper.cl
+
+    df = splink_data_sets.fake_1000
+    linker = helper.Linker(
+        df,
+        {
+            "link_type": "dedupe_only",
+            "comparisons": [cl.exact_match("first_name"), cl.exact_match("surname")]
+        },
+        **helper.extra_linker_args()
+    )
+    linker.predict()

--- a/tests/test_splink_datasets.py
+++ b/tests/test_splink_datasets.py
@@ -12,7 +12,7 @@ def test_datasets_basic_link(test_helpers):
         df,
         {
             "link_type": "dedupe_only",
-            "comparisons": [cl.exact_match("first_name"), cl.exact_match("surname")]
+            "comparisons": [cl.exact_match("first_name"), cl.exact_match("surname")],
         },
         **helper.extra_linker_args()
     )

--- a/tests/test_splink_datasets.py
+++ b/tests/test_splink_datasets.py
@@ -1,4 +1,4 @@
-from splink.datasets import splink_data_sets
+from splink.datasets import splink_datasets
 
 
 def test_datasets_basic_link(test_helpers):
@@ -7,7 +7,7 @@ def test_datasets_basic_link(test_helpers):
     helper = test_helpers["duckdb"]
     cl = helper.cl
 
-    df = splink_data_sets.fake_1000
+    df = splink_datasets.fake_1000
     linker = helper.Linker(
         df,
         {


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
No

### Give a brief description for the solution you have provided
In writing some documentation, I realised that it might be useful, particularly for new users, to have some dummy data to get up-and-running with pre-baked into Splink, without them having to copy files and read in manually

This works simply from the user perspective - simply import `splink_data_sets`, and each attribute is a pandas dataframes:
```py
from splink.datasets import splink_data_sets

df = splink_data_sets.fake_1000
...
linker = DuckDBLinker(df, settings)
```

Under-the-hood this downloads the dataset, or retrieves it from a local cache folder if it has been downloaded previously, so as not to bloat the size of the package. This only happens as datasets are accessed, so we could potentially include very large / rich datasets without any performance / storage penalty if they are never accessed.

There is a basic test - there should probably be more detailed tests which properly deal with stuff around downloading/caching, but that will be fairly fiddly so probably best as a follow-up.

Things not considered (probably for future PRs):

* range of data sets to include
* where the datasets should live
* whether options aside from pandas would be useful (load directly into your backend?)
* ~~haven't checked if caching works properly when splink is installed~~
* any kind of niceness if downloading is slow / fails

### PR Checklist

- [x] Added documentation for changes
- [ ] Added feature to example notebooks at tutorials in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


