### PR TITLE
Update sqlglot to >=13.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3585,13 +3585,13 @@ sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlglot"
-version = "18.11.3"
+version = "18.12.0"
 description = "An easily customizable SQL parser and transpiler"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "sqlglot-18.11.3-py3-none-any.whl", hash = "sha256:7a6bf3eb3612e5e88cfc790c4df97b5ec1560b7984d9cd248789b86a7417aa20"},
-    {file = "sqlglot-18.11.3.tar.gz", hash = "sha256:128ded18b4a1bec7c3ee789c0a0b3c69851a0806b783bf9a6635c487353a687b"},
+    {file = "sqlglot-18.12.0-py3-none-any.whl", hash = "sha256:e43489daa6ca685e4a95ba316f4a43c367d4c39b87788eec38718ea4bfd58451"},
+    {file = "sqlglot-18.12.0.tar.gz", hash = "sha256:71269ea98e158978362afaa5a3db313641a96b3ac70aaee35ff1b129dec3e9e6"},
 ]
 
 [package.extras]
@@ -4067,4 +4067,4 @@ spark = ["pyspark"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1,<4.0.0"
-content-hash = "f985027558f6f548d19b58929c1745a52137651fb21cc97ea5086581c9236ff2"
+content-hash = "d82f5bb46ea123dbc14cadd37849fff5a112b409a2d864de3c4bf6ccee6b798b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3585,17 +3585,17 @@ sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlglot"
-version = "11.4.1"
+version = "18.11.3"
 description = "An easily customizable SQL parser and transpiler"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "sqlglot-11.4.1-py3-none-any.whl", hash = "sha256:88e00a34b3771fa00bc688eb10719da3e5046c92502b055f19e4e3420a646c14"},
-    {file = "sqlglot-11.4.1.tar.gz", hash = "sha256:c5029e6c4a5deab04ccdcbd5722294f5a1888f7f297467de9c27dbe3a7213112"},
+    {file = "sqlglot-18.11.3-py3-none-any.whl", hash = "sha256:7a6bf3eb3612e5e88cfc790c4df97b5ec1560b7984d9cd248789b86a7417aa20"},
+    {file = "sqlglot-18.11.3.tar.gz", hash = "sha256:128ded18b4a1bec7c3ee789c0a0b3c69851a0806b783bf9a6635c487353a687b"},
 ]
 
 [package.extras]
-dev = ["autoflake", "black", "duckdb", "isort", "mypy (>=0.990)", "pandas", "pdoc", "pre-commit", "pyspark", "python-dateutil"]
+dev = ["autoflake", "black", "duckdb (>=0.6)", "isort", "mypy (>=0.990)", "pandas", "pdoc", "pre-commit", "pyspark", "python-dateutil", "types-python-dateutil"]
 
 [[package]]
 name = "tabulate"
