### PR TITLE
refactor: perf: dedupe logic, inf checks in predict.py

### DIFF
--- a/splink/predict.py
+++ b/splink/predict.py
@@ -153,12 +153,11 @@ def _combine_prior_and_bfs(
         return bf_expr, match_prob_expr
 
     bf_prior = prob_to_bayes_factor(prior)
-    bf_raw = f"cast({bf_prior} as float8) * " + " * ".join(bf_terms)
-    mp_raw = f"({bf_raw})/(1+({bf_raw}))"
+    bf_expr = f"cast({bf_prior} as float8) * " + " * ".join(bf_terms)
 
-    # if any BF is Infinity then we need to adjust expression,
-    # as arithmetic won't go through directly
+    mp_raw = f"({bf_expr})/(1+({bf_expr}))"
+    # if any BF is Infinity then we need to adjust the match probability
     any_term_inf = " OR ".join((f"{term} = {sql_infinity_expr}" for term in bf_terms))
-    bf_expr = f"CASE WHEN {any_term_inf} THEN {sql_infinity_expr} ELSE {bf_raw} END"
     match_prob_expr = f"CASE WHEN {any_term_inf} THEN 1.0 ELSE {mp_raw} END"
+
     return bf_expr, match_prob_expr

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -39,36 +39,16 @@ def predict_from_comparison_vectors_sqls(
 
     select_cols = settings_obj._columns_to_select_for_predict
     select_cols_expr = ",".join(select_cols)
-    mult = []
+    bf_terms = []
     for cc in settings_obj.comparisons:
-        mult.extend(cc._match_weight_columns_to_multiply)
+        bf_terms.extend(cc._match_weight_columns_to_multiply)
 
-    probability_two_random_records_match = (
-        settings_obj._probability_two_random_records_match
+    prior = settings_obj._probability_two_random_records_match
+    bayes_factor_expr, match_prob_expr = _combine_prior_and_bfs(
+        prior,
+        bf_terms,
+        sql_infinity_expression,
     )
-
-    if probability_two_random_records_match == 1.0:
-        bayes_factor_expr = sql_infinity_expression
-        match_prob_expr = "1.0"
-    else:
-        bayes_factor = prob_to_bayes_factor(probability_two_random_records_match)
-
-        bayes_factor_expr = " * ".join(mult)
-        bayes_factor_expr = f"cast({bayes_factor} as float8) * {bayes_factor_expr}"
-
-        # if any BF is Infinity then we need to adjust expression,
-        # as arithmetic won't go through directly
-        any_bf_inf = " OR ".join(
-            map(lambda col: f"{col} = {sql_infinity_expression}", mult)
-        )
-        bayes_factor_expr = (
-            f"CASE WHEN {any_bf_inf} THEN {sql_infinity_expression} "
-            f"ELSE {bayes_factor_expr} END"
-        )
-        match_prob_expr = (
-            f"CASE WHEN {any_bf_inf} THEN 1.0 "
-            f"ELSE (({bayes_factor_expr})/(1+({bayes_factor_expr}))) END"
-        )
 
     # In case user provided both, take the minimum of the two thresholds
     if threshold_match_probability is not None:
@@ -106,7 +86,7 @@ def predict_from_comparison_vectors_sqls(
 def predict_from_agreement_pattern_counts_sqls(
     settings_obj: Settings,
     sql_infinity_expression="'infinity'",
-):
+) -> list[dict]:
     sqls = []
 
     select_cols = []
@@ -138,34 +118,13 @@ def predict_from_agreement_pattern_counts_sqls(
     select_cols.append("agreement_pattern_count")
     select_cols_expr = ",".join(select_cols)
 
-    mult = [cc._bf_column_name for cc in settings_obj.comparisons]
-
-    probability_two_random_records_match = (
-        settings_obj._probability_two_random_records_match
+    prior = settings_obj._probability_two_random_records_match
+    bf_terms = [cc._bf_column_name for cc in settings_obj.comparisons]
+    bayes_factor_expr, match_prob_expr = _combine_prior_and_bfs(
+        prior,
+        bf_terms,
+        sql_infinity_expression,
     )
-
-    if probability_two_random_records_match == 1.0:
-        bayes_factor_expr = sql_infinity_expression
-        match_prob_expr = "1.0"
-    else:
-        bayes_factor = prob_to_bayes_factor(probability_two_random_records_match)
-
-        bayes_factor_expr = " * ".join(mult)
-        bayes_factor_expr = f"cast({bayes_factor} as double) * {bayes_factor_expr}"
-
-        # if any BF is Infinity then we need to adjust expression,
-        # as arithmetic won't go through directly
-        any_bf_inf = " OR ".join(
-            map(lambda col: f"{col} = {sql_infinity_expression}", mult)
-        )
-        bayes_factor_expr = (
-            f"CASE WHEN {any_bf_inf} THEN {sql_infinity_expression} "
-            f"ELSE {bayes_factor_expr} END"
-        )
-        match_prob_expr = (
-            f"CASE WHEN {any_bf_inf} THEN 1.0 "
-            f"ELSE (({bayes_factor_expr})/(1+({bayes_factor_expr}))) END"
-        )
 
     sql = f"""
     select
@@ -182,3 +141,24 @@ def predict_from_agreement_pattern_counts_sqls(
     sqls.append(sql)
 
     return sqls
+
+
+def _combine_prior_and_bfs(
+    prior: float, bf_terms: list[str], sql_infinity_expr: str
+) -> tuple[str, str]:
+    """Compute the combined Bayes factor and match probability expressions"""
+    if prior == 1.0:
+        bf_expr = sql_infinity_expr
+        match_prob_expr = "1.0"
+        return bf_expr, match_prob_expr
+
+    bf_prior = prob_to_bayes_factor(prior)
+    bf_raw = f"cast({bf_prior} as float8) * " + " * ".join(bf_terms)
+    mp_raw = f"({bf_raw})/(1+({bf_raw}))"
+
+    # if any BF is Infinity then we need to adjust expression,
+    # as arithmetic won't go through directly
+    any_term_inf = " OR ".join((f"{term} = {sql_infinity_expr}" for term in bf_terms))
+    bf_expr = f"CASE WHEN {any_term_inf} THEN {sql_infinity_expr} ELSE {bf_raw} END"
+    match_prob_expr = f"CASE WHEN {any_term_inf} THEN 1.0 ELSE {mp_raw} END"
+    return bf_expr, match_prob_expr


### PR DESCRIPTION
1. This factors out this logic so that they will stay in sync.
I wet with slightly less verbose names as well
2. Added type hints
3. Possibly improved performance: Before, when we
templated `bayes_factor_expr` into `match_prob_expr`, then
the check for infinity would happen twice, nestedly.
This doesn't affect the behavior,
but it may have had a performance
degradation.
Also, I don't think the CASE was needed for the BF expr,
since SQL engines should be able to handle propagating inf through
multiplication. I think it only is need to fixup the match_probability expression.
So I removed that in a followup commit as well.
4. Use list comprehension instead of map() for readibility

### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC




### PR Checklist

- [x] Added documentation for changes
- [x] Added feature to example notebooks or tutorial (if appropriate)
- [ you tell me if you think existing coverage is adequate] Added tests (if appropriate) 
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


