### PR TITLE
[FEAT] Add initial implementation of Redshift linker

### DIFF
--- a/splink/redshift/comparison_level_library.py
+++ b/splink/redshift/comparison_level_library.py
@@ -1,0 +1,12 @@
+from ..comparison_level_composition import and_, not_, or_  # noqa: F401
+from .redshift_helpers.redshift_comparison_imports import (  # noqa: F401
+    array_intersect_level,
+    columns_reversed_level,
+    distance_function_level,
+    distance_in_km_level,
+    else_level,
+    exact_match_level,
+    levenshtein_level,
+    null_level,
+    percentage_difference_level,
+)

--- a/splink/redshift/comparison_library.py
+++ b/splink/redshift/comparison_library.py
@@ -1,0 +1,7 @@
+from .redshift_helpers.redshift_comparison_imports import (  # noqa: F401
+    array_intersect_at_sizes,
+    distance_function_at_thresholds,
+    distance_in_km_at_thresholds,
+    exact_match,
+    levenshtein_at_thresholds,
+)

--- a/splink/redshift/comparison_template_library.py
+++ b/splink/redshift/comparison_template_library.py
@@ -1,0 +1,13 @@
+# Not all Comparison Template Library functions are currently implemented
+# for Redshift due to limited string matching capability in
+# cll.comparison_level_library
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+logger.warning(
+    "The Comparison Template Library is not currently implemented "
+    "for Redshift due to limited string matching capability in "
+    "`cll.comparison_level_library`"
+)

