### PR TITLE
Add a timer into debug mode

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import time
 import warnings
 from copy import copy, deepcopy
 from pathlib import Path
@@ -64,6 +65,7 @@ from .misc import (
     ensure_is_list,
     ensure_is_tuple,
     find_unique_source_dataset,
+    parse_duration,
     prob_to_bayes_factor,
 )
 from .missingness import completeness_data, missingness_data
@@ -557,6 +559,7 @@ class Linker:
             # In debug mode, we do not pipeline the sql and print the
             # results of each part of the pipeline
             for task in self._pipeline._generate_pipeline_parts(input_dataframes):
+                start_time = time.time()
                 output_tablename = task.output_table_name
                 sql = task.sql
                 print("------")
@@ -567,6 +570,8 @@ class Linker:
                     output_tablename,
                     use_cache=False,
                 )
+                run_time = parse_duration(time.time() - start_time)
+                print(f"Step ran in: {run_time}")
             self._pipeline.reset()
             return dataframe
 
@@ -3181,7 +3186,6 @@ class Linker:
         return splink_dataframe
 
     def _remove_splinkdataframe_from_cache(self, splink_dataframe: SplinkDataFrame):
-
         keys_to_delete = set()
         for key, df in self._intermediate_table_cache.items():
             if df.physical_name == splink_dataframe.physical_name:

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -1,7 +1,9 @@
 import json
 import random
 import string
-from math import inf, log2
+from collections import namedtuple
+from datetime import datetime, timedelta
+from math import ceil, inf, log2
 from typing import Iterable
 
 import numpy as np
@@ -171,3 +173,17 @@ def find_unique_source_dataset(src_ds):
     """
 
     return sql
+
+
+def parse_duration(duration: int):
+    # math.ceil so <1 second gets reported
+    d = datetime(1, 1, 1) + timedelta(seconds=int(ceil(duration)))
+    time_index = namedtuple("Time", ["Days", "Hours", "Minutes", "Seconds"])
+    duration = time_index(d.day - 1, d.hour, d.minute, d.second)
+    txt_duration = [
+        f"{t} {duration._fields[n]}" for n, t in enumerate(duration) if t > 0
+    ]
+    if len(txt_duration) > 1:
+        txt_duration[-1] = "and " + txt_duration[-1]
+
+    return ", ".join(txt_duration)


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Give a brief description for the solution you have provided
This adds a quick timer output for each step in debug mode. This should allows us to more quickly and easily evaluate which steps are causing slowdown or to more easily check if changes have made a difference to performance.

The timer output could be cleaned up, but given that we're the only people that should be using this feature, I haven't spent any time on it.

The current output for each step looks like so:
![Screenshot 2023-06-26 at 14 05 12](https://github.com/moj-analytical-services/splink/assets/45356472/f24e4518-5a9e-4bdf-8b1a-75f80c0aca22)

You can check the time parser using:
```python
from splink.misc import parse_duration

parse_duration(1000)
parse_duration(1)
parse_duration(100000)
... etc
```