### PR TITLE
adjusted default xlim inmissingness chart json

### DIFF
--- a/splink/files/chart_defs/missingness.json
+++ b/splink/files/chart_defs/missingness.json
@@ -17,7 +17,8 @@
           "type": "quantitative",
           "field": "null_proportion",
           "legend": {
-            "format": ".0%"
+            "format": ".0%",
+            "offset": 30
           },
           "scale": {
             "range": "heatmap"
@@ -51,7 +52,9 @@
         ],
         "x": {
           "type": "quantitative",
+          "scale": {"domain": [0, 1]},
           "axis": {
+            "labelAlign": "center",
             "format": "%",
             "title": "Percentage of nulls"
           },


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

  Closes #1326 

### Give a brief description for the solution you have provided
Adjusted missingness chart json so default axis are set to 0-100. Also adjusted the xlabel placement and colorbar to make label spacing nicer. 

Using consistent axis limits will allow users to more easily compare charts made using different datasets.

See the below code snippet to replicate the issue:

```
from splink.datasets import splink_datasets
from splink.duckdb.linker import DuckDBLinker
import numpy as np

settings = {
    "link_type": "dedupe_only",
    "unique_id_column_name": "unique_id",
}

df = splink_datasets.fake_1000
linker = DuckDBLinker(df, settings)
ch1 = linker.missingness_chart()

df2 = df.copy(deep=True)
df2.iloc[0:800,:] = np.nan
linker = DuckDBLinker(df2, settings)
ch2 = linker.missingness_chart()

ch1.display()
ch2.display()
```

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


