### PR TITLE
[MAINT] Refactor and clean our settings validation logs

### DIFF
--- a/splink/misc.py
+++ b/splink/misc.py
@@ -195,28 +195,6 @@ def parse_duration(duration: float) -> str:
         return txt_duration.pop()
 
 
-class colour:
-    """A class to beautify your text. Simply import and then use this class's
-    attributes to adjust how the text is formatted. For example:
-
-    `f"{colour.BOLD}Send help{colour.END}`
-
-    will print your text to the console in bold.
-    """
-
-    PURPLE = "\033[95m"
-    CYAN = "\033[96m"
-    DARKCYAN = "\033[36m"
-    BLUE = "\033[94m"
-    GREEN = "\033[92m"
-    YELLOW = "\033[93m"
-    RED = "\033[91m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
-    ITALICS = "\033[3m"
-    END = "\033[0m"
-
-
 def read_resource(path: str) -> str:
     """Reads a resource file from the splink package"""
     # In the future we may have to move to importlib.resources

--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -2,6 +2,8 @@ import sqlglot
 import sqlglot.expressions as exp
 from sqlglot.expressions import Bracket, Column, Lambda
 
+from .input_column import remove_quotes_from_identifiers
+
 
 def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
     column_names = set()
@@ -38,3 +40,29 @@ def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):
             column_names.add(column)
 
     return list(column_names)
+
+
+def parse_columns_in_sql(
+    sql: str, sql_dialect: str, remove_quotes=True
+) -> sqlglot.Expression:
+    """Extract all columns found within a SQL expression.
+
+    Args:
+        sql (str): A SQL string you wish to parse.
+
+    Returns:
+        list[exp.Column]: A list of columns as SQLglot expressions. These can be
+            unwrapped with `.sql()`. If the input string is unparseable, None will
+            be returned.
+    """
+    try:
+        syntax_tree = sqlglot.parse_one(sql, read=sql_dialect)
+    except Exception:  # Consider catching a more specific exception if possible
+        # If we can't parse a SQL condition, it's better to just pass.
+        return None
+
+    return [
+        # Remove quotes if requested by the user
+        remove_quotes_from_identifiers(col) if remove_quotes else col
+        for col in syntax_tree.find_all(exp.Column)
+    ]

--- a/splink/settings_validation/column_lookups.py
+++ b/splink/settings_validation/column_lookups.py
@@ -310,8 +310,6 @@ class InvalidColumnsLogger(InvalidColValidator):
         logger.warning("\n".join(output_warning))
 
     def construct_output_logs(self):
-        # self.check_for_single_column_dataset()
-
         # if no errors exist, then we can exit early
         if not self.invalid_cols_detected:
             return

--- a/splink/settings_validation/column_lookups.py
+++ b/splink/settings_validation/column_lookups.py
@@ -5,10 +5,8 @@ from copy import deepcopy
 from typing import NamedTuple
 
 import sqlglot
-import sqlglot.expressions as exp
 
-from ..input_column import remove_quotes_from_identifiers
-from ..misc import colour
+from ..parse_sql import parse_columns_in_sql
 from .settings_validator import SettingsValidator
 
 logger = logging.getLogger(__name__)
@@ -21,31 +19,18 @@ class InvalidColValidator(SettingsValidator):
 
     This is an extension of the `SettingsValidator` class, which extracts
     key values from a settings dictionary and contains some core cleaning
-    functionality.
+    functions.
 
     Args:
-        SettingsValidator (_type_): The central settings validation class,
+        SettingsValidator: The central settings validation class,
             containing key values from a settings dictionary and
             some core cleaning functionality.
     """
 
-    def __init__(self, linker):
-        self.linker = linker
+    def return_missing_columns(self, cols_to_check: set) -> InvalidCols:
+        """Identify missing columns in the input dataframe(s). This function
+        does not apply any cleaning to the input column(s).
 
-    def check_column_exists(self, column_name: str):
-        """Check whether a column name exists within all of the input
-        dataframes.
-
-        Args:
-            column_name (str): A column name to check
-
-        Returns:
-            bool: True if the column exists.
-        """
-        return column_name in self.input_columns
-
-    def return_missing_columns(self, cols_to_check: set) -> list:
-        """
         Args:
             cols_to_check (set): A list of columns to check for the
                 existence of.
@@ -54,12 +39,14 @@ class InvalidColValidator(SettingsValidator):
             list: Returns a list of all input columns not found within
                 your raw input tables.
         """
-        missing_cols = [
-            col for col in cols_to_check if not self.check_column_exists(col)
-        ]
-        return InvalidCols("invalid_cols", missing_cols)
+        # the key to use when producing our warning logs
+        invalid_type = "invalid_cols"
+        missing_cols = [col for col in cols_to_check if not col in self.input_columns]
+        return InvalidCols(invalid_type, missing_cols)
 
-    def clean_and_return_missing_columns(self, cols: list[sqlglot.expressions]):
+    def clean_and_return_missing_columns(
+        self, cols: list[sqlglot.expressions]
+    ) -> list[InvalidCols]:
         """Clean a list of sqlglot column names to remove the prefix (l.)
         and suffix (_l) and then return any that are missing from the
         input dataframe(s).
@@ -72,25 +59,13 @@ class InvalidColValidator(SettingsValidator):
             list: Returns a list of all input columns not found within
                 your raw input tables.
         """
