### PR TITLE
fix sqlite table registration

### DIFF
--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -169,7 +169,12 @@ class SQLiteLinker(Linker):
             input = pd.DataFrame.from_records(input)
 
         # Will error if an invalid data type is passed
-        input.to_sql(table_name, self.con, index=False)
+        input.to_sql(
+            table_name,
+            self.con,
+            index=False,
+            if_exists="replace",
+        )
 
     def _random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes the outstanding failing `sqlite` tests - now _all_ tests pass ✅ 


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
changed `SQLiteLinker`'s `_table_registration` to overwrite if table already exists. This is the same behaviour as `postgres`, and `duckdb` (although there it is implicit in the `con.register` function).


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


