### PR TITLE
lock poetry to v1.5.1

### DIFF
--- a/.github/workflows/pytest_postgres.yml
+++ b/.github/workflows/pytest_postgres.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.5.1
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.5.1
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC


### Give a brief description for the solution you have provided
Poetry > v1.6.0 no longer works for python 3.7, so our CI tests have been failing. For the time being, I've frozen our poetry version to v1.5.1 to resolve this.

Going forward, we could potentially add a check to establish whether the python version is >3.7 and conditionally install a valid version of poetry.



