### PR TITLE
Comparison viewer - handle comparisons with spacey names + fix waterfall tooltip

### DIFF
--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -6877,7 +6877,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
       return html`<div id='${get_id_from_comparison(cc)}'>${splink_vis_utils.select(
         select_values,
         {
-          label: `Filter ${cc.name}`
+          label: `Filter '${cc.name}'`
         }
       )}</div>`;
     })}

--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -6862,6 +6862,10 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	function get_gammas_filters(splink_settings_object) {
 	  let ss_cols = splink_settings_object.comparisons;
 
+	  function get_id_from_comparison(cc){
+		return `id_${cc.sanitised_name}`;
+	  }
+
 	  const form = html`<form>
     ${ss_cols.map((cc) => {
 	  let select_values = cc.comparison_levels.map((cl) => {
@@ -6870,7 +6874,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	  select_values.unshift(["Any", "Any"]);
 	  select_values = new Map(select_values);
 
-      return html`<div id='id_${cc.name}'>${splink_vis_utils.select(
+      return html`<div id='${get_id_from_comparison(cc)}'>${splink_vis_utils.select(
         select_values,
         {
           label: `Filter ${cc.name}`
@@ -6883,7 +6887,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	  form.oninput = function () {
 	    let mydict = {};
 	    ss_cols.forEach((cc) => {
-	      mydict[cc.name] = form.querySelector(`#id_${cc.name} form`).value;
+	      mydict[cc.name] = form.querySelector(`#${get_id_from_comparison(cc)} form`).value;
 	    });
 	    form.value = mydict;
 	  };
@@ -7854,6 +7858,11 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	    return this.original_dict["column_name"];
 	  }
 
+	  get sanitised_name() {
+		// replace spaces in names in same fashion as Splink does behind the scenes
+		return this.name.replaceAll(' ', '_')
+	  };
+
 	  get num_levels() {
 	    return this.comparison_levels.length;
 	  }
@@ -7972,7 +7981,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	    let lookup = {};
 
 	    this.comparisons.forEach((cc) => {
-	      lookup[cc.name] = cc;
+	      lookup[cc.sanitised_name] = cc;
 	    });
 
 	    return lookup;

--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -6887,7 +6887,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	  form.oninput = function () {
 	    let mydict = {};
 	    ss_cols.forEach((cc) => {
-	      mydict[cc.name] = form.querySelector(`#${get_id_from_comparison(cc)} form`).value;
+	      mydict[cc.sanitised_name] = form.querySelector(`#${get_id_from_comparison(cc)} form`).value;
 	    });
 	    form.value = mydict;
 	  };

--- a/splink/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/files/splink_vis_utils/splink_vis_utils.js
@@ -7092,9 +7092,19 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 
 	  let this_cc = splink_settings.get_col_by_name(col_name);
 	  let this_cl = this_cc.get_comparison_level(gamma_value);
+	  const columns_used = this_cc.columns_used;
 
-	  let value_l = row[col_name + "_l"];
-	  let value_r = row[col_name + "_r"];
+	  function get_data_value(dataset_suffix){
+		// dataset_suffix is 'l' or 'r'
+		// for each column used, get the row value,
+		// and join together in comma-separated fashion
+		return columns_used.map(
+			(col_name) => row[`${col_name}_${dataset_suffix}`]
+		).join(", ");
+	  }
+
+	  let value_l = get_data_value("l");
+	  let value_r = get_data_value("r");
 
 	  let bayes_factor = row["bf_" + col_name];
 


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes #845.
Also fixes semi-related issue where the tooltip in comparison viewer + cluster studio would not properly show left and right values if the comparison used multiple input columns (which would previously render as undefined).


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


