### PR TITLE
Fix issue 1414

### DIFF
--- a/splink/find_matches_to_new_records.py
+++ b/splink/find_matches_to_new_records.py
@@ -10,15 +10,19 @@ def add_unique_id_and_source_dataset_cols_if_needed(
 ):
     cols = new_records_df.columns
 
-    sds_col, _ = linker._settings_obj._source_dataset_col
-
+    # Add source dataset column to new records if required and not exists
     sds_sel_sql = ""
-    if sds_col not in cols:
-        sds_sel_sql = f", 'new_record' as {sds_col}"
+    if linker._settings_obj._source_dataset_column_name_is_required:
+        sds_col, _ = linker._settings_obj._source_dataset_col
 
+        if sds_col not in cols:
+            sds_sel_sql = f", 'new_record' as {sds_col}"
+
+    # Add unique_id column to new records if not exists
+    uid_sel_sql = ""
     uid_col = linker._settings_obj._unique_id_column_name
     if uid_col not in cols:
-        uid_sel_sql = f", 'no_id_provided' as {uid_col}, 'new_record' as {sds_col}"
+        uid_sel_sql = f", 'no_id_provided' as {uid_col}"
 
     sql = f"""
         select * {sds_sel_sql} {uid_sel_sql}

--- a/splink/find_matches_to_new_records.py
+++ b/splink/find_matches_to_new_records.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from .input_column import InputColumn
+
 if TYPE_CHECKING:
     from .linker import Linker
     from .splink_dataframe import SplinkDataFrame
@@ -9,18 +11,25 @@ def add_unique_id_and_source_dataset_cols_if_needed(
     linker: "Linker", new_records_df: "SplinkDataFrame"
 ):
     cols = new_records_df.columns
+    cols = [c.unquote().name() for c in cols]
 
     # Add source dataset column to new records if required and not exists
     sds_sel_sql = ""
     if linker._settings_obj._source_dataset_column_name_is_required:
-        sds_col, _ = linker._settings_obj._source_dataset_col
+        sds_col = linker._settings_obj._source_dataset_input_column
 
+        # TODO: Shouldn't be necessary but the source dataset properties on settings
+        # are currently broken
+        sds_col = InputColumn(sds_col, linker._settings_obj)
+        sds_col = sds_col.unquote().name()
         if sds_col not in cols:
             sds_sel_sql = f", 'new_record' as {sds_col}"
 
     # Add unique_id column to new records if not exists
     uid_sel_sql = ""
     uid_col = linker._settings_obj._unique_id_column_name
+    uid_col = InputColumn(uid_col, linker._settings_obj)
+    uid_col = uid_col.unquote().name()
     if uid_col not in cols:
         uid_sel_sql = f", 'no_id_provided' as {uid_col}"
 

--- a/splink/find_matches_to_new_records.py
+++ b/splink/find_matches_to_new_records.py
@@ -18,7 +18,7 @@ def add_unique_id_and_source_dataset_cols_if_needed(
 
     uid_col = linker._settings_obj._unique_id_column_name
     if uid_col not in cols:
-        uid_sel_sql = f", 'id' as {uid_col}, 'new_record' as {sds_col}"
+        uid_sel_sql = f", 'no_id_provided' as {uid_col}, 'new_record' as {sds_col}"
 
     sql = f"""
         select * {sds_sel_sql} {uid_sel_sql}

--- a/splink/find_matches_to_new_records.py
+++ b/splink/find_matches_to_new_records.py
@@ -1,0 +1,24 @@
+from splink.linker import Linker
+from splink.splink_dataframe import SplinkDataFrame
+
+
+def add_unique_id_and_source_dataset_cols_if_needed(
+    linker: Linker, new_records_df: SplinkDataFrame
+):
+    cols = new_records_df.columns
+
+    sds_col, _ = linker._settings_obj._source_dataset_col
+
+    sds_sel_sql = ""
+    if sds_col not in cols:
+        sds_sel_sql = f", 'new_record' as {sds_col}"
+
+    uid_col = linker._settings_obj._unique_id_column_name
+    if uid_col not in cols:
+        uid_sel_sql = f", 'id' as {uid_col}, 'new_record' as {sds_col}"
+
+    sql = f"""
+        select * {sds_sel_sql} {uid_sel_sql}
+        from  __splink__df_new_records_with_tf_before_uid_fix
+        """
+    linker._enqueue_sql(sql, "__splink__df_new_records_with_tf")

