### PR TITLE
implement a janitorclass to automatically format class attributes

### DIFF
--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -7,6 +7,7 @@ import sqlglot.expressions as exp
 from sqlglot.errors import ParseError
 
 from .default_from_jsonschema import default_value_from_schema
+from .misc import JanitorClass
 
 
 def sqlglot_tree_signature(tree):
@@ -223,15 +224,9 @@ def _get_dialect_quotes(dialect):
         sqlglot_dialect = sqlglot.Dialect[dialect.lower()]
     except KeyError:
         return start, end
-    return _get_sqlglot_dialect_quotes(sqlglot_dialect)
+    return _get_sqlglot_dialect_quotes(JanitorClass(sqlglot_dialect))
 
 
 def _get_sqlglot_dialect_quotes(dialect: sqlglot.Dialect):
-    try:
-        # For sqlglot >= 16.0.0
-        start = dialect.IDENTIFIER_START
-        end = dialect.IDENTIFIER_END
-    except AttributeError:
-        start = dialect.identifier_start
-        end = dialect.identifier_end
-    return start, end
+    # From sqlglot >= 16.0.0 all static variables are uppercase
+    return dialect.IDENTIFIER_START, dialect.IDENTIFIER_END

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -94,6 +94,14 @@ class EverythingEncoder(json.JSONEncoder):
             return obj.__str__()
 
 
+class JanitorClass:
+    def __init__(self, RootClass, *args, **kwargs):
+        self.wrapped = RootClass(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.wrapped, name.upper())
+
+
 def calculate_cartesian(df_rows, link_type):
     """
     Calculates the cartesian product for the input df(s).


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Follows on from https://github.com/moj-analytical-services/splink/pull/1642.



### Give a brief description for the solution you have provided
Adds in a simple `JanitorClass` that automatically sets class attributes to upper case. This streamlines some of the SQLglot code and removes the need for a verbose try except clause to grab our quote identifiers.

If you think this is over-engineering the solution, then I shall scrap it!

Just to note, this can also be done with metaclasses with some inheritance magic. However, as SQLglot already makes use of metaclasses, I've just implemented a wrapper class that manipulates how attributes are pulled.



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


