### PR TITLE
run actions on `_dev` branches

### DIFF
--- a/.github/workflows/pytest_postgres.yml
+++ b/.github/workflows/pytest_postgres.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - '**dev'
 
 jobs:
   test:

--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - '**dev'
 
 jobs:
   test:


### PR DESCRIPTION
A quick one for you - this adds tests to PRs pointing at branches ending in `dev`.

This should mean we can use `dev` branches more flexibly going forward.