### PR TITLE
fix non-quoted db&catalog issues

### DIFF
--- a/splink/spark/linker.py
+++ b/splink/spark/linker.py
@@ -227,7 +227,7 @@ class SparkLinker(Linker):
         # be stored. The filter will remove none, so if catalog is not provided and
         # spark version is < 3.3.0 we will use the default catalog.
         self.splink_data_store = ".".join(
-            filter(lambda x: x, [self.catalog, self.database])
+            [f"`{x}`" for x in [self.catalog, self.database] if x is not None]
         )
 
     def _drop_splink_cached_tables(self):

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -17,7 +17,8 @@ from .linker_utils import (
 )
 
 
-def test_full_example_spark(df_spark, tmp_path):
+def test_full_example_spark(spark, df_spark, tmp_path):
+    spark.sql("CREATE DATABASE IF NOT EXISTS `1111`")
     # Annoyingly, this needs an independent linker as csv doesn't
     # accept arrays as inputs, which we are adding to df_spark below
     linker = SparkLinker(df_spark, get_settings_dict())
@@ -66,6 +67,7 @@ def test_full_example_spark(df_spark, tmp_path):
         settings,
         break_lineage_method="checkpoint",
         num_partitions_on_repartition=2,
+        database="1111",
     )
 
     linker.profile_columns(


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
See https://github.com/moj-analytical-services/splink/issues/1556



### Give a brief description for the solution you have provided
Previously, we weren't quoting catalog and database names which was resulting in unusual catalog and database combinations causing SQL errors.

I've simply added quotes to `self.splink_data_store` (the only location both catalog and db are used) and it appears to be resolving the issue. 

To test, you can try creating a random database named `1111` and setting that as your target db from within the linker object:
```
# Create a database called '1111'
spark.sql("CREATE DATABASE IF NOT EXISTS `1111`")

# Run our actual link job
linker = SparkLinker(
    df_spark,
    settings_dict,
    database="1111"
)
```


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


