### PR TITLE
Comparison viewer colour gamma grid on match weight

### DIFF
--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -8784,7 +8784,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 				color: {
 					field: "match_probability",
 					legend: {
-						title: ""
+						title: "Match probability"
 					},
 					scale: {
 						domain: [
@@ -8796,7 +8796,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 							"red",
 							"orange",
 							"green"
-						]
+						],
 					},
 					type: "quantitative"
 				},
@@ -8883,6 +8883,11 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 						"x"
 					]
 				}
+			},
+			resolve: {
+				scale: {
+					color: "shared"
+				}
 			}
 		},
 		{
@@ -8931,22 +8936,23 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 							title: ""
 						},
 						color: {
-							field: "gam_value_norm",
+							field: "match_weight",
 							legend: {
-								title: ""
+								title: "Match weight"
 							},
 							type: "quantitative",
 							scale: {
 								domain: [
+									-5,
 									0,
-									0.5,
-									1
+									5
 								],
 								range: [
 									"red",
-									"orange",
-									"green"
-								]
+									"white",
+									"green",
+								],
+								interpolate: "lab"  
 							}
 						},
 						tooltip: [
@@ -8956,6 +8962,10 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 							},
 							{
 								field: "gam_value",
+								type: "quantitative"
+							},
+							{
+								field: "match_weight",
 								type: "quantitative"
 							}
 						]
@@ -9012,7 +9022,12 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 						}
 					}
 				}
-			]
+			],
+			resolve: {
+				scale: {
+					color: "independent"
+				}
+			}
 		},
 		{
 			encoding: {
@@ -9083,14 +9098,19 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 						]
 					}
 				}
-			]
+			],
+			resolve: {
+				scale: {
+					color: "shared"
+				}
+			}
 		}
 	];
 	var base_spec = {
 		$schema: $schema,
 		config: config,
 		data: data,
-		vconcat: vconcat
+		vconcat: vconcat,
 	};
 
 	function sort_match_weight(a, b) {
@@ -9153,7 +9173,8 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	    counter += 1;
 	    let gam_key_counter = 0;
 	    gamma_keys.forEach((k) => {
-	      let settings_col = ss_object.get_col_by_name(k.replace("gamma_", ""));
+		  let data_col_name = k.replace("gamma_", "");
+	      let settings_col = ss_object.get_col_by_name(data_col_name);
 	      let num_levels = settings_col.num_levels;
 
 	      let row = {};
@@ -9164,6 +9185,10 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	      row["gam_concat"] = d["gam_concat"];
 	      row["gam_concat_id"] = counter;
 	      row["gam_key_count"] = gam_key_counter;
+
+		  // TODO: variable prefix?
+		  row["bayes_factor"] = d[`bf_${data_col_name}`];
+		  row["match_weight"] = log2(d[`bf_${data_col_name}`]);
 	      result_data.push(row);
 	      gam_key_counter += 1;
 	    });

--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -8949,7 +8949,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 								],
 								range: [
 									"red",
-									"white",
+									"#bbbbbb",
 									"green",
 								],
 								interpolate: "lab"  


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes #1437.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
The gamma-value grid in comparison viewer is now coloured according to the match weight associated with the corresponding gamma level, with the match weight also in the tooltip. The colour scale is similar to that of the comparison vector histogram, but a couple of small differences:
* this is on match-weight scale, rather than probability, so colours do not 'line up' directly. I think that it is still fairly intuitive though, and don't believe that this should lead to any serious confusion
* the midpoint is a grey, rather than yellow, as that seemed to make more sense as a 'neutral' in this context (i.e. not much evidence for/against) than yellow did

I like the proposed idea of alternate + more accessible colour schemes, but decided that was probably best to do as a wider change uniformly across our vis, so have left that to a separate issue (#1469) for a future PR.

Example:
<img width="1305" alt="Screenshot 2023-07-26 at 10 43 11" src="https://github.com/moj-analytical-services/splink/assets/48208438/38e582ad-79c8-4894-8400-3723cd4d2b1f">

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


