### PR TITLE
Finds blocking rules which return a comparison count below a given threshold

### DIFF
--- a/splink/find_brs_with_comparison_counts_below_threshold.py
+++ b/splink/find_brs_with_comparison_counts_below_threshold.py
@@ -1,0 +1,225 @@
+import logging
+import string
+from typing import TYPE_CHECKING, Dict, List, Set
+
+import pandas as pd
+
+from .input_column import InputColumn
+
+if TYPE_CHECKING:
+    from .linker import Linker
+logger = logging.getLogger(__name__)
+
+
+def sanitise_column_name(column_name):
+    allowed_chars = string.ascii_letters + string.digits + "_"
+    sanitized_name = "".join(c for c in column_name if c in allowed_chars)
+    return sanitized_name
+
+
+def _generate_output_combinations_table_row(
+    blocking_columns, splink_blocking_rule, comparison_count, all_columns
+):
+    row = {}
+
+    blocking_columns = [sanitise_column_name(c) for c in blocking_columns]
+    all_columns = [sanitise_column_name(c) for c in all_columns]
+
+    row["blocking_columns"] = blocking_columns
+    row["splink_blocking_rule"] = splink_blocking_rule
+    row["comparison_count"] = comparison_count
+    row["complexity"] = len(blocking_columns)
+
+    for col in all_columns:
+        row[f"__fixed__{col}"] = 1 if col in blocking_columns else 0
+
+    return row
+
+
+def _generate_combinations(
+    all_columns, current_combination, already_visited: Set[frozenset]
+):
+    """Generate combinations of columns to visit that haven't been visited already
+    irrespective of order
+    """
+
+    combinations = []
+    for col in all_columns:
+        if col not in current_combination:
+            next_combination = current_combination + [col]
+            if frozenset(next_combination) not in already_visited:
+                combinations.append(next_combination)
+
+    return combinations
+
+
+def _generate_blocking_rule(linker: "Linker", cols_as_string):
+    """Generate a blocking rule given a list of column names as string"""
+
+    dialect = linker._sql_dialect
+
+    module_mapping = {
+        "presto": "splink.athena.blocking_rule_library",
+        "duckdb": "splink.duckdb.blocking_rule_library",
+        "postgres": "splink.postgres.blocking_rule_library",
+        "spark": "splink.spark.blocking_rule_library",
+        "sqlite": "splink.sqlite.blocking_rule_library",
+    }
+
+    if dialect not in module_mapping:
+        raise ValueError(f"Unsupported SQL dialect: {dialect}")
+
+    module_name = module_mapping[dialect]
+    block_on_module = __import__(module_name, fromlist=["block_on"])
+    block_on = block_on_module.block_on
+
+    if len(cols_as_string) == 0:
+        return "1 = 1"
+
+    br = block_on(cols_as_string)
+
+    return br
+
+
+def _search_tree_for_blocking_rules_below_threshold_count(
+    linker: "Linker",
+    all_columns: List[str],
+    threshold: float,
+    current_combination: List[str] = None,
+    already_visited: Set[frozenset] = None,
+    results: List[Dict[str, str]] = None,
+) -> List[Dict[str, str]]:
+    """
+    Recursively search combinations of fields to find ones that result in a count less
+    than the threshold.
+
+    Uses the new, fast counting function
+    linker._count_num_comparisons_from_blocking_rule_pre_filter_conditions
+    to count
+
+    The tree looks like this, where c1 c2 are columns:
+    c1                    count_comparisons(c1)
+    ├── c2                count_comparisons(c1, c2)
+    │   └── c3            count_comparisons(c1, c2, c3)
+    ├── c3                count_comparisons(c1, c3)
+    │   └── c2            count_comparisons(c1, c3, c2)
+    c2                    count_comparisons(c2)
+    ├── c1                count_comparisons(c2, c1)
+    │   └── c3            count_comparisons(c2, c1, c3)
+    ├── c3                count_comparisons(c2, c3)
+    │   └── c1            count_comparisons(c2, c3, c1)
+
+    Once the count is below the threshold, no branches from the node are explored.
+
+    When a count is below the threshold, create a dictionary with the relevant stats
+    like :
+    {
+        'blocking_columns':['first_name'],
+        'splink_blocking_rule':<Custom rule>',
+        comparison_count':4827,
+        'complexity':1,
+        '__fixed__first_name':1,
+        '__fixed__surname':0,
+        '__fixed__dob':0,
+        '__fixed__city':0,
+        '__fixed__email':0,
+        '__fixed__cluster':0,
+    }
+
+    Return a list of these dicts.
+
+
+    Args:
+        linker: splink.Linker
+        fields (List[str]): List of fields to combine.
+        threshold (float): The count threshold.
+        current_combination (List[str], optional): Current combination of fields.
+        already_visited (Set[frozenset], optional): Set of visited combinations.
+        results (List[Dict[str, str]], optional): List of results. Defaults to [].
+
+    Returns:
+        List[Dict]: List of results.  Each result is a dict with statistics like
+            the number of comparisons, the blocking rule etc.
+    """
+    if current_combination is None:
+        current_combination = []
+    if already_visited is None:
+        already_visited = set()
+    if results is None:
+        results = []
+
+    if len(current_combination) == len(all_columns):
+        return results  # All fields included, meaning we're at a leaf so exit recursion
+
+    br = _generate_blocking_rule(linker, current_combination)
+    comparison_count = (
+        linker._count_num_comparisons_from_blocking_rule_pre_filter_conditions(br)
+    )
+    row = _generate_output_combinations_table_row(
+        current_combination,
+        br,
+        comparison_count,
+        all_columns,
+    )
+
+    already_visited.add(frozenset(current_combination))
+
+    if comparison_count > threshold:
+        # Generate all valid combinations and continue the search
+        combinations = _generate_combinations(
+            all_columns, current_combination, already_visited
+        )
+        for next_combination in combinations:
+            _search_tree_for_blocking_rules_below_threshold_count(
+                linker,
+                all_columns,
+                threshold,
+                next_combination,
+                already_visited,
+                results,
+            )
+    else:
+        results.append(row)
+
+    return results
+
+
+def find_blocking_rules_below_threshold_comparison_count(
+    linker: "Linker", max_comparisons_per_rule, columns=None
+) -> pd.DataFrame:
+    """
+    Finds blocking rules which return a comparison count below a given threshold.
+
+    In addition to returning blocking rules, returns the comparison count and
+    'complexity', which refers to the number of equi-joins used by the rule.
+
+    Also returns one-hot encoding that describes which columns are __fixed__ by the
+    blocking rule
+
+    e.g. equality on first_name and surname is complexity of 2
+
+    Args:
+        linker (Linker): The Linker object
+        max_comparisons_per_rule (int): Max comparisons allowed per blocking rule.
+        columns: Columns to consider. If None, uses all columns used by the
+            ComparisonLevels of the Linker.
+
+    Returns:
+        pd.DataFrame: DataFrame with blocking rules, comparison_count, and complexity.
+    """
+
+    if not columns:
+        columns = linker._column_names_as_input_columns
+
+    columns_as_strings = []
+
+    for c in columns:
+        if isinstance(c, InputColumn):
+            columns_as_strings.append(c.quote().name())
+        else:
+            columns_as_strings.append(c)
+
+    results = _search_tree_for_blocking_rules_below_threshold_count(
+        linker, columns_as_strings, max_comparisons_per_rule
+    )
+    return pd.DataFrame(results)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -263,6 +263,29 @@ class Linker:
         return column_names
 
     @property
