### PR TITLE
[BUG] fix how nulls are registered in pyspark when loading a pandas df

### DIFF
--- a/splink/spark/linker.py
+++ b/splink/spark/linker.py
@@ -466,15 +466,17 @@ class SparkLinker(Linker):
     def _table_registration(self, input, table_name):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
-            input = self.spark.createDataFrame(input)
         elif isinstance(input, list):
             input = pd.DataFrame.from_records(input)
-            input = self.spark.createDataFrame(input)
-        elif isinstance(input, pd.DataFrame):
-            input = input.fillna(nan).replace([nan], [None])
+
+        if isinstance(input, pd.DataFrame):
+            input = self._clean_pandas_df(input)
             input = self.spark.createDataFrame(input)
 
         input.createOrReplaceTempView(table_name)
+
+    def _clean_pandas_df(self, df):
+        return df.fillna(nan).replace([nan, pd.NA], [None, None])
 
     def _random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None

--- a/splink/spark/linker.py
+++ b/splink/spark/linker.py
@@ -8,6 +8,7 @@ from itertools import compress
 
 import pandas as pd
 import sqlglot
+from numpy import nan
 from pyspark.sql.dataframe import DataFrame as spark_df
 from pyspark.sql.types import DoubleType, StringType
 from pyspark.sql.utils import AnalysisException
@@ -470,6 +471,7 @@ class SparkLinker(Linker):
             input = pd.DataFrame.from_records(input)
             input = self.spark.createDataFrame(input)
         elif isinstance(input, pd.DataFrame):
+            input = input.fillna(nan).replace([nan], [None])
             input = self.spark.createDataFrame(input)
 
         input.createOrReplaceTempView(table_name)

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -1,6 +1,8 @@
 import os
 
+import pandas as pd
 import pyspark.sql.functions as f
+import pytest
 from pyspark.sql.types import StringType, StructField, StructType
 
 import splink.spark.comparison_level_library as cll
@@ -8,6 +10,7 @@ import splink.spark.comparison_library as cl
 from splink.spark.linker import SparkLinker
 
 from .basic_settings import get_settings_dict, name_comparison
+from .decorator import mark_with_dialects_including
 from .linker_utils import (
     _test_write_functionality,
     register_roc_data,
@@ -167,3 +170,25 @@ def test_link_only(df_spark):
     assert len(df_predict) == 7257
     assert set(df_predict.source_dataset_l.values) == {"my_left_ds"}
     assert set(df_predict.source_dataset_r.values) == {"my_right_ds"}
+
+
+@pytest.mark.parametrize(
+    ("df"),
+    [
+        pytest.param(
+            pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv"),
+            id="Spark load from pandas df",
+        )
+    ],
+)
+@mark_with_dialects_including("spark")
+def test_spark_load_from_file(df, spark):
+    settings = get_settings_dict()
+
+    linker = SparkLinker(
+        df,
+        settings,
+        spark=spark,
+    )
+
+    assert len(linker.predict().as_pandas_dataframe()) == 3167


### PR DESCRIPTION
### Type of PR

- [x] BUG

### Give a brief description for the solution you have provided
A small fix to adjust how nulls/nans are registered in pyspark when using `createDataFrame` (as we do in `register_table`).

This simply fills any nulls that are found with `np.nan` and should fix the issue at the cost of computational cost.

Given that we recommend users feed the `SparkLinker` a spark df, I think it's fine to go with this approach as it will rarely trigger.