--- a/splink/find_matches_to_new_records.py
+++ b/splink/find_matches_to_new_records.py
@@ -1,9 +1,12 @@
-from splink.linker import Linker
-from splink.splink_dataframe import SplinkDataFrame
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .linker import Linker
+    from .splink_dataframe import SplinkDataFrame
 
 
 def add_unique_id_and_source_dataset_cols_if_needed(
-    linker: Linker, new_records_df: SplinkDataFrame
+    linker: "Linker", new_records_df: "SplinkDataFrame"
 ):
     cols = new_records_df.columns
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -52,6 +52,7 @@ from .connected_components import (
 from .em_training_session import EMTrainingSession
 from .estimate_u import estimate_u_values
 from .exceptions import SplinkException
+from .find_matches_to_new_records import add_unique_id_and_source_dataset_cols_if_needed
 from .labelling_tool import (
     generate_labelling_tool_comparisons,
     render_labelling_tool_html,
@@ -1761,10 +1762,14 @@ class Linker:
         else:
             new_records_tablename = records_or_tablename
 
+        new_records_df = self._table_to_splink_dataframe(
+            "__splink__df_new_records", new_records_tablename
+        )
+
         cache = self._intermediate_table_cache
         input_dfs = []
-        # If our df_concat_with_tf table already exists, use backwards inference to
-        # find all underlying term frequency tables.
+        # If our df_concat_with_tf table already exists, derive the term frequency
+        # tables from df_concat_with_tf rather than computing them
         if "__splink__df_concat_with_tf" in cache:
             concat_with_tf = cache["__splink__df_concat_with_tf"]
             tf_tables = compute_term_frequencies_from_concat_with_tf(self)
@@ -1795,7 +1800,9 @@ class Linker:
 
         sql = _join_tf_to_input_df_sql(self)
         sql = sql.replace("__splink__df_concat", new_records_tablename)
-        self._enqueue_sql(sql, "__splink__df_new_records_with_tf")
+        self._enqueue_sql(sql, "__splink__df_new_records_with_tf_before_uid_fix")
+
+        add_unique_id_and_source_dataset_cols_if_needed(self, new_records_df)
 
         sql = block_using_rules_sql(self)
         self._enqueue_sql(sql, "__splink__df_blocked")


### PR DESCRIPTION
## Issue 
If you run code like:

```python
settings = {   
    "link_type": "link_only",
    "comparisons": [
        exact_match("first_name"),
        exact_match("surname"),
    ],
}

rec = {
    "first_name": "robin",
    "surname": "linacre",
}

linker.find_matches_to_new_records(
    [rec], match_weight_threshold=-1000000
).as_pandas_dataframe()

```

you get an error like:
```
Error was: Binder Error: Values list "r" does not have a column named "source_dataset"
```
or
```
Error was: Binder Error: Values list "r" does not have a column named "unique_id"
```

This is frustrating from the users point of view because:
- It's not obvious they should need to set a source_dataset column
- If they realised it's needed, it's not obvious what the value should be 
- Similar with the ID, it's not obvious it's needed or what it should be

See #1414  for bug report.

---




<details><summary>Testing script:</summary>

```python
import pandas as pd
import logging
from splink.duckdb.comparison_library import jaro_winkler_at_thresholds
from splink.duckdb.linker import DuckDBLinker

records_l = [
    {"uid": 1, "first_name": "robin", "surname": "linacre"},
    {"uid": 2, "first_name": "james", "surname": "booth"},
]

records_r = [
    {"uid": 3, "first_name": "robin", "surname": "linacre"},
    {"uid": 4, "first_name": "rob", "surname": "linaker"},
    {"uid": 5, "first_name": "john", "surname": "smith"},
]

df_l = pd.DataFrame(records_l)
df_r = pd.DataFrame(records_r)
df = pd.concat([df_l, df_r])

settings = {
    "probability_two_random_records_match": 0.01,
    "unique_id_column_name": "uid",
    "source_dataset_column_name": "src_dtaset",
    "link_type": "link_only",
    "blocking_rules_to_generate_predictions": ["1=1"],
    "comparisons": [
        jaro_winkler_at_thresholds("first_name", [0.9, 0.8]),
        jaro_winkler_at_thresholds("surname", [0.9, 0.8]),
    ],
    "retain_intermediate_calculation_columns": True,
}

linker = DuckDBLinker([df_l, df_r], settings)

linker.predict().as_pandas_dataframe()


logging.getLogger("splink").setLevel(1)
rec = {
    "first_name": "robin",
    "surname": "linacre",
}

linker.find_matches_to_new_records(
    [rec], match_weight_threshold=-1000000
).as_pandas_dataframe()


settings = {
    "probability_two_random_records_match": 0.01,
    "unique_id_column_name": "uid",
    "source_dataset_column_name": "src_dtaset",
    "link_type": "dedupe_only",
    "blocking_rules_to_generate_predictions": ["1=1"],
    "comparisons": [
        jaro_winkler_at_thresholds("first_name", [0.9, 0.8]),
        jaro_winkler_at_thresholds("surname", [0.9, 0.8]),
    ],
    "retain_intermediate_calculation_columns": True,
}

linker = DuckDBLinker(df, settings)


rec = {
    "first_name": "robin",
    "surname": "linacre",
}

linker.find_matches_to_new_records(
    [rec], match_weight_threshold=-1000000
).as_pandas_dataframe()

```

</details>



