### PR TITLE
Check input frames have same columns - missingness

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -275,6 +275,7 @@ class Linker:
                 if col not in common_cols
             }
             raise SplinkException(
+                "All linker input frames must have the same set of columns.  "
                 "The following columns were not found in all input frames: "
                 + ", ".join(problem_names)
             )

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -3001,8 +3001,8 @@ class Linker:
 
         Args:
             input_dataset (str, optional): Name of one of the input tables in the
-            database.  If provided, missingness will be computed for this table alone.
-            Defaults to None.
+                database.  If provided, missingness will be computed for this table alone.
+                Defaults to None.
 
         Examples:
             ```py

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -259,9 +259,7 @@ class Linker:
         # sort it for consistent ordering, and give each frame's
         # columns as a tuple so we can hash it
         column_names_by_input_df = [
-            tuple(
-                sorted([col.name() for col in input_df.columns])
-            )
+            tuple(sorted([col.name() for col in input_df.columns]))
             for input_df in input_dfs
         ]
         # check that the set of input columns is the same for each frame,
@@ -277,8 +275,8 @@ class Linker:
                 if col not in common_cols
             }
             raise SplinkException(
-                "The following columns were not found in all input frames: " +
-                ", ".join(problem_names)
+                "The following columns were not found in all input frames: "
+                + ", ".join(problem_names)
             )
 
         return next(iter(input_dfs)).columns
@@ -3022,7 +3020,8 @@ class Linker:
 
         Args:
             input_dataset (str, optional): Name of one of the input tables in the
-                database.  If provided, missingness will be computed for this table alone.
+                database.  If provided, missingness will be computed for
+                this table alone.
                 Defaults to None.
 
         Examples:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -249,7 +249,7 @@ class Linker:
         self.debug_mode = False
 
     @property
-    def _get_input_columns(
+    def _input_columns(
         self,
     ):
         """Retrieve the column names from the input dataset(s)"""

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -40,13 +40,13 @@ def missingness_sqls(columns, input_tablename):
 
 
 def missingness_data(linker, input_tablename):
+    columns = linker._get_input_columns
     if input_tablename is None:
         splink_dataframe = linker._initialise_df_concat(materialise=True)
     else:
         splink_dataframe = linker._table_to_splink_dataframe(
             input_tablename, input_tablename
         )
-    columns = splink_dataframe.columns
 
     sqls = missingness_sqls(columns, splink_dataframe.physical_name)
 

--- a/splink/missingness.py
+++ b/splink/missingness.py
@@ -40,7 +40,7 @@ def missingness_sqls(columns, input_tablename):
 
 
 def missingness_data(linker, input_tablename):
-    columns = linker._get_input_columns
+    columns = linker._input_columns
     if input_tablename is None:
         splink_dataframe = linker._initialise_df_concat(materialise=True)
     else:

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -229,7 +229,7 @@ def profile_columns(linker, column_expressions=None, top_n=10, bottom_n=10):
     """
 
     if not column_expressions:
-        column_expressions = linker._get_input_columns
+        column_expressions = [col.name() for col in linker._get_input_columns]
 
     df_concat = linker._initialise_df_concat()
 

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -229,7 +229,7 @@ def profile_columns(linker, column_expressions=None, top_n=10, bottom_n=10):
     """
 
     if not column_expressions:
-        column_expressions = [col.name() for col in linker._get_input_columns]
+        column_expressions = [col.name() for col in linker._input_columns]
 
     df_concat = linker._initialise_df_concat()
 

--- a/tests/test_missingness.py
+++ b/tests/test_missingness.py
@@ -1,3 +1,7 @@
+import pandas as pd
+from pytest import raises
+
+from splink.exceptions import SplinkException
 from tests.decorator import mark_with_dialects_excluding
 
 
@@ -7,5 +11,25 @@ def test_missingness_chart(dialect, test_helpers):
 
     df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
-    linker = helper.Linker(df, {"link_type": "dedupe_only"}, **helper.extra_linker_args())
+    linker = helper.Linker(
+        df, {"link_type": "dedupe_only"}, **helper.extra_linker_args()
+    )
     linker.missingness_chart()
+
+
+@mark_with_dialects_excluding()
+def test_missingness_chart_mismatched_columns(dialect, test_helpers):
+    helper = test_helpers[dialect]
+
+    df_l = helper.load_frame_from_csv(
+        "./tests/datasets/fake_1000_from_splink_demos.csv"
+    )
+    df_r = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df_r.rename(columns={"surname": "SURNAME"}, inplace=True)
+    df_r = helper.convert_frame(df_r)
+
+    linker = helper.Linker(
+        [df_l, df_r], {"link_type": "link_only"}, **helper.extra_linker_args()
+    )
+    with raises(SplinkException):
+        linker.missingness_chart()

--- a/tests/test_missingness.py
+++ b/tests/test_missingness.py
@@ -1,0 +1,11 @@
+from tests.decorator import mark_with_dialects_excluding
+
+
+@mark_with_dialects_excluding()
+def test_missingness_chart(dialect, test_helpers):
+    helper = test_helpers[dialect]
+
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    linker = helper.Linker(df, {"link_type": "dedupe_only"}, **helper.extra_linker_args())
+    linker.missingness_chart()


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Closes #808.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
The main thing here is that the property `linker._input_columns` now checks columns for _all_ input dataframes, and gives a clear error message if they are not identical sets, outputting columns that are not common to all frames.

Other changes:
* renamed `linker._get_input_columns` -> `linker._input_columns` (clearer name for property vs method)
* `linker._input_columns` returns a list of `InputColumn`s rather than just their `name`s, for flexibility
  * and adjusted `profile_data` accordingly
* used `linker._input_columns` for missingness chart so we get the check for free
* fix `missingness_chart` docstring
* added simple tests


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


