### PR TITLE
Issue 1225 - Poor performance of estimate u in a link_only job

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -142,7 +142,6 @@ def block_using_rules_sql(linker: Linker):
         select * from __splink__df_concat_with_tf{sample_switch}
         where {source_dataset_col} = '{df_r.templated_name}'
         """
-
         linker._enqueue_sql(sql, f"__splink__df_concat_with_tf{sample_switch}_right")
 
     # Cover the case where there are no blocking rules

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -127,17 +127,23 @@ def block_using_rules_sql(linker: Linker):
         df_l = linker._input_tables_dict[keys[0]]
         df_r = linker._input_tables_dict[keys[1]]
 
-        sql = f"""
-        select * from __splink__df_concat_with_tf
-        where {source_dataset_col} = '{df_l.templated_name}'
-        """
-        linker._enqueue_sql(sql, "__splink__df_concat_with_tf_left")
+        if linker._train_u_using_random_sample_mode:
+            sample_switch = "_sample"
+        else:
+            sample_switch = ""
 
         sql = f"""
-        select * from __splink__df_concat_with_tf
+        select * from __splink__df_concat_with_tf{sample_switch}
+        where {source_dataset_col} = '{df_l.templated_name}'
+        """
+        linker._enqueue_sql(sql, f"__splink__df_concat_with_tf{sample_switch}_left")
+
+        sql = f"""
+        select * from __splink__df_concat_with_tf{sample_switch}
         where {source_dataset_col} = '{df_r.templated_name}'
         """
-        linker._enqueue_sql(sql, "__splink_df_concat_with_tf_right")
+
+        linker._enqueue_sql(sql, f"__splink__df_concat_with_tf{sample_switch}_right")
 
     # Cover the case where there are no blocking rules
     # This is a bit of a hack where if you do a self-join on 'true'

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -90,6 +90,8 @@ def estimate_u_values(linker: Linker, max_pairs, seed=None):
         # sample size is for df_concat_with_tf, i.e. proportion of the total nodes
         sample_size = proportion * total_nodes
 
+        print(f"{proportion=} || {sample_size=}")
+
     if proportion >= 1.0:
         proportion = 1.0
 

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -90,8 +90,6 @@ def estimate_u_values(linker: Linker, max_pairs, seed=None):
         # sample size is for df_concat_with_tf, i.e. proportion of the total nodes
         sample_size = proportion * total_nodes
 
-        print(f"{proportion=} || {sample_size=}")
-
     if proportion >= 1.0:
         proportion = 1.0
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -263,7 +263,10 @@ class Linker:
             return "__splink__compare_two_records_left_with_tf"
 
         if self._train_u_using_random_sample_mode:
-            return "__splink__df_concat_with_tf_sample"
+            if self._two_dataset_link_only:
+                return "__splink__df_concat_with_tf_sample_left"
+            else:
+                return "__splink__df_concat_with_tf_sample"
 
         if self._analyse_blocking_mode:
             return "__splink__df_concat"
@@ -285,7 +288,10 @@ class Linker:
             return "__splink__compare_two_records_right_with_tf"
 
         if self._train_u_using_random_sample_mode:
-            return "__splink__df_concat_with_tf_sample"
+            if self._two_dataset_link_only:
+                return "__splink__df_concat_with_tf_sample_right"
+            else:
+                return "__splink__df_concat_with_tf_sample"
 
         if self._analyse_blocking_mode:
             return "__splink__df_concat"
@@ -319,12 +325,6 @@ class Linker:
 
         if self._compare_two_records_mode:
             return True
-
-        # in u-train sample mode we are joining the concatenated table mixing
-        # both data sets - hence if we inner join on True we will end up with
-        # samples which both originate from the same dataset
-        if self._train_u_using_random_sample_mode:
-            return False
 
         if self._analyse_blocking_mode:
             return False

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -297,7 +297,7 @@ class Linker:
             return "__splink__df_concat"
 
         if self._two_dataset_link_only:
-            return "__splink_df_concat_with_tf_right"
+            return "__splink__df_concat_with_tf_right"
         return "__splink__df_concat_with_tf"
 
     @property

--- a/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
+++ b/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
@@ -1,0 +1,306 @@
+import logging
+import re
+
+import pandas as pd
+
+import splink.duckdb.comparison_library as cl
+from splink.duckdb.linker import DuckDBLinker
+
+
+# Create a log handler that allows us to captured logged messages to a python list
+class ListHandler(logging.Handler):
+    def __init__(self, log_list):
+        super().__init__()
+        self.log_list = log_list
+
+    def emit(self, record):
+        self.log_list.append(self.format(record))
+
+
+logger = logging.getLogger("splink")
+
+
+data_one = [
+    {
+        "unique_id": "a0",
+        "first_name": "Julia ",
+        "surname": "Taylor",
+        "dob": "2015-07-31",
+        "city": "London",
+        "email": "hannah88@powers.com",
+        "group": "0",
+    },
+    {
+        "unique_id": "a1",
+        "first_name": "Juli",
+        "surname": "Taylor",
+        "dob": "2015-07-31",
+        "city": "London",
+        "email": "hannah8@powers.com",
+        "group": "0",
+    },
+    {
+        "unique_id": "a2",
+        "first_name": "Julia ",
+        "surname": "Taylo",
+        "dob": "2015-07-31",
+        "city": "Lambeth",
+        "email": "hannah88@powers.com",
+        "group": "0",
+    },
+    {
+        "unique_id": "a3",
+        "first_name": "Juli",
+        "surname": "Taylor",
+        "dob": "2015-07-31",
+        "city": "Lambeth",
+        "email": "hannah88@powers.com",
+        "group": "0",
+    },
+]
+
+data_three = [
+    {
+        "unique_id": "b0",
+        "first_name": "Juli",
+        "surname": "Taylo",
+        "dob": "2015-07-31",
+        "city": "London",
+        "email": "hannah88@powers.com",
+        "group": "0",
+    },
+    {
+        "unique_id": "b1",
+        "first_name": "Juli",
+        "surname": "Taylor",
+        "dob": "2015-07-31",
+        "city": "London",
+        "email": "hannah8@powers.com",
+        "group": "0",
+    },
+    {
+        "unique_id": "b2",
+        "first_name": "Julia",
+        "surname": "Taylor",
+        "dob": "2015-07-31",
+        "city": "Lambeth",
+        "email": "hannah88@powers.com",
+        "group": "0",
+    },
+]
+
+
+def test_dedupe_only():
+
+    df_one = pd.DataFrame(data_one)
+
+    log_list = []
+    handler = ListHandler(log_list)
+    logger.addHandler(handler)
+
+    settings = {
+        "link_type": "dedupe_only",
+        "probability_two_random_records_match": 4 / 1000,
+        "blocking_rules_to_generate_predictions": [
+            "l.first_name = r.first_name",
+            "l.surname = r.surname",
+        ],
+        "comparisons": [
+            cl.exact_match("first_name"),
+            cl.exact_match("surname"),
+            cl.exact_match("dob"),
+            cl.exact_match("city", term_frequency_adjustments=True),
+            cl.exact_match("email"),
+        ],
+    }
+    linker = DuckDBLinker(
+        df_one,
+        settings,
+        set_up_basic_logging=False,
+    )
+    logging.getLogger("splink").setLevel(1)
+
+    linker.estimate_u_using_random_sampling(max_pairs=1000)
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+    assert (
+        "from __splink__df_concat_with_tf_sample as l inner join __splink__df_concat_with_tf_sample as r"  # noqa: E501
+        in all_log_messages
+    )
+
+    handler.log_list.clear()
+
+    linker.predict()
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+
+    assert (
+        "from __splink__df_concat_with_tf as l inner join __splink__df_concat_with_tf as r"  # noqa: E501
+        in all_log_messages
+    )
+
+
+def test_link_and_dedupe():
+
+    df_one = pd.DataFrame(data_one)
+    df_two = pd.read_csv("tests/datasets/fake_1000_from_splink_demos.csv")
+
+    log_list = []
+    handler = ListHandler(log_list)
+    logger.addHandler(handler)
+    settings = {
+        "link_type": "link_and_dedupe",
+        "probability_two_random_records_match": 4 / 1000,
+        "blocking_rules_to_generate_predictions": [
+            "l.first_name = r.first_name",
+            "l.surname = r.surname",
+        ],
+        "comparisons": [
+            cl.exact_match("first_name"),
+            cl.exact_match("surname"),
+            cl.exact_match("dob"),
+            cl.exact_match("city", term_frequency_adjustments=True),
+            cl.exact_match("email"),
+        ],
+    }
+    linker = DuckDBLinker(
+        [df_one, df_two],
+        settings,
+        input_table_aliases=["df_one", "df_two"],
+        set_up_basic_logging=False,
+    )
+
+    handler.log_list.clear()
+
+    linker.estimate_u_using_random_sampling(max_pairs=1000)
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+    assert (
+        "from __splink__df_concat_with_tf_sample as l inner join __splink__df_concat_with_tf_sample as r"  # noqa: E501
+        in all_log_messages
+    )
+
+    log_list.clear()
+
+    linker.predict()
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+
+    assert (
+        "from __splink__df_concat_with_tf as l inner join __splink__df_concat_with_tf as r"  # noqa: E501
+        in all_log_messages
+    )
+
+
+def test_link_only_two():
+
+    df_one = pd.DataFrame(data_one)
+    df_two = pd.read_csv("tests/datasets/fake_1000_from_splink_demos.csv")
+
+    log_list = []
+    handler = ListHandler(log_list)
+    logger.addHandler(handler)
+
+    settings = {
+        "link_type": "link_only",
+        "probability_two_random_records_match": 4 / 1000,
+        "blocking_rules_to_generate_predictions": [
+            "l.first_name = r.first_name",
+            "l.surname = r.surname",
+        ],
+        "comparisons": [
+            cl.exact_match("first_name"),
+            cl.exact_match("surname"),
+            cl.exact_match("dob"),
+            cl.exact_match("city", term_frequency_adjustments=True),
+            cl.exact_match("email"),
+        ],
+    }
+    linker = DuckDBLinker(
+        [df_one, df_two],
+        settings,
+        input_table_aliases=["df_one", "df_two"],
+        set_up_basic_logging=False,
+    )
+
+    log_list.clear()
+
+    linker.estimate_u_using_random_sampling(max_pairs=1000)
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+    assert (
+        "from __splink__df_concat_with_tf_sample_left as l inner join __splink__df_concat_with_tf_sample_right as r"  # noqa: E501
+        in all_log_messages
+    )
+
+    log_list.clear()
+
+    linker.predict()
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+
+    assert (
+        "from __splink__df_concat_with_tf_left as l inner join __splink__df_concat_with_tf_right as r"  # noqa: E501
+        in all_log_messages
+    )
+
+
+def test_link_only_three():
+
+    df_one = pd.DataFrame(data_one)
+    df_two = pd.read_csv("tests/datasets/fake_1000_from_splink_demos.csv")
+    df_three = pd.DataFrame(data_three)
+
+    log_list = []
+    handler = ListHandler(log_list)
+    logger.addHandler(handler)
+
+    settings = {
+        "link_type": "link_only",
+        "probability_two_random_records_match": 4 / 1000,
+        "blocking_rules_to_generate_predictions": [
+            "l.first_name = r.first_name",
+            "l.surname = r.surname",
+        ],
+        "comparisons": [
+            cl.exact_match("first_name"),
+            cl.exact_match("surname"),
+            cl.exact_match("dob"),
+            cl.exact_match("city", term_frequency_adjustments=True),
+            cl.exact_match("email"),
+        ],
+    }
+    linker = DuckDBLinker(
+        [df_one, df_two, df_three],
+        settings,
+        input_table_aliases=["df_one", "df_two", "df_three"],
+        set_up_basic_logging=False,
+    )
+
+    log_list.clear()
+
+    linker.estimate_u_using_random_sampling(max_pairs=1000)
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+    assert (
+        "from __splink__df_concat_with_tf_sample as l inner join __splink__df_concat_with_tf_sample as r"  # noqa: E501
+        in all_log_messages
+    )
+
+    log_list.clear()
+
+    linker.predict()
+
+    all_log_messages = "\n".join(log_list)
+    all_log_messages = re.sub(r"\s+", " ", all_log_messages)
+
+    assert (
+        "from __splink__df_concat_with_tf as l inner join __splink__df_concat_with_tf as r"  # noqa: E501
+        in all_log_messages
+    )

--- a/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
+++ b/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
@@ -72,7 +72,7 @@ data_three = [
     {
         "unique_id": "b1",
         "first_name": "Juli",
-        "surname": "Taylor",
+        "surname": "Taylr",
         "dob": "2015-07-31",
         "city": "London",
         "email": "hannah8@powers.com",


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

Closes #1225 - see the issue for a detailed description of the underlying cause of the problem

Built on top of #1059 so let's get that merged first, then we can point this at `master`

### Give a brief description for the solution you have provided

The challenge is that for a link only, it's much more efficient to run sql like:
```
select ...
from df_one
inner join
df_two
[where conditions]
```

rather than concatenating the two and running:
```
select ...
from dfs_concat as l
inner join
dfs_concat as r
where l.source_dataset != r.source_dataset
[other where conditions]
```

The later  is inefficient because intra-dataset comparisons are generated and then rejected, rather than never being generated.

The efficient solution is fine for the n=2 case, but in n=3 you'd need (pseudocode):
```
df_one inner join df_two
union all
df_one inner join df_three
union all
df_two inner join df_three
```

This statement will quickly become unmanageable as n grows

Options:

1.  Could try to implement a left join approach for the n=2 case (which is most common).  This is relatively straightforward in the case of 2 input datasets, but results in n choose 2 joins in the more general case of n datasets.

Pros:

- Consistent with the approach I currently use for blocking. 

Cons:
- Doesn't solve the n>2 case.

2. In the case if unbalanced datasets, (we could test when the ratio of target rows to total comparisons is poor), change link_type to 'link and dedupe' for the purpose of estimating u

Pros:
- Generalise to n>2

Cons:
- Questionable estimates of u


### Conclusion

For the moment I've gone with option 1 since it preserves the quality of estimates.

Note that the code still works for n>2, it just uses the less inefficient `where l.source_dataset != r.source_dataset` which is  n't too bad in most cases, but gets extremely bad in the case of very unbalanced datsets.


### PR Checklist

- [ ] Added tests (if appropriate)



