### PR TITLE
remove `set` clause

### DIFF
--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -172,13 +172,11 @@ class DateComparisonBase(Comparison):
                 "sql_condition": f"SUBSTR({col_name}_l, 6, 5) = '01-01'",
                 "label_for_charts": "Date is 1st Jan",
             }
-            comparison_level = {
-                and_(
+            comparison_level = and_(
                     self._exact_match_level(col_name),
                     dob_first_jan,
                     label_for_charts="Exact match and 1st Jan",
                 )
-            }
 
             if m_probability_1st_january:
                 comparison_level["m_probability"] = m_probability_1st_january


### PR DESCRIPTION
### Type of PR

- [x] BUG

### Give a brief description for the solution you have provided
One of the comparison levels within `date_comparison` was being transformed into a `set` and subsequently breaking when you attempted to call the function with that functionality.

I've simply removed the set argument so `comparison_level` is correctly read in as a `ComparisonLevel` class.

Code that was previously failing:
```
import splink.spark.comparison_template_library as ctl

ctl.date_comparison(
    "dob",
    separate_1st_january = True,
    datediff_thresholds = [1, 10],
    datediff_metrics = ["year", "year"],
)
```
It's line `separate_1st_january = True,` that was previously causing issues.