### PR TITLE
add in a check to see if `docs-venv` is already active

### DIFF
--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -4,19 +4,24 @@
 # python scripts/json_schema_to_md_doc.py
 # python scripts/generate_dialect_comparison_docs.py
 
-deactivate
-python3 -m venv docs-venv
-source docs-venv/bin/activate
-pip install --upgrade pip
-pip install -r scripts/docs-requirements.txt
-# if you haven't run generate_dialect_comparison_docs.py, then install the splink dependencies and run
-if [[ ! -f "docs/includes/generated_files/comparison_level_library_dialect_table.md" ]]
-then
+if [[ "$VIRTUAL_ENV" == *"/docs-venv"* ]]; then
+
+    deactivate
+    python3 -m venv docs-venv
+    source docs-venv/bin/activate
+    pip install --upgrade pip
+    pip install -r scripts/docs-requirements.txt
     pip install poetry
     poetry install
+
+fi
+
+# if you haven't run generate_dialect_comparison_docs.py, then install the splink dependencies and run
+if [[ ! -f "docs/includes/generated_files/comparison_level_library_dialect_table.md" ]]; then
     python3 scripts/generate_dialect_comparison_docs.py
     python3 scripts/generate_dataset_docs.py
 fi
+
 # manually preprocess include files as include-markdown plugin clashes with mknotebooks
 # make sure not to commit changes to files with inclusions!
 python3 scripts/preprocess_markdown_includes.py


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [x] DOC

### Give a brief description for the solution you have provided
A quick change that removes the need to endlessly run `poetry install` every time you kill your mkdocs instance.

Now you can just reenter the `docs-venv` venv and the `make_docs_locally.sh` script should only run the calls needed to create the docs.