--- a/splink/redshift/linker.py
+++ b/splink/redshift/linker.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from ..input_column import InputColumn
+from ..linker import Linker
+from ..misc import ensure_is_list
+from ..splink_dataframe import SplinkDataFrame
+from ..sql_transform import sqlglot_transform_sql
+from ..unique_id_concat import _composite_unique_id_from_nodes_sql
+from .redshift_helpers.redshift_transforms import add_frame_clause
+
+logger = logging.getLogger(__name__)
+
+
+class RedshiftDataFrame(SplinkDataFrame):
+    linker: RedshiftLinker
+
+    def __init__(self, df_name, physical_name, linker):
+        super().__init__(df_name, physical_name, linker)
+        self._db_schema = linker._db_schema
+        self.physical_name = f"{self.physical_name}"
+
+    @property
+    def columns(self) -> list[InputColumn]:
+        sql = f"""
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = '{self.physical_name}'
+        OR table_schema || '.' || table_name = '{self.physical_name}'
+        OR (
+            table_catalog || '.' ||
+            table_schema || '.' ||
+            table_name
+        ) = '{self.physical_name}';
+        """
+        res = self.linker._run_sql_execution(sql).fetchall()
+        cols = [r["column_name"] for r in res]
+
+        return [InputColumn(c, sql_dialect="postgres") for c in cols]
+
+    def validate(self):
+        if type(self.physical_name) is not str:
+            raise ValueError(
+                f"{self.df_name} is not a string dataframe.\n"
+                "Redshift Linker requires input data"
+                " to be a string containing the name of the"
+                " redshift table."
+            )
+
+        sql = f"""
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_name = '{self.physical_name}'
+        OR table_schema || '.' || table_name = '{self.physical_name}'
+        OR (
+            table_catalog || '.' ||
+            table_schema || '.' ||
+            table_name
+        ) = '{self.physical_name}';
+        """
+
+        res = self.linker._run_sql_execution(sql).fetchall()
+        if len(res) == 0:
+            raise ValueError(
+                f"{self.physical_name} does not exist in the redshift db provided.\n"
+                "Redshift Linker requires input data"
+                " to be a string containing the name of a"
+                " redshift table that exists in the provided db."
+            )
+
+    def _drop_table_from_database(self, force_non_splink_table=False):
+        self._check_drop_table_created_by_splink(force_non_splink_table)
+        self.linker._delete_table_from_database(self.physical_name)
+
+    def as_record_dict(self, limit=None):
+        sql = f"""
+        SELECT *
+        FROM {self.physical_name}
+        """
+        if limit:
+            sql += f" LIMIT {limit}"
+        sql += ";"
+        res = self.linker._run_sql_execution(sql).mappings().all()
+        return [dict(r) for r in res]
+
+
+class RedshiftLinker(Linker):
+    def __init__(
+        self,
+        input_table_or_tables,
+        settings_dict=None,
+        engine: Engine = None,
+        set_up_basic_logging=True,
+        input_table_aliases: str | list = None,
+        schema="splink",
+    ):
+        self._sql_dialect_ = "postgres"
+        if not isinstance(engine, Engine):
+            raise ValueError(
+                "You must supply a sqlalchemy engine " "to create a RedshiftLinker."
+            )
+
+        self._engine = engine
+        input_tables = ensure_is_list(input_table_or_tables)
+        input_aliases = self._ensure_aliases_populated_and_is_list(
+            input_table_or_tables, input_table_aliases
+        )
+        accepted_df_dtypes = pd.DataFrame
+        self._db_schema = schema
+
+        # Create custom SQL functions in database
+        self._register_custom_functions()
+
+        # Create splink schema
+        self._create_splink_schema()
+
+        super().__init__(
+            input_tables,
+            settings_dict,
+            accepted_df_dtypes,
+            set_up_basic_logging,
+            input_table_aliases=input_aliases,
+        )
+
+    def _table_to_splink_dataframe(self, templated_name, physical_name):
+        return RedshiftDataFrame(templated_name, physical_name, self)
+
+    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
+        # In the case of a table already existing in the database,
+        # execute sql is only reached if the user has explicitly turned off the cache
+        self._delete_table_from_database(physical_name)
+        sql = sqlglot_transform_sql(sql, add_frame_clause)
+
+        sql = f"CREATE TABLE {physical_name} AS {sql}"
+        self._log_and_run_sql_execution(sql, templated_name, physical_name)
+
+        return self._table_to_splink_dataframe(templated_name, physical_name)
+
+    def _run_sql_execution(
+        self, final_sql: str, templated_name: str = None, physical_name: str = None
+    ):
+        with self._engine.connect() as con:
+            res = con.execute(text(final_sql))
+        return res
+
+    def _table_registration(self, input, table_name):
+        if isinstance(input, dict):
+            input = pd.DataFrame(input)
+        elif isinstance(input, list):
+            input = pd.DataFrame.from_records(input)
+
+        # Will error if an invalid data type is passed
+        input.to_sql(
+            table_name,
+            con=self._engine,
+            index=False,
+            if_exists="replace",
+            schema=self._db_schema,
+        )
+
+    def register_table(self, input, table_name, overwrite=False):
+        # If the user has provided a table name, return it as a SplinkDataframe
+        if isinstance(input, str):
+            return self._table_to_splink_dataframe(table_name, input)
+
+        # Check if table name is already in use
+        exists = self._table_exists_in_database(table_name)
+        if exists:
+            if not overwrite:
+                raise ValueError(
+                    f"Table '{table_name}' already exists in database. "
+                    "Please use the 'overwrite' argument if you wish to overwrite"
+                )
+            else:
+                self._delete_table_from_database(table_name)
+
+        self._table_registration(input, table_name)
+        return self._table_to_splink_dataframe(table_name, table_name)
+
+    def _random_sample_sql(
+        self, proportion, sample_size, seed=None, table=None, unique_id=None
+    ):
+        if proportion == 1.0:
+            return ""
+        if seed:
+            # TODO: we could maybe do seeds by handling it in calling function
+            # need to execute setseed() in surrounding session
+            raise NotImplementedError(
+                "Redshift does not support seeds in random "
+                "samples. Please remove the `seed` parameter."
+            )
+
+        sample_size = int(sample_size)
+
+        if unique_id is None:
+            # unique_id col, with source_dataset column if needed to disambiguate
+            unique_id_cols = self._settings_obj._unique_id_input_columns
+            unique_id = _composite_unique_id_from_nodes_sql(unique_id_cols)
+        if table is None:
+            table = "__splink__df_concat_with_tf"
+        return (
+            f"WHERE {unique_id} IN ("
+            f"    SELECT {unique_id} FROM {table}"
+            f"    ORDER BY RANDOM() LIMIT {sample_size}"
+            f")"
+        )
+
+    @property
+    def _infinity_expression(self):
+        return "'infinity'"
+
+    def _table_exists_in_database(self, table_name):
+        sql = f"""
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_name = '{table_name}';
+        """
+
+        rec = self._run_sql_execution(sql).fetchall()
+        return len(rec) > 0
+
+    def _delete_table_from_database(self, name):
+        drop_sql = f"DROP TABLE IF EXISTS {name};"
+        self._run_sql_execution(drop_sql)
+
+    def _create_log2_function(self):
+        sql = """
+        CREATE OR REPLACE FUNCTION log2(float8)
+        RETURNS float8 AS $$
+        SELECT (log($1)/log(2))::float8
+        $$ LANGUAGE SQL IMMUTABLE;
+        """
+        self._run_sql_execution(sql)
+
+    def _register_custom_functions(self):
+        # if people have issues with permissions we can allow these to be optional
+        # need for predict_from_comparison_vectors_sql (could adjust)
+        self._create_log2_function()
+
+    def _create_splink_schema(self):
+        sql = f"""
+        CREATE SCHEMA IF NOT EXISTS {self._db_schema};
+        SET search_path TO {self._db_schema},public;
+        """
+        self._run_sql_execution(sql)
+
+    def drop_all_tables_created_by_splink(self, tables_to_exclude=[]):
+        sql = f"""SELECT table_name
+                FROM information_schema.tables
+                where table_schema = '{self._db_schema}';"""
+        results = self._run_sql_execution(sql).fetchall()
+        for res in results:
+            if res.table_name not in tables_to_exclude:
+                self._delete_table_from_database(res.table_name)

