### PR TITLE
add splink demos branch flag to local docs build

### DIFF
--- a/docs/dev_guides/changing_splink/build_docs_locally.md
+++ b/docs/dev_guides/changing_splink/build_docs_locally.md
@@ -8,77 +8,90 @@ source scripts/make_docs_locally.sh
 
 This is much faster than waiting for github actions to run if you're trying to make fiddly changes to formatting etc.
 
+
 The Splink repo contains a [working `requirements.txt` for building the docs](https://github.com/moj-analytical-services/splink/scripts/docs-requirements.txt), or a more complete version:
 
+??? note "requirements.txt"
+    ```
+    attrs==22.2.0
+    beautifulsoup4==4.11.2
+    bleach==6.0.0
+    certifi==2022.12.7
+    charset-normalizer==3.0.1
+    click==8.1.3
+    colorama==0.4.6
+    defusedxml==0.7.1
+    EditorConfig==0.12.3
+    fastjsonschema==2.16.2
+    ghp-import==2.1.0
+    gitdb==4.0.10
+    GitPython==3.1.31
+    griffe==0.25.5
+    idna==3.4
+    importlib-metadata==6.0.0
+    Jinja2==3.0.3
+    jsbeautifier==1.14.7
+    jsonschema==4.17.3
+    jsonschema2md==0.4.0
+    jupyter_client==8.0.3
+    jupyter_core==5.2.0
+    jupyterlab-pygments==0.2.2
+    Markdown==3.3.7
+    MarkupSafe==2.1.2
+    mergedeep==1.3.4
+    mistune==2.0.5
+    mkdocs==1.4.2
+    mkdocs-autorefs==0.4.1
+    mkdocs-click==0.8.0
+    mkdocs-gen-files==0.4.0
+    mkdocs-include-markdown-plugin==4.0.3
+    mkdocs-material==8.5.11
+    mkdocs-material-extensions==1.1.1
+    mkdocs-mermaid2-plugin==0.6.0
+    mkdocs-monorepo-plugin==1.0.4
+    mkdocs-schema-reader==0.11.1
+    mkdocs-semiliterate==0.7.0
+    mkdocs-simple-plugin==2.1.2
+    mkdocstrings==0.20.0
+    mkdocstrings-python==0.8.3
+    mkdocstrings-python-legacy==0.2.3
+    mknotebooks==0.7.1
+    nbclient==0.7.2
+    nbconvert==7.2.9
+    nbformat==5.7.3
+    packaging==23.0
+    pandocfilters==1.5.0
+    platformdirs==3.0.0
+    Pygments==2.14.0
+    pymdown-extensions==9.9.2
+    pyrsistent==0.19.3
+    python-dateutil==2.8.2
+    python-slugify==8.0.0
+    pytkdocs==0.16.1
+    PyYAML==6.0
+    pyyaml_env_tag==0.1
+    pyzmq==25.0.0
+    requests==2.28.2
+    six==1.16.0
+    smmap==5.0.0
+    soupsieve==2.4
+    text-unidecode==1.3
+    tinycss2==1.2.1
+    tornado==6.2
+    traitlets==5.9.0
+    urllib3==1.26.14
+    watchdog==2.2.1
+    webencodings==0.5.1
+    zipp==3.14.0
+    ```
+
+## Making changes to Tutorial and Example notebooks
+
+The Splink [tutorial](/demos/00_Tutorial_Introduction.html) and [example notebooks](/examples_index.html) are stored in a separate [splink_demos repo](https://github.com/moj-analytical-services/splink_demos). 
+
+This split can make it difficult to make changes to tutorials and examples as you cannot see how they are rendered in the docs site. The code below builds the docs with the tutorials and example notebooks from a feature branch `splink-demos-branch-name`, so that you can check the docs rendering before merging into master in splink_demos.
+
+```sh
+source scripts/make_docs_locally.sh splink-demos-branch-name
 ```
-attrs==22.2.0
-beautifulsoup4==4.11.2
-bleach==6.0.0
-certifi==2022.12.7
-charset-normalizer==3.0.1
-click==8.1.3
-colorama==0.4.6
-defusedxml==0.7.1
-EditorConfig==0.12.3
-fastjsonschema==2.16.2
-ghp-import==2.1.0
-gitdb==4.0.10
-GitPython==3.1.31
-griffe==0.25.5
-idna==3.4
-importlib-metadata==6.0.0
-Jinja2==3.0.3
-jsbeautifier==1.14.7
-jsonschema==4.17.3
-jsonschema2md==0.4.0
-jupyter_client==8.0.3
-jupyter_core==5.2.0
-jupyterlab-pygments==0.2.2
-Markdown==3.3.7
-MarkupSafe==2.1.2
-mergedeep==1.3.4
-mistune==2.0.5
-mkdocs==1.4.2
-mkdocs-autorefs==0.4.1
-mkdocs-click==0.8.0
-mkdocs-gen-files==0.4.0
-mkdocs-include-markdown-plugin==4.0.3
-mkdocs-material==8.5.11
-mkdocs-material-extensions==1.1.1
-mkdocs-mermaid2-plugin==0.6.0
-mkdocs-monorepo-plugin==1.0.4
-mkdocs-schema-reader==0.11.1
-mkdocs-semiliterate==0.7.0
-mkdocs-simple-plugin==2.1.2
-mkdocstrings==0.20.0
-mkdocstrings-python==0.8.3
-mkdocstrings-python-legacy==0.2.3
-mknotebooks==0.7.1
-nbclient==0.7.2
-nbconvert==7.2.9
-nbformat==5.7.3
-packaging==23.0
-pandocfilters==1.5.0
-platformdirs==3.0.0
-Pygments==2.14.0
-pymdown-extensions==9.9.2
-pyrsistent==0.19.3
-python-dateutil==2.8.2
-python-slugify==8.0.0
-pytkdocs==0.16.1
-PyYAML==6.0
-pyyaml_env_tag==0.1
-pyzmq==25.0.0
-requests==2.28.2
-six==1.16.0
-smmap==5.0.0
-soupsieve==2.4
-text-unidecode==1.3
-tinycss2==1.2.1
-tornado==6.2
-traitlets==5.9.0
-urllib3==1.26.14
-watchdog==2.2.1
-webencodings==0.5.1
-zipp==3.14.0
-```
+

--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -5,10 +5,13 @@
 # python scripts/generate_dialect_comparison_docs.py
 
 UPDATE="TRUE"
-if [[ $UPDATE == "TRUE" ]]
-then
+if [[ $UPDATE == "TRUE" ]]; then
     rm -rf docs/demos/
-    git clone https://github.com/moj-analytical-services/splink_demos.git docs/demos/
+    if [ -n "$1" ]; then
+        git clone -b $1 --single-branch https://github.com/moj-analytical-services/splink_demos.git docs/demos/
+    else
+        git clone https://github.com/moj-analytical-services/splink_demos.git docs/demos/
+    fi
 fi
 
 deactivate


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [X] FEAT
- [ ] MAINT
- [X] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
N/A


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
Changing tutorials and examples in splink_demos is annoying as you cannot easily render them in the doc site to check everything is working. This PR adds a flag to allow users to specify a branch name from splink demos to pull the tutorial and example notebooks from.


```sh
source scripts/make_docs_locally.sh splink-demos-branch-name
```


### PR Checklist

- [X] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


