### PR TITLE
Reduce EM training warnings

### DIFF
--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -165,6 +165,9 @@ class ComparisonLevel:
         # Enable the level to 'know' when it's been trained
         self._trained_m_probabilities: list = []
         self._trained_u_probabilities: list = []
+        # controls warnings from model training - ensures we only send once
+        self._m_warning_sent = False
+        self._u_warning_sent = False
 
         self._validate()
 
@@ -224,11 +227,13 @@ class ComparisonLevel:
         if value == LEVEL_NOT_OBSERVED_TEXT:
             cc_n = self.comparison._output_column_name
             cl_n = self.label_for_charts
-            logger.warning(
-                "\nWARNING:\n"
-                f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
-                "unable to train m value"
-            )
+            if not self._m_warning_sent:
+                logger.warning(
+                    "WARNING:\n"
+                    f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
+                    "unable to train m value\n"
+                )
+                self._m_warning_sent = True
 
         self._m_probability = value
 
@@ -250,11 +255,13 @@ class ComparisonLevel:
         if value == LEVEL_NOT_OBSERVED_TEXT:
             cc_n = self.comparison._output_column_name
             cl_n = self.label_for_charts
-            logger.warning(
-                "\nWARNING:\n"
-                f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
-                "unable to train u value"
-            )
+            if not self._u_warning_sent:
+                logger.warning(
+                    "WARNING:\n"
+                    f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
+                    "unable to train u value\n"
+                )
+                self._u_warning_sent = True
         self._u_probability = value
 
     @property

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -332,7 +332,7 @@ class ComparisonLevel:
     def _m_is_trained(self):
         if self.is_null_level:
             return True
-        if self._m_probability == "level not observed in data":
+        if self._m_probability == LEVEL_NOT_OBSERVED_TEXT:
             return False
         if self._m_probability is None:
             return False
@@ -342,7 +342,7 @@ class ComparisonLevel:
     def _u_is_trained(self):
         if self.is_null_level:
             return True
-        if self._u_probability == "level not observed in data":
+        if self._u_probability == LEVEL_NOT_OBSERVED_TEXT:
             return False
         if self._u_probability is None:
             return False


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes #1095.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
I have added some flags to the comparison-level object to check if the warning has already been sent, and skipping if so (which should be local to the training session - i.e. it will be emitted at the start of each EM training session).
This felt like the lesser evil - moving the warnings to training functions felt like more of an issue as:
* a bit fiddly to make sure these are emitted at a sensible time (i.e. start of session)
* tricky to co-ordinate, as there is more than one way to train (e.g. from labels)
* more changes (so easier to break functionality on cases I didn't check)
But let me know if you disagree


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