--- a/splink/redshift/redshift_comparison_level_library.py
+++ b/splink/redshift/redshift_comparison_level_library.py
@@ -1,0 +1,12 @@
+import warnings
+
+from ..exceptions import SplinkDeprecated
+from .comparison_level_library import *  # noqa: F403
+
+warnings.warn(
+    "Importing directly from `splink.redshift.redshift_comparison_level_library` "
+    "is deprecated and will be removed in Splink v4. "
+    "Please import from `splink.redshift.comparison_level_library` going forward.",
+    SplinkDeprecated,
+    stacklevel=2,
+)

--- a/splink/redshift/redshift_comparison_library.py
+++ b/splink/redshift/redshift_comparison_library.py
@@ -1,0 +1,12 @@
+import warnings
+
+from ..exceptions import SplinkDeprecated
+from .comparison_library import *  # noqa: F403
+
+warnings.warn(
+    "Importing directly from `splink.redshift.redshift_comparison_library` "
+    "is deprecated and will be removed in Splink v4. "
+    "Please import from `splink.redshift.comparison_library` going forward.",
+    SplinkDeprecated,
+    stacklevel=2,
+)

--- a/splink/redshift/redshift_comparison_template_library.py
+++ b/splink/redshift/redshift_comparison_template_library.py
@@ -1,0 +1,12 @@
+import warnings
+
+from ..exceptions import SplinkDeprecated
+from .comparison_template_library import *  # noqa: F403
+
+warnings.warn(
+    "Importing directly from `splink.redshift.redshift_comparison_template_library` "
+    "is deprecated and will be removed in Splink v4. "
+    "Please import from `splink.redshift.comparison_template_library` going forward.",
+    SplinkDeprecated,
+    stacklevel=2,
+)

--- a/splink/redshift/redshift_helpers/redshift_base.py
+++ b/splink/redshift/redshift_helpers/redshift_base.py
@@ -1,0 +1,58 @@
+from ...dialect_base import (
+    DialectBase,
+)
+
+
+def regex_extract_sql(col_name, regex):
+    return f"""
+        regexp_substr({col_name}, '{regex}')
+    """
+
+
+def datediff_sql(
+    col_name_l,
+    col_name_r,
+    date_threshold,
+    date_metric,
+    cast_str=False,
+    date_format=None,
+):
+    if date_metric not in ("day", "month", "year"):
+        raise ValueError("`date_metric` must be one of ('day', 'month', 'year')")
+
+    if date_format is None:
+        date_format = "yyyy-MM-dd"
+
+    if cast_str:
+        datediff_args = f"""
+            to_date({col_name_l}, '{date_format}'),
+            to_date({col_name_r}, '{date_format}')
+        """
+    else:
+        datediff_args = f"{col_name_l}, {col_name_r}"
+
+    date_f = f"""
+        abs(
+            datediff(
+                {date_metric},
+                {datediff_args}
+            )
+        )
+    """
+    return f"""
+        {date_f} <= {date_threshold}
+    """
+
+
+class RedshiftBase(DialectBase):
+    @property
+    def _sql_dialect(self):
+        return "postgres"
+
+    @property
+    def _regex_extract_function(self):
+        return regex_extract_sql
+
+    @property
+    def _datediff_function(self):
+        return datediff_sql

