### PR TITLE
Add dataset table generation script to docs workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -64,11 +64,13 @@ jobs:
       - name: Install library
         run: poetry install --no-interaction
 
-      - name: Generate comparison/level library dialect tables
+      - name: Generate comparison/level library dialect + dataset tables
         run: |
           source .venv/bin/activate
           mv scripts/generate_dialect_comparison_docs.py generate_dialect_comparison_docs.py
+          mv scripts/generate_dataset_docs.py generate_dataset_docs.py
           python generate_dialect_comparison_docs.py
+          python generate_dataset_docs.py
 
       - name: Upload generated docs files
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Thanks to @RossKen for pointing this issue out (and actually checking my update to live docs site 😶‍🌫️ )

New automated dataset table (from #1358) was not in fact automated.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
Doc-building CI does not use the local build script, and I neglected to update the workflow file to include the generation of this dataset table. This PR fixes that.

Have tested this out by running the action (on a different branch) - see the relevant part of the built page [here](https://github.com/ADBond/splink/blob/gh-pages/datasets.html#L2708-L2727).


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