-        cols = set(self.remove_prefix_and_suffix_from_column(c) for c in cols)
-        return self.return_missing_columns(cols)
+        cleaned_cols = set(self.remove_prefix_and_suffix_from_column(c) for c in cols)
+        return self.return_missing_columns(cleaned_cols)
 
-    def validate_table_name(self, col: sqlglot.expressions):
-        """Check if the table name supplied is valid.
-
-        Args:
-            col (sqlglot.expressions): A column string given as
-                a sqlglot expression
-
-        Returns:
-            bool: Whether the table name exists and is valid.
-        """
-        table_name = col.table
-        # If the table name exists, check it's valid.
-        return table_name not in ["l", "r"]
-
-    def validate_table_names(self, cols: list[sqlglot.expressions]):
-        """Validate a series of table names with `validate_table_name`
+    def validate_table_names(self, cols: list[sqlglot.expressions]) -> InvalidCols:
+        """Validate a series of table names assigned to columns extracted from
+        SQL statements. Here, we expect all columns to be assigned either a `l` or
+        `r` prefix.
 
         Args:
             cols (list[sqlglot.expressions]): A list of columns given as
@@ -103,24 +78,12 @@ class InvalidColValidator(SettingsValidator):
         # the key to use when producing our warning logs
         invalid_type = "invalid_table_pref"
         # list of valid columns
-        invalid_cols = [c.sql() for c in cols if self.validate_table_name(c)]
+        invalid_cols = [c.sql() for c in cols if c.table not in ["l", "r"]]
         return InvalidCols(invalid_type, invalid_cols)
 
-    def validate_column_suffix(self, col: sqlglot.expressions):
-        """Check if the column suffix supplied is valid.
-
-        Args:
-            col (sqlglot.expressions): A column string given as
-                a sqlglot expression
-
-        Returns:
-            bool: Whether a valid column suffix exists
-        """
-        # Check if the supplied col suffix is valid.
-        return not col.sql().endswith(("_l", "_r"))
-
-    def validate_column_suffixes(self, cols: list[sqlglot.expressions]):
-        """Validate a series of column suffixes with `validate_column_suffix`
+    def validate_column_suffixes(self, cols: list[sqlglot.expressions]) -> InvalidCols:
+        """Validate a series of column suffixes. Here, we expect columns to be suffixed
+        with either `_l` or `_r`. Where this is missing, flag it as an error.
 
         Args:
             cols (list[sqlglot.expressions]): A list of columns given as
@@ -133,19 +96,22 @@ class InvalidColValidator(SettingsValidator):
         # the key to use when producing our warning logs
         invalid_type = "invalid_col_suffix"
         # list of valid columns
-        invalid_cols = [c.sql() for c in cols if self.validate_column_suffix(c)]
+        invalid_cols = [c.sql() for c in cols if not c.sql().endswith(("_l", "_r"))]
         return InvalidCols(invalid_type, invalid_cols)
 