--- a/splink/redshift/redshift_helpers/redshift_comparison_imports.py
+++ b/splink/redshift/redshift_helpers/redshift_comparison_imports.py
@@ -1,0 +1,136 @@
+from ...comparison_level_library import (
+    ArrayIntersectLevelBase,
+    ColumnsReversedLevelBase,
+    DistanceFunctionLevelBase,
+    DistanceInKMLevelBase,
+    ElseLevelBase,
+    ExactMatchLevelBase,
+    LevenshteinLevelBase,
+    NullLevelBase,
+    PercentageDifferenceLevelBase,
+)
+from ...comparison_library import (
+    ArrayIntersectAtSizesBase,
+    DistanceFunctionAtThresholdsBase,
+    DistanceInKMAtThresholdsBase,
+    ExactMatchBase,
+    LevenshteinAtThresholdsBase,
+)
+from .redshift_base import (
+    RedshiftBase,
+)
+
+
+# Class used to feed our comparison_library classes
+class RedshiftComparisonProperties(RedshiftBase):
+    @property
+    def _exact_match_level(self):
+        return exact_match_level
+
+    @property
+    def _null_level(self):
+        return null_level
+
+    @property
+    def _else_level(self):
+        return else_level
+
+    @property
+    def _array_intersect_level(self):
+        return array_intersect_level
+
+    @property
+    def _columns_reversed_level(self):
+        return columns_reversed_level
+
+    @property
+    def _distance_in_km_level(self):
+        return distance_in_km_level
+
+    @property
+    def _distance_function_level(self):
+        return distance_function_level
+
+    @property
+    def _levenshtein_level(self):
+        return levenshtein_level
+
+
+#########################
+### COMPARISON LEVELS ###
+#########################
+class null_level(RedshiftBase, NullLevelBase):
+    pass
+
+
+class exact_match_level(RedshiftBase, ExactMatchLevelBase):
+    pass
+
+
+class else_level(RedshiftBase, ElseLevelBase):
+    pass
+
+
+class columns_reversed_level(RedshiftBase, ColumnsReversedLevelBase):
+    pass
+
+
+class distance_function_level(RedshiftBase, DistanceFunctionLevelBase):
+    pass
+
+
+class levenshtein_level(RedshiftBase, LevenshteinLevelBase):
+    pass
+
+
+class array_intersect_level(RedshiftBase, ArrayIntersectLevelBase):
+    pass
+
+
+class percentage_difference_level(RedshiftBase, PercentageDifferenceLevelBase):
+    pass
+
+
+class distance_in_km_level(RedshiftBase, DistanceInKMLevelBase):
+    pass
+
+
+##########################
+### COMPARISON LIBRARY ###
+##########################
+class exact_match(RedshiftComparisonProperties, ExactMatchBase):
+    pass
+
+
+class distance_function_at_thresholds(
+    RedshiftComparisonProperties, DistanceFunctionAtThresholdsBase
+):
+    @property
+    def _distance_level(self):
+        return self._distance_function_level
+
+
+class levenshtein_at_thresholds(
+    RedshiftComparisonProperties, LevenshteinAtThresholdsBase
+):
+    @property
+    def _distance_level(self):
+        return self._levenshtein_level
+
+
+class array_intersect_at_sizes(RedshiftComparisonProperties, ArrayIntersectAtSizesBase):
+    pass
+
+
+class distance_in_km_at_thresholds(
+    RedshiftComparisonProperties, DistanceInKMAtThresholdsBase
+):
+    pass
+
+
+###################################
+### COMPARISON TEMPLATE LIBRARY ###
+###################################
+# Not yet implemented
+# Currently does not support the necessary comparison levels
+# required for existing comparison templates

--- a/splink/redshift/redshift_helpers/redshift_transforms.py
+++ b/splink/redshift/redshift_helpers/redshift_transforms.py
@@ -1,0 +1,14 @@
+import re
+
+import sqlglot
+
+
+def add_frame_clause(node):
+    sql = node.sql()
+    sql = re.sub(
+        r"(partition by \w+ order by \w+ desc)",
+        r"\1 rows between unbounded preceding and current row",
+        sql,
+        flags=re.IGNORECASE,
+    )
+    return sqlglot.parse_one(sql)

--- a/splink/redshift/redshift_linker.py
+++ b/splink/redshift/redshift_linker.py
@@ -1,0 +1,12 @@
+import warnings
+
+from ..exceptions import SplinkDeprecated
+from .linker import RedshiftDataFrame, RedshiftLinker  # noqa: F401
+
+warnings.warn(
+    "Importing directly from `splink.redshift.redshift_linker` "
+    "is deprecated and will be removed in Splink v4. "
+    "Please import from `splink.redshift.linker` going forward.",
+    SplinkDeprecated,
+    stacklevel=2,
+)


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

https://github.com/moj-analytical-services/splink/issues/1220

### Give a brief description for the solution you have provided

My coworker @BartBaddeley has implemented a bare-bones linker for Redshift.

Redshift is quite limited really e.g. it doesn't have any built-in string distance functions. [Python UDFs could be used to implement any missing functionality](https://towardsdatascience.com/bringing-fuzzy-matching-to-redshift-d487ce98d170) but I don't know how fast that would be.

Anyway we haven't needed any such features so far. We think this could be useful to other people. 
Maybe someone else will eventually pick this up and add more features. "Scratch your own itch" and all that 🙂 

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)