@@ -4067,4 +4067,4 @@ spark = ["pyspark"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1,<4.0.0"
-content-hash = "4959ce0faf49469abe224d385df9c1b00a4477589ae8b880680b671bc11bf376"
+content-hash = "f985027558f6f548d19b58929c1745a52137651fb21cc97ea5086581c9236ff2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ jsonschema = ">=3.2,<5.0"
 pandas = ">1.3.0"
 duckdb = ">=0.8.0"
 # normalize issue in sqlglot - temporarily exclude updates
-sqlglot = ">=7.0.0,<11.4.2"
+sqlglot = "^18.0.0"
 altair = "^5.0.1"
 Jinja2 = ">=3.0.3"
 phonetics = "^1.0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ jsonschema = ">=3.2,<5.0"
 # 1.3.5 is the last version supporting py 3.7.1
 pandas = ">1.3.0"
 duckdb = ">=0.8.0"
-# normalize issue in sqlglot - temporarily exclude updates
-sqlglot = "^18.0.0"
+sqlglot = ">=13.0.0, <19.0.0"
 altair = "^5.0.1"
 Jinja2 = ">=3.0.3"
 phonetics = "^1.0.5"

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import sqlglot
 from sqlglot.expressions import Identifier
 from sqlglot.optimizer.normalize import normalize
+from sqlglot.optimizer.simplify import simplify
 
 from .constants import LEVEL_NOT_OBSERVED_TEXT
 from .default_from_jsonschema import default_value_from_schema
@@ -495,7 +496,7 @@ class ComparisonLevel:
         sql_syntax_tree = sqlglot.parse_one(
             self.sql_condition.lower(), read=self.sql_dialect
         )
-        sql_cnf = normalize(sql_syntax_tree)
+        sql_cnf = simplify(normalize(sql_syntax_tree))
 
         exprs = _get_and_subclauses(sql_cnf)
         for expr in exprs:
@@ -508,7 +509,7 @@ class ComparisonLevel:
         sql_syntax_tree = sqlglot.parse_one(
             self.sql_condition.lower(), read=self.sql_dialect
         )
-        sql_cnf = normalize(sql_syntax_tree)
+        sql_cnf = simplify(normalize(sql_syntax_tree))
 
         exprs = _get_and_subclauses(sql_cnf)
         for expr in exprs:

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -227,14 +227,5 @@ def _get_dialect_quotes(dialect):
 
 
 def _get_sqlglot_dialect_quotes(dialect: sqlglot.Dialect):
-    # TODO: once we drop support for sqlglot < 6.0.0, we can simplify this
-    try:
-        # For sqlglot < 6.0.0
-        quotes = dialect.identifiers
-        quote = '"' if '"' in quotes else quotes[0]
-        start = end = quote
-    except AttributeError:
-        # For sqlglot >= 6.0.0
-        start = dialect.identifier_start
-        end = dialect.identifier_end
-    return start, end
+    # For sqlglot ^18.0.0
+    return dialect.IDENTIFIER_START, dialect.IDENTIFIER_END

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -227,5 +227,11 @@ def _get_dialect_quotes(dialect):
 
 
 def _get_sqlglot_dialect_quotes(dialect: sqlglot.Dialect):
-    # For sqlglot ^18.0.0
-    return dialect.IDENTIFIER_START, dialect.IDENTIFIER_END
+    try:
+        # For sqlglot >= 16.0.0
+        start = dialect.IDENTIFIER_START
+        end = dialect.IDENTIFIER_END
+    except AttributeError:
+        start = dialect.identifier_start
+        end = dialect.identifier_end
+    return start, end

--- a/tests/test_comparison_level.py
+++ b/tests/test_comparison_level.py
@@ -1,4 +1,4 @@
-from pytest import mark
+from pytest import mark, raises
 
 from splink.comparison_level import ComparisonLevel
 
@@ -14,20 +14,47 @@ def make_comparison_level(sql_condition, dialect):
         sql_dialect=dialect,
     )
 
+
 # SQL conditions that are of 'exact match' type
