### PR TITLE
small tweak to also adjust heatmap scale axis limits

### DIFF
--- a/splink/files/chart_defs/missingness.json
+++ b/splink/files/chart_defs/missingness.json
@@ -20,7 +20,7 @@
             "format": ".0%",
             "offset": 30
           },
-          "scale": {
+          "scale": {"domain": [0, 1],
             "range": "heatmap"
           },
           "title": "Missingness"


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

Related to PR #1511. Small amendment to also adjust limits of heatmap so that bar colours are consistent across charts.



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


