### PR TITLE
Cluster metrics

### DIFF
--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -17,8 +17,8 @@ def _size_density_sql(
     """
 
     # Get physical table names from Splink dataframes
-    df_predict = df_predict.physical_name
-    df_clustered = df_clustered.physical_name
+    edges_table = df_predict.physical_name
+    clusters_table = df_clustered.physical_name
 
     sqls = []
     sql = f"""

--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -1,0 +1,59 @@
+def _size_density_sql(
+    df_predict, df_clustered, threshold_match_probability, _unique_row_id
+):
+    """Generates sql for computing cluster size and density at a given threshold.
+
+    Args:
+        df_predict (SplinkDataFrame): The results of `linker.predict()`
+        df_clustered (SplinkDataFrame): The outputs of
+                `linker.cluster_pairwise_predictions_at_threshold()`
+        threshold_match_probability (float): Filter the pairwise match
+            predictions to include only pairwise comparisons with a
+            match_probability above this threshold.
+        _unique_row_id (string): name of unique id column in settings dict
+
+    Returns:
+        sql string for computing cluster size and density
+    """
+
+    # Get physical table names from Splink dataframes
+    edges_table = df_edges.physical_name
+    clusters_table = df_clusters.physical_name
+
+    sqls = []
+    sql = f"""
+        SELECT
+            {_unique_row_id}_l,
+            COUNT(*) AS count_edges
+        FROM {edges_table}
+        WHERE match_probability >= {cluster_threshold}
+        GROUP BY {_unique_row_id}_l
+    """
+
+    sql = {"sql": sql, "output_table_name": "__count_edges"}
+    sqls.append(sql)
+
+    sql = f"""
+        SELECT
+            c.cluster_id,
+            count(*) AS n_nodes,
+            sum(e.count_edges) AS n_edges
+        FROM {clusters_table} AS c
+        LEFT JOIN __count_edges e ON c.{_unique_row_id} = e.{_unique_row_id}_l
+        GROUP BY c.cluster_id
+    """
+    sql = {"sql": sql, "output_table_name": "__counts_per_cluster"}
+    sqls.append(sql)
+
+    sql = """
+        SELECT
+            cluster_id,
+            n_nodes,
+            n_edges,
+            (n_edges * 2)/(n_nodes * (n_nodes-1)) AS density
+        FROM __counts_per_cluster
+    """
+    sql = {"sql": sql, "output_table_name": "__splink__cluster_metrics_clusters"}
+    sqls.append(sql)
+
+    return sqls

--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -1,3 +1,5 @@
+from splink.input_column import InputColumn
+
 def _size_density_sql(
     df_predict, df_clustered, threshold_match_probability, _unique_id_col
 ):

--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -1,5 +1,6 @@
 from splink.input_column import InputColumn
 
+
 def _size_density_sql(
     df_predict, df_clustered, threshold_match_probability, _unique_id_col
 ):

--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -26,7 +26,7 @@ def _size_density_sql(
             {_unique_row_id}_l,
             COUNT(*) AS count_edges
         FROM {edges_table}
-        WHERE match_probability >= {cluster_threshold}
+        WHERE match_probability >= {threshold_match_probability}
         GROUP BY {_unique_row_id}_l
     """
 

--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -17,8 +17,8 @@ def _size_density_sql(
     """
 
     # Get physical table names from Splink dataframes
-    edges_table = df_edges.physical_name
-    clusters_table = df_clusters.physical_name
+    df_predict = df_predict.physical_name
+    df_clustered = df_clustered.physical_name
 
     sqls = []
     sql = f"""

--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -33,7 +33,7 @@ def _size_density_sql(
         GROUP BY {unique_id_col_l}
     """
 
-    sql = {"sql": sql, "output_table_name": "__count_edges"}
+    sql = {"sql": sql, "output_table_name": "__splink__count_edges"}
     sqls.append(sql)
 
     sql = f"""
@@ -42,10 +42,10 @@ def _size_density_sql(
             count(*) AS n_nodes,
             sum(e.count_edges) AS n_edges
         FROM {clusters_table} AS c
-        LEFT JOIN __count_edges e ON c.{_unique_id_col} = e.{unique_id_col_l}
+        LEFT JOIN __splink__count_edges e ON c.{_unique_id_col} = e.{unique_id_col_l}
         GROUP BY c.cluster_id
     """
-    sql = {"sql": sql, "output_table_name": "__counts_per_cluster"}
+    sql = {"sql": sql, "output_table_name": "__splink__counts_per_cluster"}
     sqls.append(sql)
 
     sql = """
@@ -54,7 +54,7 @@ def _size_density_sql(
             n_nodes,
             n_edges,
             (n_edges * 2)/(n_nodes * (n_nodes-1)) AS density
-        FROM __counts_per_cluster
+        FROM __splink__counts_per_cluster
     """
     sql = {"sql": sql, "output_table_name": "__splink__cluster_metrics_clusters"}
     sqls.append(sql)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2073,9 +2073,9 @@ class Linker:
         )
 
         for sql in sqls:
-            linker._enqueue_sql(sql["sql"], sql["output_table_name"])
+            self._enqueue_sql(sql["sql"], sql["output_table_name"])
 
-        df_cluster_metrics = linker._execute_sql_pipeline()
+        df_cluster_metrics = self._execute_sql_pipeline()
 
         return df_cluster_metrics
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2058,7 +2058,8 @@ class Linker:
                 threshold.
 
         Returns:
-            SplinkDataFrame: A SplinkDataFrame containing cluster IDs and selected cluster metrics
+            SplinkDataFrame: A SplinkDataFrame containing cluster IDs and selected
+            cluster metrics
 
         """
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2070,7 +2070,7 @@ class Linker:
             df_predict,
             df_clustered,
             threshold_match_probability,
-            _unique_row_id=unique_id_col,
+            _unique_id_col=unique_id_col,
         )
 
         for sql in sqls:

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2064,7 +2064,7 @@ class Linker:
         """
 
         # Get unique row id column name from settings
-        unique_id_col = self._settings_dict["unique_id_column_name"]
+        unique_id_col = self._settings_obj._unique_id_column_name
 
         sqls = _size_density_sql(
             df_predict,

--- a/tests/test_cluster_metrics.py
+++ b/tests/test_cluster_metrics.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pandas.testing import assert_frame_equal
+
 from splink.duckdb.linker import DuckDBLinker
 
 # Dummy df

--- a/tests/test_cluster_metrics.py
+++ b/tests/test_cluster_metrics.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from splink.duckdb.linker import DuckDBLinker
+
+# Dummy df
+person_ids = [i + 1 for i in range(5)]
+df = pd.DataFrame({"person_id": person_ids})
+
+# Dummy edges df
+edges_data = [
+    # cluster A edges
+    {"person_id_l": 1, "person_id_r": 2, "match_probability": 0.99},
+    {"person_id_l": 1, "person_id_r": 3, "match_probability": 0.99},
+    # cluster B edge
+    {"person_id_l": 4, "person_id_r": 5, "match_probability": 0.99},
+    # edges not in relevant clusters
+    {"person_id_l": 10, "person_id_r": 11, "match_probability": 0.99},
+    {"person_id_l": 12, "person_id_r": 12, "match_probability": 0.95},
+]
+edges = pd.DataFrame(edges_data)
+
+# Dummy clusters df
+cluster_ids = ["A", "A", "A", "B", "B"]
+clusters_data = {"cluster_id": cluster_ids, "person_id": person_ids}
+clusters = pd.DataFrame(clusters_data)
+
+# Expected dataframe
+expected_data = [
+    {"cluster_id": "A", "n_nodes": 3, "n_edges": 2.0, "density": 2 / 3},
+    {"cluster_id": "B", "n_nodes": 2, "n_edges": 1.0, "density": 1.0},
+]
+df_expected = pd.DataFrame(expected_data)
+
+
+def test_size_density():
+    # Linker with basic settings
+    settings = {"link_type": "dedupe_only", "unique_id_column_name": "person_id"}
+    linker = DuckDBLinker(df, settings)
+
+    # Register as Splink dataframes
+    df_predict = linker.register_table(edges, "df_predict", overwrite=True)
+    df_clustered = linker.register_table(clusters, "df_clustered", overwrite=True)
+
+    df_cluster_metrics = linker._compute_cluster_metrics(
+        df_predict, df_clustered, threshold_match_probability=0.99
+    )
+    df_cluster_metrics = df_cluster_metrics.as_pandas_dataframe()
+
+    assert_frame_equal(df_cluster_metrics, df_expected)


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Related to #1538, #1001, #539

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->

**1. New method added to linker for computing cluster metrics.**
- Wasn't sure of the best location so have put below `cluster_pairwise_predictions_at_threshold` as closely related.
- Once more metrics are added, the idea is to include an option `metrics` for the user to select which metrics they wish to be computed, e.g. "default", "all", or a custom list ["size", "is_bridge"]

**2. New script `cluster_metrics.py` added to contain functions for generating the sql for computing different metrics**

**3. Test added for `_compute_cluster_metrics`**
- Test passes

Thank you @ADBond and @ThomasHepworth for your help and input


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


