### PR TITLE
Make brs json serialisable

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -55,6 +55,11 @@ class BlockingRule:
     def match_key(self):
         return len(self.preceding_rules)
 
+    @property
+    def sql(self):
+        # Wrapper to reveal the underlying SQL
+        return self.blocking_rule
+
     def add_preceding_rules(self, rules):
         rules = ensure_is_list(rules)
         self.preceding_rules = rules
@@ -143,6 +148,13 @@ class BlockingRule:
             output["salting_partitions"] = self.salting_partitions
 
         return output
+
+    def _as_completed_dict(self):
+
+        if not self.salting_partitions > 1 and self.sql_dialect == "spark":
+            return self.blocking_rule
+        else:
+            return self.as_dict()
 
     @property
     def descr(self):

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -432,7 +432,9 @@ class Settings:
 
     def _as_completed_dict(self):
         rr_match = self._probability_two_random_records_match
+        brs = self._blocking_rules_to_generate_predictions
         current_settings = {
+            "blocking_rules_to_generate_predictions": [br._as_completed_dict() for br in brs],
             "comparisons": [cc._as_completed_dict() for cc in self.comparisons],
             "probability_two_random_records_match": rr_match,
             "unique_id_column_name": self._unique_id_column_name,

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -434,7 +434,9 @@ class Settings:
         rr_match = self._probability_two_random_records_match
         brs = self._blocking_rules_to_generate_predictions
         current_settings = {
-            "blocking_rules_to_generate_predictions": [br._as_completed_dict() for br in brs],
+            "blocking_rules_to_generate_predictions": [
+                br._as_completed_dict() for br in brs
+            ],
             "comparisons": [cc._as_completed_dict() for cc in self.comparisons],
             "probability_two_random_records_match": rr_match,
             "unique_id_column_name": self._unique_id_column_name,


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Fixes a bug identified in https://github.com/moj-analytical-services/splink/pull/1517, in which our custom blocking rules were non-JSON serialisable (i.e. they weren't in a format in which they could be converted to valid JSON).

To resolve, I've simply added an `as_completed_dict()` function to our blocking class and added the output of this to our settings method of the same name.


