### PR TITLE
Fix find_matches test

### DIFF
--- a/tests/test_find_new_matches.py
+++ b/tests/test_find_new_matches.py
@@ -2,25 +2,25 @@ from copy import deepcopy
 
 import pandas as pd
 
-from splink.duckdb.comparison_library import exact_match
-
 from .basic_settings import get_settings_dict
 from .decorator import mark_with_dialects_excluding
 
 df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
 
-settings = get_settings_dict()
-settings_tf = deepcopy(settings, None)
-# Settings with two term frequency columns
-settings_tf["comparisons"][1] = exact_match(
-    "surname", True, m_probability_exact_match=0.7, m_probability_else=0.1
-)
-settings_no_tf = deepcopy(settings, None)
-# Settings with no term frequencies
-settings_no_tf["comparisons"][0] = exact_match(
-    "first_name", False, m_probability_exact_match=0.7, m_probability_else=0.1
-)
+def get_different_settings_dicts(exact_match):
+    settings = get_settings_dict()
+    settings_tf = deepcopy(settings, None)
+    # Settings with two term frequency columns
+    settings_tf["comparisons"][1] = exact_match(
+        "surname", term_frequency_adjustments=True, m_probability_exact_match=0.7, m_probability_else=0.1
+    )
+    settings_no_tf = deepcopy(settings, None)
+    # Settings with no term frequencies
+    settings_no_tf["comparisons"][0] = exact_match(
+        "first_name", term_frequency_adjustments=False, m_probability_exact_match=0.7, m_probability_else=0.1
+    )
+    return settings_tf, settings_no_tf, settings
 
 # The record to be matched
 record = {

--- a/tests/test_find_new_matches.py
+++ b/tests/test_find_new_matches.py
@@ -13,14 +13,21 @@ def get_different_settings_dicts(exact_match):
     settings_tf = deepcopy(settings, None)
     # Settings with two term frequency columns
     settings_tf["comparisons"][1] = exact_match(
-        "surname", term_frequency_adjustments=True, m_probability_exact_match=0.7, m_probability_else=0.1
+        "surname",
+        term_frequency_adjustments=True,
+        m_probability_exact_match=0.7,
+        m_probability_else=0.1,
     )
     settings_no_tf = deepcopy(settings, None)
     # Settings with no term frequencies
     settings_no_tf["comparisons"][0] = exact_match(
-        "first_name", term_frequency_adjustments=False, m_probability_exact_match=0.7, m_probability_else=0.1
+        "first_name",
+        term_frequency_adjustments=False,
+        m_probability_exact_match=0.7,
+        m_probability_else=0.1,
     )
     return settings_tf, settings_no_tf, settings
+
 
 # The record to be matched
 record = {
@@ -44,7 +51,7 @@ def test_tf_tables_init_works(test_helpers, dialect):
             df,
             s,
             **helper.extra_linker_args(),
-            input_table_aliases=f"test_tf_table_alias_{idx}"
+            input_table_aliases=f"test_tf_table_alias_{idx}",
         )
 
         # Compute tf table for first name

--- a/tests/test_find_new_matches.py
+++ b/tests/test_find_new_matches.py
@@ -39,11 +39,12 @@ def test_tf_tables_init_works(test_helpers, dialect):
     helper = test_helpers[dialect]
     Linker = helper.Linker
 
-    for s in [settings_tf, settings_no_tf, settings]:
+    for idx, s in enumerate(get_different_settings_dicts(helper.cl.exact_match)):
         linker = Linker(
             df,
             s,
             **helper.extra_linker_args(),
+            input_table_aliases=f"test_tf_table_alias_{idx}"
         )
 
         # Compute tf table for first name


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixing failing postgres tests that have appeared lately.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
A couple of things were happening here:
* the arguments to `exact_match` were not updated since regex functionality was added so the positional boolean argument was being misinterpreted - I have changed this to an explicit keyword argument call (maybe we could consider adding FBT001 + FBT003 to linter: https://beta.ruff.rs/docs/rules/#flake8-boolean-trap-fbt)
* the backend-agnostic tests were all using `duckdb.exact_match`, which caused some funky behaviour - this is now wrapped in a function to handle arbitrary backends
  * ultimately I think this should be superseded by a more general solution for using `get_settings_dict()` sensibly
* there is also a workaround for an issue with repeated table-names in sqlite tests, but this probably requires a more robust solution overall that doesn't need to be handled test-side


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


