### PR TITLE
ref: Remove pre-check for path when loading file

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1068,11 +1068,6 @@ class Linker:
 
         if not isinstance(settings_dict, dict):
             p = Path(settings_dict)
-            if not p.is_file():  # check if it's a valid file/filepath
-                raise FileNotFoundError(
-                    "The filepath you have provided is either not a valid file "
-                    "or doesn't exist along the path provided."
-                )
             settings_dict = json.loads(p.read_text())
 
         # Store the cache ID so it can be reloaded after cache invalidation


### PR DESCRIPTION
first, I don't think this is needed: if the file isn't valid
the p.read_text() is going to fail.

Second, this makes the error useless, because it doesn't
say what path I tried to access. Just let the
.read_text() fail, and that
error will contain the path.

### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->



### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