-exact_matchy_sql_conditions = [
-    "col_l = col_r",
-    "col_l = col_r AND another_col_l = another_col_r",
-    "col_l = col_r AND another_col_l = another_col_r AND third_l = third_r",
-    "(col_l = col_r AND another_col_l = another_col_r) AND third_l = third_r",
-    "col_l = col_r AND (another_col_l = another_col_r AND third_l = third_r)",
+exact_matchy_sql_conditions_and_columns = [
+    ("col_l = col_r", ["col"]),
+    ("col_l = col_r AND another_col_l = another_col_r", ["col", "another_col"]),
+    (
+        "col_l = col_r AND another_col_l = another_col_r AND third_l = third_r",
+        ["col", "another_col", "third"],
+    ),
+    (
+        "(col_l = col_r AND another_col_l = another_col_r) AND third_l = third_r",
+        ["col", "another_col", "third"],
+    ),
+    (
+        "col_l = col_r AND (another_col_l = another_col_r AND third_l = third_r)",
+        ["col", "another_col", "third"],
+    ),
 ]
 
-@mark.parametrize("sql_condition", exact_matchy_sql_conditions)
+
+@mark.parametrize(
+    "sql_condition, exact_match_cols", exact_matchy_sql_conditions_and_columns
+)
 @mark_with_dialects_excluding()
-def test_exact_match_checks_exact_matchy_levels(sql_condition, dialect):
+def test_is_exact_match_for_exact_matchy_levels(
+    sql_condition, exact_match_cols, dialect
+):
     lev = make_comparison_level(sql_condition, dialect)
     assert lev._is_exact_match
+
+
+@mark.parametrize(
+    "sql_condition, exact_match_cols", exact_matchy_sql_conditions_and_columns
+)
+@mark_with_dialects_excluding()
+def test_exact_match_colnames_for_exact_matchy_levels(
+    sql_condition, exact_match_cols, dialect
+):
+    lev = make_comparison_level(sql_condition, dialect)
+    assert lev._exact_match_colnames == exact_match_cols
+
 
 # SQL conditions that are NOT of 'exact match' type
 non_exact_matchy_sql_conditions = [
@@ -40,8 +67,19 @@ non_exact_matchy_sql_conditions = [
     "substr(col_l, 2) = substr(col_r, 2)",
 ]
 
+
 @mark.parametrize("sql_condition", non_exact_matchy_sql_conditions)
 @mark_with_dialects_excluding()
-def test_exact_match_checks_non_exact_matchy_levels(sql_condition, dialect):
+def test_is_exact_match_for_non_exact_matchy_levels(sql_condition, dialect):
     lev = make_comparison_level(sql_condition, dialect)
     assert not lev._is_exact_match
+
+
+@mark.parametrize("sql_condition", non_exact_matchy_sql_conditions)
+@mark_with_dialects_excluding()
+def test_exact_match_colnames_for_non_exact_matchy_levels(sql_condition, dialect):
+    lev = make_comparison_level(sql_condition, dialect)
+    # _exact_match_colnames should have an error if it is
+    # not actually an exact match level
+    with raises(ValueError):
+        lev._exact_match_colnames

--- a/tests/test_comparison_level.py
+++ b/tests/test_comparison_level.py
@@ -1,0 +1,47 @@
+from pytest import mark
+
+from splink.comparison_level import ComparisonLevel
+
+from .decorator import mark_with_dialects_excluding
+
+
+def make_comparison_level(sql_condition, dialect):
+    return ComparisonLevel(
+        {
+            "sql_condition": sql_condition,
+            "label_for_charts": "nice_informative_label",
+        },
+        sql_dialect=dialect,
+    )
+
+# SQL conditions that are of 'exact match' type
+exact_matchy_sql_conditions = [
+    "col_l = col_r",
+    "col_l = col_r AND another_col_l = another_col_r",
+    "col_l = col_r AND another_col_l = another_col_r AND third_l = third_r",
+    "(col_l = col_r AND another_col_l = another_col_r) AND third_l = third_r",
+    "col_l = col_r AND (another_col_l = another_col_r AND third_l = third_r)",
+]
+
+@mark.parametrize("sql_condition", exact_matchy_sql_conditions)
+@mark_with_dialects_excluding()
+def test_exact_match_checks_exact_matchy_levels(sql_condition, dialect):
+    lev = make_comparison_level(sql_condition, dialect)
+    assert lev._is_exact_match
+
+# SQL conditions that are NOT of 'exact match' type
+non_exact_matchy_sql_conditions = [
+    "levenshtein(col_l, col_r) < 3",
+    "col_l < col_r",
+    "col_l = col_r OR another_col_l = another_col_r",
+    "col_l = a_different_col_r",
+    "col_l = col_r AND (col_2_l = col_2_r OR col_3_l = col_3_r)",
+    "col_l = col_r AND (col_2_l < col_2_r)",
+    "substr(col_l, 2) = substr(col_r, 2)",
+]
+
+@mark.parametrize("sql_condition", non_exact_matchy_sql_conditions)
+@mark_with_dialects_excluding()
+def test_exact_match_checks_non_exact_matchy_levels(sql_condition, dialect):
+    lev = make_comparison_level(sql_condition, dialect)
+    assert not lev._is_exact_match

--- a/tests/test_comparison_level.py
+++ b/tests/test_comparison_level.py
@@ -17,19 +17,19 @@ def make_comparison_level(sql_condition, dialect):
 
 # SQL conditions that are of 'exact match' type
 exact_matchy_sql_conditions_and_columns = [
-    ("col_l = col_r", ["col"]),
-    ("col_l = col_r AND another_col_l = another_col_r", ["col", "another_col"]),
+    ("col_l = col_r", {"col"}),
+    ("col_l = col_r AND another_col_l = another_col_r", {"col", "another_col"}),
     (
         "col_l = col_r AND another_col_l = another_col_r AND third_l = third_r",
-        ["col", "another_col", "third"],
+        {"col", "another_col", "third"},
     ),
     (
         "(col_l = col_r AND another_col_l = another_col_r) AND third_l = third_r",
-        ["col", "another_col", "third"],
+        {"col", "another_col", "third"},
     ),
     (
         "col_l = col_r AND (another_col_l = another_col_r AND third_l = third_r)",
-        ["col", "another_col", "third"],
+        {"col", "another_col", "third"},
     ),
 ]
 
@@ -53,7 +53,7 @@ def test_exact_match_colnames_for_exact_matchy_levels(
     sql_condition, exact_match_cols, dialect
 ):
     lev = make_comparison_level(sql_condition, dialect)
-    assert lev._exact_match_colnames == exact_match_cols
+    assert set(lev._exact_match_colnames) == exact_match_cols
 
 
 # SQL conditions that are NOT of 'exact match' type

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -36,12 +36,12 @@ def test_move_l_r_table_prefix_to_column_suffix():
     move_l_r_test(br, expected)
 
     br = "len(list_filter(l.name_list, x -> list_contains(r.name_list, x))) >= 1"
-    expected = "len(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    expected = "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
     move_l_r_test(br, expected)
 
     br = "len(list_filter(l.name_list, x -> list_contains(r.name_list, x))) >= 1"
     res = move_l_r_table_prefix_to_column_suffix(br)
-    expected = "len(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    expected = "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
     assert res.lower() == expected.lower()
 
 

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -36,12 +36,16 @@ def test_move_l_r_table_prefix_to_column_suffix():
     move_l_r_test(br, expected)
 
     br = "len(list_filter(l.name_list, x -> list_contains(r.name_list, x))) >= 1"
-    expected = "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    expected = (
+        "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    )
     move_l_r_test(br, expected)
 
     br = "len(list_filter(l.name_list, x -> list_contains(r.name_list, x))) >= 1"
     res = move_l_r_table_prefix_to_column_suffix(br)
-    expected = "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    expected = (
+        "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
+    )
     assert res.lower() == expected.lower()
 
 


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
There were a few issues popping up due to using a slightly dated version of SQLglot. For example - https://github.com/moj-analytical-services/splink/pull/1636#issuecomment-1749317412, shows SQLglot only picking up up one column used within the `datediff` function.

Additionally, we'll be able absorb any performance improvements and new additions that are now present after a few months of using v11.

See https://github.com/moj-analytical-services/splink/issues/894 for more on the original issue w/ CNF/DNF.

### Give a brief description for the solution you have provided
Update SQLglot to >=13.0.0.

I've frozen the version at <v19.0.0 so we can update it incrementally, as and when we see fit.

Thanks to @ADBond for checking over the existing issue around DNF not working as expected.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


