### PR TITLE
Fix estimate lambda as zero

### DIFF
--- a/splink/analyse_blocking.py
+++ b/splink/analyse_blocking.py
@@ -99,8 +99,12 @@ def cumulative_comparisons_generated_by_blocking_rules(
     linker._enqueue_sql(sql, "__splink__df_count_cumulative_blocks")
     cumulative_blocking_rule_count = linker._execute_sql_pipeline([concat])
     br_n = cumulative_blocking_rule_count.as_pandas_dataframe()
+    # not all dialects return column names when frame is empty (e.g. sqlite, postgres)
+    if br_n.empty:
+        br_n["row_count"] = []
+        br_n["match_key"] = []
     cumulative_blocking_rule_count.drop_table_from_database_and_remove_from_cache()
-    br_count, br_keys = list(br_n.row_count), list(br_n["match_key"].astype("int"))
+    br_count, br_keys = list(br_n["row_count"]), list(br_n["match_key"].astype("int"))
 
     if len(br_count) != len(brs_as_objs):
         missing_br = [x for x in range(len(brs_as_objs)) if x not in br_keys]

--- a/tests/test_estimate_prob_two_rr_match.py
+++ b/tests/test_estimate_prob_two_rr_match.py
@@ -292,8 +292,7 @@ def test_prob_rr_match_link_and_dedupe_multitable(test_helpers, dialect):
     assert prob == 1
 
 
-# TODO: restore postgres backend once bug fixed
-@mark_with_dialects_excluding("postgres", "sqlite")
+@mark_with_dialects_excluding()
 def test_prob_rr_valid_range(test_helpers, dialect, caplog):
     helper = test_helpers[dialect]
 


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes #1233 (and the same issue for postgres).


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
when we analyse blocking, if the returned frame is empty then not all backends retain the column names - in particular postgres + sqlite. This checks if the frame is empty, and assigns (still empty) columns if so.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks at tutorial in [splink_demos](https://github.com/moj-analytical-services/splink_demos) (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