+    def _column_names_as_input_columns(
+        self,
+        include_unique_id_col_names=False,
+        include_additional_columns_to_retain=False,
+    ):
+        """Retrieve the column names from the input dataset(s)"""
+        df_obj: SplinkDataFrame = next(iter(self._input_tables_dict.values()))
+
+        input_columns = df_obj.columns
+        remove_columns = []
+        if not include_unique_id_col_names:
+            remove_columns.extend(self._settings_obj._unique_id_input_columns)
+        if not include_additional_columns_to_retain:
+            remove_columns.extend(self._settings_obj._additional_columns_to_retain)
+
+        remove_id_cols = [c.unquote().name() for c in remove_columns]
+        columns = [
+            col for col in input_columns if col.unquote().name() not in remove_id_cols
+        ]
+
+        return columns
+
+    @property
     def _cache_uid(self):
         if self._settings_dict:
             return self._settings_obj._cache_uid


### PR DESCRIPTION
This is the first PR in a series which will establish two new functions.
```
linker._detect_blocking_rules_for_prediction(
    max_comparisons_per_rule=1e3, min_freedom=1, 
)
linker._detect_blocking_rules_for_em_training(
    max_comparisons_per_rule=1e2, min_freedom=0
)
```

See [here](https://github.com/moj-analytical-services/splink/pull/1464) for further description.

This PR adds the first ingredient: the ability to quickly and efficiently find a list of blocking rules that returns a comparison count below a certain threshold.  

Here's my current strategy.

This is motivated by exploiting the new `linker._count_num_comparisons_from_blocking_rule_pre_filter_conditions(br)` function that is super fast, so can evaluate large numbers of possible blocking rules quickly:

Let's say we have columns `c1`, `c2`, `c3`, etc.

We recurse through a tree running functions like:

```
c1                    count_comparisons(c1)           
├── c2                count_comparisons(c1, c2)
│   └── c3            count_comparisons(c1, c2, c3)     
├── c3                count_comparisons(c1, c3)
│   └── c2            count_comparisons(c1, c3, c2)  
c2                    count_comparisons(c2)          
├── c1                count_comparisons(c2, c1)       
│   └── c3            count_comparisons(c2, c1, c3)
├── c3                count_comparisons(c2, c3)
│   └── c1            count_comparisons(c2, c3, c1)
etc.
```

It skips running any count that has been generated before with the same columns in a different order

Once the count is below the threshold, no branches from the node are explored.

So for example, if `count_comparisons(c1,c2) < threshold_max_rows`, it will skip all children such as `count_comparisons(c1,c2,c3)`.  In practice, this means only a small subset of the full tree is explored, making things a lot faster.

Moving to the real outputs now with a threshold of 1m, this results in a table of results like:

| blocking_rules | comparison_count | complexity |
|-|:-|:-|
| first_name, surname | 533,375 | 2 |
| first_name, dob | 174,651 | 2 |
| first_name, birth_place | 344,971 | 2 |
| first_name, postcode_fake | 149,105 | 2 |  
| first_name, gender, surname | 373,354 | 3 |
| etc. |  |  |





<details> <summary>(Note the actual table has one hot encoding like this)</summary>

|    | blocking_rules              | comparison_count   |   complexity |   __fixed__first_name |   __fixed__surname |   __fixed__dob |   __fixed__birth_place |   __fixed__postcode_fake |   __fixed__gender |   __fixed__occupation |
|---:|:----------------------------|:-------------------|-------------:|----------------------:|-------------------:|---------------:|-----------------------:|-------------------------:|------------------:|----------------------:|
|  0 | first_name, surname         | 533,375            |            2 |                     1 |                  1 |              0 |                      0 |                        0 |                 0 |                     0 |
|  1 | first_name, dob             | 174,651            |            2 |                     1 |                  0 |              1 |                      0 |                        0 |                 0 |                     0 |
|  2 | first_name, birth_place     | 344,971            |            2 |                     1 |                  0 |              0 |                      1 |                        0 |                 0 |                     0 |
|  3 | first_name, postcode_fake   | 149,105            |            2 |                     1 |                  0 |              0 |                      0 |                        1 |                 0 |                     0 |
|  4 | first_name, gender, surname | 373,354            |            3 |                     1 |                  1 |              0 |                      0 |                        0 |                 1 |                     0 |

</details>
