### PR TITLE
Fix local docs table gen

### DIFF
--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -7,7 +7,7 @@
 if [[ "$VIRTUAL_ENV" != "$cwd/docs-venv" ]]; then
     if [ -n "$VIRTUAL_ENV" ]; then
         deactivate
-    else    
+    else
         :
     fi
     python3 -m venv docs-venv
@@ -19,8 +19,8 @@ fi
 # if you haven't run generate_dialect_comparison_docs.py, then install the splink dependencies and run
 if [[ ! -f "docs/includes/generated_files/comparison_level_library_dialect_table.md" ]]
 then
-    pip install poetry
-    poetry install
+    # add the latest Splink build to the deployment
+    source scripts/test_poetry_build.sh --current_venv
     python3 scripts/generate_dialect_comparison_docs.py
     python3 scripts/generate_dataset_docs.py
 fi

--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -4,11 +4,18 @@
 # python scripts/json_schema_to_md_doc.py
 # python scripts/generate_dialect_comparison_docs.py
 
-deactivate
-python3 -m venv docs-venv
-source docs-venv/bin/activate
-pip install --upgrade pip
-pip install -r scripts/docs-requirements.txt
+if [[ "$VIRTUAL_ENV" != "$cwd/docs-venv" ]]; then
+    if [ -n "$VIRTUAL_ENV" ]; then
+        deactivate
+    else    
+        :
+    fi
+    python3 -m venv docs-venv
+    source docs-venv/bin/activate
+    pip install --upgrade pip
+    pip install -r scripts/docs-requirements.txt
+fi
+
 # if you haven't run generate_dialect_comparison_docs.py, then install the splink dependencies and run
 if [[ ! -f "docs/includes/generated_files/comparison_level_library_dialect_table.md" ]]
 then

--- a/scripts/test_poetry_build.sh
+++ b/scripts/test_poetry_build.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
 
-deactivate
-# Delete the dist folder if it exists
-rm -rf dist/
-rm -rf venv
+# If the user requests that the current virtual
+# environment be used - "--current_venv" -
+# install poetry (if not already installed) and the latest Splink build.
+# Otherwise, deactivate and create a new venv.
+if [ "$1" == "--current_venv" ]; then
+    pip3 install poetry
+else
+    deactivate
+    # Delete the dist folder if it exists
+    rm -rf dist/
+    rm -rf venv
 
-# Setup python and build the package
-python3 -m venv venv
-source venv/bin/activate
+    # Setup python and build the package
+    python3 -m venv venv
+    source venv/bin/activate
+fi
+
+# Create the wheel for the poetry build
 poetry build --format=wheel --verbose
 
 # Find the `.whl` file

--- a/scripts/test_poetry_build.sh
+++ b/scripts/test_poetry_build.sh
@@ -4,13 +4,16 @@
 # environment be used - "--current_venv" -
 # install poetry (if not already installed) and the latest Splink build.
 # Otherwise, deactivate and create a new venv.
-if [ "$1" == "--current_venv" ]; then
+if [ "$1" = "--current_venv" ]; then
+    # Installing poetry in the current virtual environment
     pip3 install poetry
 else
-    deactivate
+    # Deactivate the current virtual environment if it is active
+    if command -v deactivate > /dev/null 2>&1; then
+        deactivate
+    fi
     # Delete the dist folder if it exists
-    rm -rf dist/
-    rm -rf venv
+    rm -rf dist/ venv/
 
     # Setup python and build the package
     python3 -m venv venv


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Tags onto https://github.com/moj-analytical-services/splink/pull/1590.


### Give a brief description for the solution you have provided
Fixes an issue (at least for me) in which the generated docs tables ([splink_datasets](https://moj-analytical-services.github.io/splink/datasets.html#splink_datasets), [comparison_library](https://moj-analytical-services.github.io/splink/comparison_library.html#documentation-for-comparison_library), etc.) weren't being generated locally. 

This would then cause the if statement `if [[ ! -f "docs/includes/generated_files/comparison_level_library_dialect_table.md" ]]` to continuously trigger if you were to run the docs builder repeatedly (which frustratingly installs all Splink dependencies through poetry).

The issue is with the way in which filepaths and imports are working in the [table generation](https://github.com/moj-analytical-services/splink/blob/master/scripts/generate_dataset_docs.py) scripts. The fix below simply takes advantage of the poetry creation bash script. With the changes below, Splink is now built and then installed using poetry, rather than trying to use and resolve all of the splink dev dependencies before creating the  docs.

This should be quicker, install less fluff and most importantly, fix the main issue causing the tables not to be created by installing Splink directly.

**Local build looks like so:**
<img width="810" alt="Screenshot 2023-09-11 at 12 45 27" src="https://github.com/moj-analytical-services/splink/assets/45356472/15c8ec19-e50a-4c56-86ae-af53d7de2917">