-    def validate_columns_in_sql_string(
+    def validate_columns_in_sql_strings(
         self,
-        sql_string: str,
+        sql_strings: list[str],
         checks: list,
-    ):
-        """Evaluate whether the columns supplied in a given string of SQL
+    ) -> list[InvalidCols]:
+        """Evaluate whether the column(s) supplied in a series of SQL strings
         exist in our raw data.
 
+        This is used to assess whether a blocking rule or comparison level
+        contains columns that exist in the underlying dataset(s) supplied.
+
         Args:
-            sql_string (str): A string of valid SQL
+            sql_strings (list[str]): A list of valid SQL strings
             checks (list[function]): The functions used to check the parsed
                 sql string. These can be: `clean_and_return_missing_columns`,
                 `validate_table_names` and `validate_column_suffixes`
@@ -156,43 +122,20 @@ class InvalidColValidator(SettingsValidator):
                 identified.
         """
 
-        try:
-            syntax_tree = sqlglot.parse_one(sql_string, read=self._sql_dialect)
-        except Exception:
-            # Usually for the `ELSE` clause. If we can't parse a
-            # SQL condition, it's better to just pass.
-            return
+        validation_dict = {}
+        for sql_string in sql_strings:
+            cols = parse_columns_in_sql(sql_string, sql_dialect=self._sql_dialect)
+            if not cols: continue  # checks if our sql string is parseable
+            # Collect trees for checks and filter only those that contain invalid columns
+            invalid_column_trees = [
+                # deepcopy to ensure our syntax trees aren't manipulated
+                inv_cols for inv_cols in (check(deepcopy(cols)) for check in checks)
+                if inv_cols.contains_invalid_columns
+            ]
 
-        cols = [
-            remove_quotes_from_identifiers(col)
-            for col in syntax_tree.find_all(exp.Column)
-        ]
-        # deepcopy to ensure our syntax trees aren't manipulated
-        invalid_tree = [check(deepcopy(cols)) for check in checks]
-        # Report only those checks with valid flags (i.e. there's an invalid
-        # column in one of the checks)
-        return [tree for tree in invalid_tree if tree.is_valid]
+            if invalid_column_trees: validation_dict[sql_string] = invalid_column_trees
 
-    def validate_columns_in_sql_string_dict_comp(
-        self,
-        sql_conds,
-        prefix_suffix_fun,
-    ):
-        # This is simply a wrapper function that loops
-        # around validate_columns_in_sql_string so we can
-        # more easily reuse the code
-        def validate(
-            sql,
-        ):
-            return self.validate_columns_in_sql_string(
-                sql,
-                checks=(
-                    self.clean_and_return_missing_columns,
-                    prefix_suffix_fun,
-                ),
-            )
-
-        return {sql: validate(sql) for sql in sql_conds if validate(sql)}
+        return validation_dict
 
     def validate_settings_column(self, settings_id, cols: set):
         """Validate simple settings columns with strings as input.
@@ -208,57 +151,10 @@ class InvalidColValidator(SettingsValidator):
                 columns identified as missing.
         """
         missing_cols = self.return_missing_columns(cols)
-        # The `is_valid` check simply tests to see if any values have
+        # The `contains_invalid_columns` check simply tests to see if any values have
         # been flagged. If there are no invalid cols, return None.
-        if missing_cols.is_valid:
+        if missing_cols.contains_invalid_columns:
             return settings_id, missing_cols
-
-    @property
-    def validate_uid(self):
-        return self.validate_settings_column(
-            settings_id="unique_id_column_name",
-            cols=self.uid,
-        )
-
-    @property
-    def validate_cols_to_retain(self):
-        return self.validate_settings_column(
-            settings_id="additional_columns_to_retain",
-            cols=self.cols_to_retain,
-        )
-
-    @property
-    def validate_blocking_rules(self):
-        # See docstring for `validate_columns_in_sql_string_dict_comp`.
-        return self.validate_columns_in_sql_string_dict_comp(
-            sql_conds=self.blocking_rules,
-            prefix_suffix_fun=self.validate_table_names,
-        )
-
-    @property
-    def validate_comparison_levels(self):
-        # See docstring for `validate_columns_in_sql_string_dict_comp`.
-        invalid_col_tracker = []
-        for comparisons in self.comparisons:
-            # pull out comparison dict
-            comp_dict = comparisons._comparison_dict
-            sql_conds = [cl["sql_condition"] for cl in comp_dict["comparison_levels"]]
-
-            cl_invalid = self.validate_columns_in_sql_string_dict_comp(
-                sql_conds=sql_conds,
-                prefix_suffix_fun=self.validate_column_suffixes,
-            )
-            if cl_invalid:
-                output_c_name = comp_dict.get("output_column_name")
-                # This needs to be a tuple as output_c_name can be
-                # set to None.
-                output_tuple = (
-                    output_c_name,
-                    cl_invalid,
-                )
-                invalid_col_tracker.append(output_tuple)
-
-        return invalid_col_tracker
 
 
 class InvalidColumnsLogger(InvalidColValidator):
@@ -269,8 +165,7 @@ class InvalidColumnsLogger(InvalidColValidator):
 
     def __init__(self, linker):
         self.settings_validator = super().__init__(linker)
-        self.bold_underline = colour.BOLD + colour.UNDERLINE
-        self.bold_red = colour.BOLD + colour.RED
+        self.input_columns = self._input_columns
 
         # These are extracted in the inherited
         # SettingsValidator class
@@ -292,21 +187,87 @@ class InvalidColumnsLogger(InvalidColValidator):
             )
         )
 
-    def construct_generic_settings_log_string(self, constructor_dict):
-        settings_id, InvCols = constructor_dict
-        logger.warning(
-            f"{colour.BOLD}A problem was found within your setting "
-            f"`{settings_id}`:{colour.END}\n{InvCols.construct_log_string}"
-            "\n"
+    @property
+    def validate_uid(self):
+        return self.validate_settings_column(
+            settings_id="unique_id_column_name",
+            cols=self.uid,
         )
 
-    def log_invalid_warnings_within_sql(self, invalid_sql_statements):
+    @property
+    def validate_cols_to_retain(self):
+        return self.validate_settings_column(
+            settings_id="additional_columns_to_retain",
+            cols=self.cols_to_retain,
+        )
+
+    @property
+    def validate_blocking_rules(self):
+        return self.validate_columns_in_sql_strings(
+            sql_strings=self.blocking_rules,
+            checks=(
+                # Check column validity and for invalid table names
+                self.clean_and_return_missing_columns,
+                self.validate_table_names,
+            ),
+        )
+
+    @property
+    def validate_comparison_levels(self):
+        # See docstring for `validate_columns_in_sql_string_dict_comp`.
+        invalid_col_tracker = []
+        for comparisons in self.comparisons:
+            # pull out comparison dict
+            comp_dict = comparisons._comparison_dict
+            sql_strings = [cl["sql_condition"] for cl in comp_dict["comparison_levels"]]
+
+            cl_invalid = self.validate_columns_in_sql_strings(
+                sql_strings=sql_strings,
+                checks=(
+                    # Check column validity and for invalid suffixes
+                    self.clean_and_return_missing_columns,
+                    self.validate_column_suffixes,
+                ),
+            )
+            if cl_invalid:
+                invalid_col_tracker.append(
+                    (comp_dict.get("output_column_name"), cl_invalid)
+                )
+
+        return invalid_col_tracker
+
+    def construct_generic_settings_log_string(self, constructor_dict) -> str:
+        if not constructor_dict: return ""
+
+        settings_id, InvCols = constructor_dict
+        output_warning = [
+            "======================================",
+            f"Setting: `{settings_id}`",
+            "======================================\n",
+        ]
+
+        # The blank string acts as a newline
+        output_warning.extend([InvCols.construct_log_string(), ""])
+        logger.warning("\n".join(output_warning))
+
+    def log_invalid_warnings_within_sql(
+        self,
+        invalid_sql_statements: dict[str, list[InvalidCols]]
+    ) -> str:
+        log_str = []
         for sql, invalid_cols in invalid_sql_statements.items():
-            invalid_strings = "\n".join(c.construct_log_string for c in invalid_cols)
-            sql = f"{self.bold_red}`{sql}`{colour.END}"
-            logger.warning(f"{sql}:\n{invalid_strings}")
+            log_str.append(f"    SQL: `{sql}`")
+
+            for c in invalid_cols:
+                log_str.append(f"{c.construct_log_string()}")
+            # Acts as a newline as we're joining at the end of the str
+            log_str.append("")
+
+        return "\n".join(log_str)
 
     def construct_blocking_rule_log_strings(self, invalid_brs):
+        if not invalid_brs: return ""
+
         # `invalid_brs` are in the format of:
         # {
         # "blocking_rule_1": {
@@ -314,58 +275,61 @@ class InvalidColumnsLogger(InvalidColValidator):
         #  - InvalidCols tuple for invalid table names
         # }
         # }
+        output_warning = [
+            "======================================",
+            "Invalid Columns(s) in Blocking Rule(s)",
+            "======================================\n",
+        ]
 
-        logger.warning(
-            f"{colour.BOLD}The following blocking rule(s) were "
-            f"found to contain invalid column(s):{colour.END}"
-        )
+        output_warning.append(self.log_invalid_warnings_within_sql(invalid_brs))
+        logger.warning("\n".join(output_warning))
 
-        self.log_invalid_warnings_within_sql(invalid_brs)
+    def construct_comparison_level_log_strings(self, invalid_cls) -> str:
+        if not invalid_cls: return ""
 
-        logger.warning("\n")
-
-    def construct_comparison_level_log_strings(self, invalid_cls):
         # `invalid_cls` is made up of a tuple containing:
         # 1) The `output_column_name` for the level, if it exists
         # 2) A dictionary in the same format as our blocking rules
         # {sql: [InvalidCols tuples]}
-        logger.warning(
-            f"{colour.BOLD}The following comparison(s) were "
-            f"found to contain invalid column(s):{colour.END}"
-        )
+
+        output_warning = [
+            "======================================",
+            "Invalid Columns(s) in Comparison(s)",
+            "======================================\n",
+        ]
+
         for cn, cls in invalid_cls:
             # Annoyingly, `output_comparison_name` can be None,
             # so this allows those entries without a name to pass
             # through.
-            if cn is not None:
-                logger.warning(f"{colour.BOLD}{cn}{colour.END}")
-            self.log_invalid_warnings_within_sql(cls)
+            if cn is not None: output_warning.append(f"Comarpison: {cn}")
+            output_warning.append("--------------------------------------")
 
-        logger.warning("\n")
+            output_warning.append(self.log_invalid_warnings_within_sql(cls))
+
+        logger.warning("\n".join(output_warning))
 
     def construct_output_logs(self):
-        # if no errors exist, return
+        # self.check_for_single_column_dataset()
+
+        # if no errors exist, then we can exit early
         if not self.invalid_cols_detected:
             return
 
-        if self.valid_uid:
-            self.construct_generic_settings_log_string(self.valid_uid)
-
-        if self.valid_cols_to_retain:
-            self.construct_generic_settings_log_string(self.valid_cols_to_retain)
-
-        if self.invalid_brs:
-            self.construct_blocking_rule_log_strings(self.invalid_brs)
-
-        if self.invalid_cls:
-            self.construct_comparison_level_log_strings(self.invalid_cls)
-
-        # Only trigger if one of the outputs is valid
         logger.warning(
-            f"{self.bold_underline}"
+            "SETTINGS VALIDATION: The following errors were identified in your settings "
+            "dictionary. \n"
+        )
+
+        self.construct_generic_settings_log_string(self.valid_uid)
+        self.construct_generic_settings_log_string(self.valid_cols_to_retain)
+        self.construct_blocking_rule_log_strings(self.invalid_brs)
+        self.construct_comparison_level_log_strings(self.invalid_cls)
+
+        # print so this doesn't appear in the logs
+        print(
             "You may want to verify your settings dictionary has "
             "valid inputs in all fields before continuing."
-            f"{colour.END}"
         )
 
 
@@ -386,53 +350,39 @@ class InvalidCols(NamedTuple):
     invalid_columns: list
 
     @property
-    def is_valid(self):
+    def contains_invalid_columns(self):
         # Quick check to see whether invalid cols exist.
         # Makes list comprehension simpler.
         return True if len(self.invalid_columns) > 0 else False
 
     @property
-    def _columns(self):
-        return "columns" if len(self.invalid_columns) > 1 else "column"
-
-    @property
     def columns_as_text(self):
-        return ", ".join(
-            f"{colour.ITALICS}`{c}`{colour.END}" for c in self.invalid_columns
-        )
+        """Returns the invalid columns as a comma-separated
+        string wrapped with backticks."""
+
+        return ", ".join(f"`{c}`" for c in self.invalid_columns)
 
     @property
     def invalid_cols(self):
-        _c = self._columns
-        _is_are = "are" if _c == "columns" else "is"
         return (
-            f"The following {_c} {_is_are} missing from one or more "
-            f"of your input dataframe(s):\n{self.columns_as_text}"
+            "       - Missing column(s) from input dataframe(s): "
+            f"{self.columns_as_text}"
         )
-
-    @property
-    def invalid_table_pref_intro_text(self):
-        _c = self._columns
-        cont = "contain" if _c == "columns" else "contains"
-        return f"The following {_c} {cont} invalid "
 
     @property
     def invalid_table_pref(self):
         return (
-            f"{self.invalid_table_pref_intro_text}\n"
-            "table prefixes (only `l.` and `r.` are valid):"
-            f"\n{self.columns_as_text}"
+            "       - Invalid table prefixes (only `l.` and `r.` are valid): "
+            f"{self.columns_as_text}"
         )
 
     @property
     def invalid_col_suffix(self):
         return (
-            f"{self.invalid_table_pref_intro_text}\n"
-            "table suffixes (only `_l` and `_r` are valid):"
-            f"\n{self.columns_as_text}"
+            "       - Invalid table suffixes (only `_l` and `_r` are valid): "
+            f"{self.columns_as_text}"
         )
 
-    @property
     def construct_log_string(self):
         if self.invalid_columns:
             # calls invalid_cols, invalid_table_pref, etc

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -27,34 +27,38 @@ class SettingsValidator:
         self.linker = linker
 
     @property
+    def settings_obj(self):
+       return self.linker._settings_obj
+
+    @property
     def _sql_dialect(self):
-        if self.linker._settings_obj:
-            return self.linker._settings_obj._sql_dialect
+        if self.settings_obj:
+            return self.settings_obj._sql_dialect
         else:
             return None
 
     @property
     def cols_to_retain(self):
         return self.clean_list_of_column_names(
-            self.linker._settings_obj._additional_cols_to_retain
+            self.settings_obj._additional_cols_to_retain
         )
 
     @property
     def uid(self):
-        uid_as_tree = InputColumn(self.linker._settings_obj._unique_id_column_name)
+        uid_as_tree = InputColumn(self.settings_obj._unique_id_column_name)
         return self.clean_list_of_column_names(uid_as_tree)
 
     @property
     def blocking_rules(self):
-        brs = self.linker._settings_obj._blocking_rules_to_generate_predictions
+        brs = self.settings_obj._blocking_rules_to_generate_predictions
         return [br.blocking_rule for br in brs]
 
     @property
     def comparisons(self):
-        return self.linker._settings_obj.comparisons
+        return self.settings_obj.comparisons
 
     @property
-    def input_columns_by_df(self):
+    def _input_columns_by_df(self):
         """A dictionary containing all input dataframes and the columns located
         within.
 
@@ -71,12 +75,12 @@ class SettingsValidator:
         return input_columns
 
     @property
-    def input_columns(self):
+    def _input_columns(self):
         """
         Returns:
             set: The set intersection of all columns contained within each dataset.
         """
-        return reduce(and_, self.input_columns_by_df.values())
+        return reduce(and_, self._input_columns_by_df.values())
 
     def clean_list_of_column_names(self, col_list, as_tree=True):
         """Clean a list of columns names by removing the quote characters

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -28,7 +28,7 @@ class SettingsValidator:
 
     @property
     def settings_obj(self):
-       return self.linker._settings_obj
+        return self.linker._settings_obj
 
     @property
     def _sql_dialect(self):

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -255,7 +255,7 @@ def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
     blocking_rules_to_check = [
         'levenshtein("sur_name", r."sur Name") < 3',
         "coalesce(l.first_name, NULL) = coalesce(first_name, NULL)",
-        "datediff('day', l.\"cluster\", r.dob_test)",
+        "datediff('day', l.\"dob_test\", r.cluster)",
         # Identical rule - should be ignored
         "datediff('day', l.\"dob_test\", r.cluster)",
     ]

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import pandas as pd
 import pytest
+import logging
 
 from splink.convert_v2_to_v3 import convert_settings_from_v2_to_v3
 from splink.duckdb.linker import DuckDBLinker
@@ -80,7 +81,7 @@ def verify_complicated_settings_objects(invalid, expected):
             )
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("sqlite", "postgres")
 def test_invalid_cols_detected(test_helpers, dialect):
     helper = test_helpers[dialect]
     Linker = helper.Linker
@@ -103,8 +104,8 @@ def test_invalid_cols_detected(test_helpers, dialect):
     assert settings_logger.invalid_cols_detected is True
 
 
-@mark_with_dialects_excluding()
-def test_columns_from_settings(test_helpers, dialect):
+@mark_with_dialects_excluding("sqlite", "postgres", "spark")
+def test_unique_id_settings_validation(test_helpers, dialect, caplog):
     helper = test_helpers[dialect]
     Linker = helper.Linker
     df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
@@ -130,14 +131,45 @@ def test_columns_from_settings(test_helpers, dialect):
     assert uid_check is None
 
     # Add additional faulty columns to retain
-    settings["unique_id_column_name"] = "invalid column name"
-    uid_check = alter_settings(linker, settings).validate_uid
+    invalid_id = "invalid column name"
+    settings["unique_id_column_name"] = invalid_id
+    uid_check = alter_settings(linker, settings)
     verify_single_setting_validation(
-        uid_check,
+        uid_check.validate_uid,
         "unique_id_column_name",
         "invalid_cols",
-        ["invalid column name"],
+        [invalid_id],
     )
+
+    # Check logger formatting is approximately what we expect...
+    with caplog.at_level(logging.WARNING):
+        uid_check.construct_output_logs()
+        str_header = (
+            "Setting: `unique_id_column_name`\n"
+            "======================================\n"
+        )
+        str_error = (
+        "       - Missing column(s) from input dataframe(s): "
+        f"`{invalid_id}`\n"
+        )
+        for string in [str_header, str_error]:
+            assert string in caplog.text
+
+
+@mark_with_dialects_excluding("sqlite", "postgres", "spark")
+def test_retained_cols_settings_validation(test_helpers, dialect, caplog):
+    helper = test_helpers[dialect]
+    Linker = helper.Linker
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    # Create random settings to check outputs with
+    settings = get_settings_dict()
+    linker = Linker(
+        df,
+        settings,
+        **helper.extra_linker_args(),
+    )
+    settings_logger = InvalidColumnsLogger(linker)
 
     ##################
     # COLS TO RETAIN #
@@ -147,19 +179,50 @@ def test_columns_from_settings(test_helpers, dialect):
     assert settings_logger.validate_cols_to_retain is None
 
     # Add additional faulty columns to retain
+    exp_cols_to_retain = ["also_invalid", "invalid column name"]
     settings["additional_columns_to_retain"] = [
         "cluster",
         "invalid column name",
         "also_invalid",
         "cluster",  # duplicate - check it is ignored
     ]
-    c_to_retain = alter_settings(linker, settings).validate_cols_to_retain
+    c_to_retain = alter_settings(linker, settings)
     verify_single_setting_validation(
-        c_to_retain,
+        c_to_retain.validate_cols_to_retain,
         "additional_columns_to_retain",
         "invalid_cols",
-        ["also_invalid", "invalid column name"],
+        exp_cols_to_retain
     )
+    # Check logger formatting is approximately what we expect...
+    with caplog.at_level(logging.WARNING):
+        c_to_retain.construct_output_logs()
+        str_header = (
+            "Setting: `additional_columns_to_retain`\n"
+            "======================================\n"
+        )
+        # column names are stored in a hashset, so we can't check for exact equality
+        # including the column names
+        str_error = (
+        "       - Missing column(s) from input dataframe(s): `"
+        )
+        for string in [str_header, str_error]:
+            assert string in caplog.text
+
+
+@mark_with_dialects_excluding("sqlite", "postgres", "spark")
+def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
+    helper = test_helpers[dialect]
+    Linker = helper.Linker
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    # Create random settings to check outputs with
+    settings = get_settings_dict()
+    linker = Linker(
+        df,
+        settings,
+        **helper.extra_linker_args(),
+    )
+    settings_logger = InvalidColumnsLogger(linker)
 
     ##################
     # BLOCKING RULES #
@@ -200,7 +263,7 @@ def test_columns_from_settings(test_helpers, dialect):
         "datediff('day', l.\"cluster\", r.dob_test)",
     ]
     settings["blocking_rules_to_generate_predictions"] = blocking_rules_to_check
-    invalid_brs = alter_settings(linker, settings).validate_blocking_rules
+    invalid_brs = alter_settings(linker, settings)
 
     lev_br = [
         InvalidCols(
@@ -208,18 +271,52 @@ def test_columns_from_settings(test_helpers, dialect):
         ),
         InvalidCols(invalid_type="invalid_table_pref", invalid_columns=["sur_name"]),
     ]
-    coal_br = [
-        InvalidCols(invalid_type="invalid_table_pref", invalid_columns=["first_name"])
-    ]
-    datediff_br = [
-        InvalidCols(invalid_type="invalid_cols", invalid_columns=["dob_test"])
-    ]
-    invalid_rules = (lev_br, coal_br, datediff_br)
+    coal_br = InvalidCols(invalid_type="invalid_table_pref", invalid_columns=["first_name"])
+    datediff_br = InvalidCols(invalid_type="invalid_cols", invalid_columns=["dob_test"])
+    invalid_rules = (lev_br, [coal_br], [datediff_br])
     expected_out = {
         br: inv_cols for br, inv_cols in zip(blocking_rules_to_check, invalid_rules)
     }
     # Check both dictionaries are identical
-    verify_complicated_settings_objects(invalid_brs, expected_out)
+    verify_complicated_settings_objects(invalid_brs.validate_blocking_rules, expected_out)
+
+    # Check logger formatting is approximately what we expect...
+    with caplog.at_level(logging.WARNING):
+        invalid_brs.construct_output_logs()
+
+        str_header = (
+            "Invalid Columns(s) in Blocking Rule(s)\n"
+            "======================================\n"
+        )
+        # column names are stored in a hashset, so we can't check for exact equality
+        # where we have multiple column names
+        missing_cols = (
+        "       - Missing column(s) from input dataframe(s): "
+        "`sur_name`"
+        )
+        invalid_prefix = (
+        "       - Invalid table prefixes (only `l.` and `r.` are valid): "
+        "`first_name`"
+        )
+        for string in [str_header, missing_cols, invalid_prefix]:
+        # for string in [str_header, missing_cols]:
+            assert string in caplog.text
+
+
+@mark_with_dialects_excluding("sqlite", "postgres", "spark")
+def test_comparison_settings_validation(test_helpers, dialect, caplog):
+    helper = test_helpers[dialect]
+    Linker = helper.Linker
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    # Create random settings to check outputs with
+    settings = get_settings_dict()
+    linker = Linker(
+        df,
+        settings,
+        **helper.extra_linker_args(),
+    )
+    settings_logger = InvalidColumnsLogger(linker)
 
     #####################
     # COMPARISON LEVELS #
@@ -285,7 +382,7 @@ def test_columns_from_settings(test_helpers, dialect):
     }
 
     settings["comparisons"][3:] = [email_cc, city_cc]
-    invalid_cls = alter_settings(linker, settings).validate_comparison_levels
+    invalid_cls = alter_settings(linker, settings)
 
     expected_email_invalid_output = {
         "levenshtein(emails_l, test.email_r) < 3": [
@@ -315,9 +412,30 @@ def test_columns_from_settings(test_helpers, dialect):
     # [1] - list of SQL statements and invalid column tuples
     # Dicts can't be used as output column name is not a required variable
     verify_complicated_settings_objects(
-        invalid_cls[0][1], expected_email_invalid_output
+        invalid_cls.validate_comparison_levels[0][1], expected_email_invalid_output
     )
-    verify_complicated_settings_objects(invalid_cls[1][1], expected_city_invalid_output)
+    verify_complicated_settings_objects(
+        invalid_cls.validate_comparison_levels[1][1],
+        expected_city_invalid_output
+    )
+    # Check logger formatting is approximately what we expect...
+    with caplog.at_level(logging.WARNING):
+        invalid_cls.construct_output_logs()
+
+        str_header = (
+            "Invalid Columns(s) in Comparison(s)\n"
+            "======================================\n"
+        )
+        missing_cols = (
+        "\n       - Missing column(s) from input dataframe(s): "
+        "`city_test`\n"
+        )
+        invalid_prefix = (
+        "\n       - Invalid table suffixes (only `_l` and `_r` are valid): "
+        f"`city`\n"
+        )
+        for string in [str_header, missing_cols, invalid_prefix]:
+            assert string in caplog.text
 
 
 def test_settings_validation_on_2_to_3_converter():
@@ -466,5 +584,4 @@ def test_comparison_validation():
 
     for n, (e, txt) in enumerate(expected_errors):
         with pytest.raises(e, match=txt):
-            raise errors[n]
             raise errors[n]

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -291,9 +291,7 @@ def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
         )
         # column names are stored in a hashset, so we can't check for exact equality
         # where we have multiple column names
-        missing_cols = (
-            "       - Missing column(s) from input dataframe(s): `dob_test`"
-        )
+        missing_cols = "       - Missing column(s) from input dataframe(s): `dob_test`"
         invalid_prefix = (
             "       - Invalid table prefixes (only `l.` and `r.` are valid): "
             "`first_name`"

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,8 +1,8 @@
+import logging
 from copy import deepcopy
 
 import pandas as pd
 import pytest
-import logging
 
 from splink.convert_v2_to_v3 import convert_settings_from_v2_to_v3
 from splink.duckdb.linker import DuckDBLinker
@@ -149,8 +149,7 @@ def test_unique_id_settings_validation(test_helpers, dialect, caplog):
             "======================================\n"
         )
         str_error = (
-        "       - Missing column(s) from input dataframe(s): "
-        f"`{invalid_id}`\n"
+            "       - Missing column(s) from input dataframe(s): " f"`{invalid_id}`\n"
         )
         for string in [str_header, str_error]:
             assert string in caplog.text
@@ -191,7 +190,7 @@ def test_retained_cols_settings_validation(test_helpers, dialect, caplog):
         c_to_retain.validate_cols_to_retain,
         "additional_columns_to_retain",
         "invalid_cols",
-        exp_cols_to_retain
+        exp_cols_to_retain,
     )
     # Check logger formatting is approximately what we expect...
     with caplog.at_level(logging.WARNING):
@@ -202,9 +201,7 @@ def test_retained_cols_settings_validation(test_helpers, dialect, caplog):
         )
         # column names are stored in a hashset, so we can't check for exact equality
         # including the column names
-        str_error = (
-        "       - Missing column(s) from input dataframe(s): `"
-        )
+        str_error = "       - Missing column(s) from input dataframe(s): `"
         for string in [str_header, str_error]:
             assert string in caplog.text
 
@@ -271,14 +268,18 @@ def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
         ),
         InvalidCols(invalid_type="invalid_table_pref", invalid_columns=["sur_name"]),
     ]
-    coal_br = InvalidCols(invalid_type="invalid_table_pref", invalid_columns=["first_name"])
+    coal_br = InvalidCols(
+        invalid_type="invalid_table_pref", invalid_columns=["first_name"]
+    )
     datediff_br = InvalidCols(invalid_type="invalid_cols", invalid_columns=["dob_test"])
     invalid_rules = (lev_br, [coal_br], [datediff_br])
     expected_out = {
         br: inv_cols for br, inv_cols in zip(blocking_rules_to_check, invalid_rules)
     }
     # Check both dictionaries are identical
-    verify_complicated_settings_objects(invalid_brs.validate_blocking_rules, expected_out)
+    verify_complicated_settings_objects(
+        invalid_brs.validate_blocking_rules, expected_out
+    )
 
     # Check logger formatting is approximately what we expect...
     with caplog.at_level(logging.WARNING):
@@ -291,15 +292,14 @@ def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
         # column names are stored in a hashset, so we can't check for exact equality
         # where we have multiple column names
         missing_cols = (
-        "       - Missing column(s) from input dataframe(s): "
-        "`sur_name`"
+            "       - Missing column(s) from input dataframe(s): " "`sur_name`"
         )
         invalid_prefix = (
-        "       - Invalid table prefixes (only `l.` and `r.` are valid): "
-        "`first_name`"
+            "       - Invalid table prefixes (only `l.` and `r.` are valid): "
+            "`first_name`"
         )
         for string in [str_header, missing_cols, invalid_prefix]:
-        # for string in [str_header, missing_cols]:
+            # for string in [str_header, missing_cols]:
             assert string in caplog.text
 
 
@@ -415,8 +415,7 @@ def test_comparison_settings_validation(test_helpers, dialect, caplog):
         invalid_cls.validate_comparison_levels[0][1], expected_email_invalid_output
     )
     verify_complicated_settings_objects(
-        invalid_cls.validate_comparison_levels[1][1],
-        expected_city_invalid_output
+        invalid_cls.validate_comparison_levels[1][1], expected_city_invalid_output
     )
     # Check logger formatting is approximately what we expect...
     with caplog.at_level(logging.WARNING):
@@ -427,12 +426,11 @@ def test_comparison_settings_validation(test_helpers, dialect, caplog):
             "======================================\n"
         )
         missing_cols = (
-        "\n       - Missing column(s) from input dataframe(s): "
-        "`city_test`\n"
+            "\n       - Missing column(s) from input dataframe(s): " "`city_test`\n"
         )
         invalid_prefix = (
-        "\n       - Invalid table suffixes (only `_l` and `_r` are valid): "
-        f"`city`\n"
+            "\n       - Invalid table suffixes (only `_l` and `_r` are valid): "
+            "`city`\n"
         )
         for string in [str_header, missing_cols, invalid_prefix]:
             assert string in caplog.text

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -257,7 +257,7 @@ def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
         "coalesce(l.first_name, NULL) = coalesce(first_name, NULL)",
         "datediff('day', l.\"cluster\", r.dob_test)",
         # Identical rule - should be ignored
-        "datediff('day', l.\"cluster\", r.dob_test)",
+        "datediff('day', l.\"dob_test\", r.cluster)",
     ]
     settings["blocking_rules_to_generate_predictions"] = blocking_rules_to_check
     invalid_brs = alter_settings(linker, settings)
@@ -292,7 +292,7 @@ def test_blocking_rule_settings_validation(test_helpers, dialect, caplog):
         # column names are stored in a hashset, so we can't check for exact equality
         # where we have multiple column names
         missing_cols = (
-            "       - Missing column(s) from input dataframe(s): " "`sur_name`"
+            "       - Missing column(s) from input dataframe(s): `dob_test`"
         )
         invalid_prefix = (
             "       - Invalid table prefixes (only `l.` and `r.` are valid): "


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Builds on https://github.com/moj-analytical-services/splink/pull/1522.



### Give a brief description for the solution you have provided
This PR refactors a lot of the existing code, in order to streamline the codebase and also makes fundamental changes to the logs to improve outputs.

The goals of this PR are:
* To make future development simpler by reducing the complexity of the code.
* Improve code readability.
* Improve docs readability.

<hr>

#### Main changes

**Refactoring**
* Pulled out `parse_columns_in_sql` so it can be more easily reused within the wider codebase.
* Refactored and cleaned up a lot of the existing code. If there's anything that's hard to follow, let me know as the aim here is to make the code much simpler to follow and expand, as and when needed.
* Pulled the existing test - `test_columns_from_settings` - apart, allowing us to individually verify each validation check is working as expected, rather than everything in one block. This grants us more flexibility and easier bug discovery.

**Log outputs**
* The logs now print in blocks, meaning the text output within user logging files is much easier to interpret. Previously, each paragraph was printed to the console individually, making the logs messier than they need to be.
* The logs are far cleaner. They also no longer depend on python's built in colours to help with readability, meaning they print properly across more systems and inside log text files.

**New log output**
The output from the settings logger looks now looks like so:
![Screenshot 2023-10-05 at 12 08 36](https://github.com/moj-analytical-services/splink/assets/45356472/fac642e7-7dcd-4c7b-93a8-75f7aaa542c8)

And just for reference, the existing logs looked like so when printed inside a logging file:
![Screenshot 2023-10-05 at 16 21 04](https://github.com/moj-analytical-services/splink/assets/45356472/3acceab1-04e3-4582-8380-8b1b9f186ff2)

It's decipherable, but not ideal.

Documentation will follow in a future pull request.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


