### PR TITLE
Fix tf table init on settings load

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1308,9 +1308,12 @@ class Linker:
             self._pipeline.reset()
             input_dfs = []
 
-            if "__splink__df_concat_with_tf" in cache and column_name in concat_tf_tables:
-                # If our df_concat_with_tf table already exists, use backwards inference to
-                # find a given tf table
+            if (
+                "__splink__df_concat_with_tf" in cache
+                and column_name in concat_tf_tables
+            ):
+                # If our df_concat_with_tf table already exists, use backwards
+                # inference to find a given tf table
                 colname = InputColumn(column_name)
                 sql = term_frequencies_from_concat_with_tf(colname)
                 self._enqueue_sql(sql, colname_to_tf_tablename(colname))
@@ -1327,7 +1330,7 @@ class Linker:
 
         return tf_df
 
-    def _materialise_tf_tables(self, column_names = []) -> None:
+    def _materialise_tf_tables(self, column_names=[]) -> None:
         """Compute all term frequency tables identified within your settings object,
         or supplied within the `column_names` argument.
         """
@@ -1354,7 +1357,8 @@ class Linker:
         pull the individual term frequency tables.
 
         If it doesn't exist, we can queue up the SQL required to create it using
-        `init_df_concat_with_tf`, which generate all of our tf tables as intermediate steps.
+        `init_df_concat_with_tf`, which generate all of our tf tables as intermediate
+        steps.
         """
         input_dfs = []
         cache = self._intermediate_table_cache
@@ -1999,7 +2003,7 @@ class Linker:
             self._enqueue_sql(sql["sql"], sql["output_table_name"])
 
         predictions = self._execute_sql_pipeline(
-            tf_tables+[df_records_left, df_records_right], use_cache=False
+            tf_tables + [df_records_left, df_records_right], use_cache=False
         )
 
         self._settings_obj._blocking_rules_to_generate_predictions = (

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -7,6 +7,22 @@ import pytest
 from tests.cc_testing_utils import check_df_equality
 
 
+def run_basic_splink_model(linker):
+    # A very basic model that can be used in any tests to run a very simplistic
+    # training session
+    linker.estimate_u_using_random_sampling(max_pairs=1e6)
+
+    blocking_rule = "(l.first_name = r.first_name) AND (l.surname = r.surname)"
+    linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
+
+    blocking_rule = "l.dob = r.dob"
+    linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
+
+    linker.predict()
+
+    return linker
+
+
 def _test_table_registration(
     linker, additional_tables_to_register=[], skip_dtypes=False
 ):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -152,7 +152,7 @@ def test_cache_access_compute_tf_table(debug_mode):
 
         # Double `_queue_term_frequency_tables` has the potential to queue up
         # two instances of both fn and surname tf
-        expected_tables = ['__splink__df_tf_first_name', '__splink__df_tf_surname']
+        expected_tables = ["__splink__df_tf_first_name", "__splink__df_tf_surname"]
         queued_tables = [q.output_table_name for q in linker._pipeline.queue]
         assert expected_tables.sort() == queued_tables.sort()
 

--- a/tests/test_find_new_matches.py
+++ b/tests/test_find_new_matches.py
@@ -108,7 +108,7 @@ def test_matches_work(
     path = os.path.join(tmp_path, "model.json")
     linker.save_model_to_json(path)
 
-    linker = Linker(df, settings_dict=path)
+    linker = Linker(df, settings_dict=path, **helper.extra_linker_args())
     # Works w/ loaded settings and no `compute_tf_table`
     matches = linker.find_matches_to_new_records(
         [record], blocking_rules=brs, match_weight_threshold=0


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Addresses the issue outlined here - https://github.com/moj-analytical-services/splink/issues/802.


### Give a brief description for the solution you have provided
Adds support for two new methods:
* `_queue_term_frequency_tables`
* `_materialise_tf_tables`

#### `_materialise_tf_tables`
This method is the simpler of the two, calling `compute_tf_table` on a selection of input columns defined by the user or alternatively all columns requiring term frequency adjustments identified in the settings. This function **always** materialises the table (as this is the functionality implemented in `compute_tf_table`).

#### `_queue_term_frequency_tables`
This also does what it says on the tin, queueing term frequency tables for future execution. I've set this to only queue those tables identified in the settings object, as I don't foresee any circumstances where we would want to expand this to tables outside of the settings (our existing methods/functions all rely on tf tables found in `concat_with_tf`).

This method works both when:
* No tf tables exist
* One or more required tf tables exist

In the former case, we simply create the concat_with_tf table and then infer all of the required term frequencies from this.

In the latter, we queue up the previously generated term frequency tables (first_name_tf, for example) before queueing up any missing tables as SQL CTEs.

It's worth noting that this method can be made to work without the concat_with_tf materialisation step (if you look at my commit history this was originally the case. I've opted to add the mat step in as concat_with_tf is a core table used throughout the whole of splink and also allows future runs of `_queue_term_frequency_tables` to execute more quickly.

### PR Checklist

I will update the docs tomorrow w/ the above change.

- [ ] Added documentation for changes - I will update the docs with a few guides over the next week
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


