### PR TITLE
Comparison level builders initial work

### DIFF
--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -4,8 +4,6 @@ from typing import final
 from .comparison_level import ComparisonLevel
 from .input_column import InputColumn
 
-all_dialects = ["duckdb", "spark", "sqlite", "postgres"]
-
 
 class ComparisonLevelCreator(ABC):
     def __init__(self, col_name: str = None):

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -8,7 +8,7 @@ all_dialects = ["duckdb", "spark", "sqlite", "postgres"]
 
 
 class ComparisonLevelCreator(ABC):
-    def __init__(self, col_name: str):
+    def __init__(self, col_name: str=None):
         """_summary_
 
         Args:

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -1,0 +1,101 @@
+from abc import ABC, abstractmethod
+from typing import final
+
+from .comparison_level import ComparisonLevel
+from .input_column import InputColumn
+
+all_dialects = ["duckdb", "spark", "sqlite", "postgres"]
+
+
+class ComparisonLevelCreator(ABC):
+    def __init__(self, col_name: str):
+        """_summary_
+
+        Args:
+            col_name (str): _description_
+            dialect (str, optional): _description_. Defaults to None.
+            m_probability (_type_, optional): _description_. Defaults to None.
+        """
+        self.col_name = col_name
+        # TODO: do we need to set these to None, or let ComparisonLevel handle missings?
+        self.m_probability = None
+        self.u_probability = None
+        self.tf_adjustment_column = None
+        self.tf_adjustment_weight = None
+        self.tf_minimum_u_value = None
+        self.is_null_level = None
+
+    @abstractmethod
+    def create_sql(self, sql_dialect: str):
+        pass
+
+    @abstractmethod
+    def create_label_for_charts(self):
+        pass
+
+    @final
+    def get_comparison_level(self, sql_dialect: str):
+        return ComparisonLevel(self.create_level_dict(sql_dialect))
+
+    @final
+    def create_level_dict(self, sql_dialect: str):
+        level_dict = {
+            "sql_condition": self.create_sql(sql_dialect),
+            "label_for_charts": self.create_label_for_charts(),
+        }
+
+        if self.m_probability:
+            level_dict["m_probability"] = self.m_probability
+        if self.u_probability:
+            level_dict["u_probability"] = self.u_probability
+        if self.tf_adjustment_column:
+            level_dict["tf_adjustment_column"] = self.tf_adjustment_column
+        if self.tf_adjustment_weight:
+            level_dict["tf_adjustment_weight"] = self.tf_adjustment_weight
+        if self.tf_minimum_u_value:
+            level_dict["tf_minimum_u_value"] = self.tf_minimum_u_value
+        if self.is_null_level:
+            level_dict["is_null_level"] = self.is_null_level
+
+        return level_dict
+
+    @final
+    def input_column(self, sql_dialect: str):
+        return InputColumn(self.col_name, sql_dialect)
+
+    @final
+    def configure(
+        self,
+        *,
+        m_probability: float = None,
+        u_probability: float = None,
+        tf_adjustment_column: str = None,
+        tf_adjustment_weight: float = None,
+        tf_minimum_u_value: float = None,
+        is_null_level: bool = None,
+    ):
+        """_summary_
+
+        Args:
+            m_probability (float, optional): _description_. Defaults to None.
+            u_probability (float, optional): _description_. Defaults to None.
+            tf_adjustment_column (str, optional): _description_. Defaults to None.
+            tf_adjustment_weight (float, optional): _description_. Defaults to None.
+            tf_minimum_u_value (float, optional): _description_. Defaults to None.
+            is_null_level (bool, optional): _description_. Defaults to None.
+        """
+        args = locals()
+        del args["self"]
+        for k, v in args.items():
+            if v is not None:
+                setattr(self, k, v)
+
+        return self
+
+    def __repr__(self):
+        return (
+            f"Comparison level generator for {self.create_label_for_charts()}. "
+            "Call .get_comparison_level(sql_dialect) to instantiate "
+            "a ComparisonLevel"
+        )
+

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -61,7 +61,7 @@ class ComparisonLevelCreator(ABC):
 
     @final
     def input_column(self, sql_dialect: str):
-        return InputColumn(self.col_name, sql_dialect)
+        return InputColumn(self.col_name, sql_dialect=sql_dialect)
 
     @final
     def configure(

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -8,7 +8,7 @@ all_dialects = ["duckdb", "spark", "sqlite", "postgres"]
 
 
 class ComparisonLevelCreator(ABC):
-    def __init__(self, col_name: str=None):
+    def __init__(self, col_name: str = None):
         """_summary_
 
         Args:
@@ -98,4 +98,3 @@ class ComparisonLevelCreator(ABC):
             "Call .get_comparison_level(sql_dialect) to instantiate "
             "a ComparisonLevel"
         )
-

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -1,4 +1,5 @@
 from .comparison_level_creator import ComparisonLevelCreator
+from .dialects import dialect_lookup
 
 
 class NullLevel(ComparisonLevelCreator):
@@ -35,3 +36,16 @@ class ExactMatchLevel(ComparisonLevelCreator):
     def create_label_for_charts(self):
         return f"Exact match {self.col_name}"
 
+
+class LevenshteinLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: float):
+        self.distance_threshold = distance_threshold
+        super().__init__(col_name)
+
+    def create_sql(self, sql_dialect):
+        col = self.input_column(sql_dialect)
+        lev_fn = dialect_lookup[sql_dialect].levenshtein_function_name
+        return f"{lev_fn}({col.name_l()}, {col.name_r()}) <= {self.distance_threshold}"
+
+    def create_label_for_charts(self):
+        return f"Levenshtein distance in {self.col_name} <= {self.distance_threshold}"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -1,0 +1,28 @@
+from .comparison_level_creator import ComparisonLevelCreator
+
+
+class NullLevel(ComparisonLevelCreator):
+
+    def create_sql(self, sql_dialect):
+        col = self.input_column(sql_dialect)
+        return f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL"
+
+    def create_label_for_charts(self):
+        return f"{self.col_name} is NULL"
+
+class ElseLevel(ComparisonLevelCreator):
+    def create_sql(self, sql_dialect):
+        return "ELSE"
+
+    def create_label_for_charts(self):
+        return "All other comparisons"
+
+
+class ExactMatchLevel(ComparisonLevelCreator):
+    def create_sql(self, sql_dialect):
+        col = self.input_column(sql_dialect)
+        return f"{col.name_l()} = {col.name_r()}"
+
+    def create_label_for_charts(self):
+        return f"Exact match {self.col_name}"
+

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -2,13 +2,13 @@ from .comparison_level_creator import ComparisonLevelCreator
 
 
 class NullLevel(ComparisonLevelCreator):
-
     def create_sql(self, sql_dialect):
         col = self.input_column(sql_dialect)
         return f"{col.name_l()} IS NULL OR {col.name_r()} IS NULL"
 
     def create_label_for_charts(self):
         return f"{self.col_name} is NULL"
+
 
 class ElseLevel(ComparisonLevelCreator):
     def create_sql(self, sql_dialect):
@@ -19,6 +19,15 @@ class ElseLevel(ComparisonLevelCreator):
 
 
 class ExactMatchLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, term_frequency_adjustments: bool = True):
+        config = {}
+        if term_frequency_adjustments:
+            config["tf_adjustment_column"] = col_name
+            config["tf_adjustment_weight"] = 1.0
+            # leave tf_minimum_u_value as None
+        super().__init__(col_name)
+        self.configure(**config)
+
     def create_sql(self, sql_dialect):
         col = self.input_column(sql_dialect)
         return f"{col.name_l()} = {col.name_r()}"

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractproperty
+
+
+class SplinkDialect(ABC):
+    @abstractproperty
+    def name(self):
+        pass
+
+    def sqlglot_name(self):
+        return self.name
+
+    @property
+    def levenshtein_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.name}' does not have a 'Levenshtein' function"
+        )
+
+
+class DuckDBDialect(SplinkDialect):
+    @property
+    def name(self):
+        return "duckdb"
+
+    @property
+    def levenshtein_function_name(self):
+        return "levenshtein"
+
+
+class SparkDialect(SplinkDialect):
+    @property
+    def name(self):
+        return "spark"
+
+    @property
+    def levenshtein_function_name(self):
+        return "levenshtein"
+
+
+class SqliteDialect(SplinkDialect):
+    @property
+    def name(self):
+        return "sqlite"
+
+    @property
+    def levenshtein_function_name(self):
+        return "levenshtein"
+
+
+class PostgresDialect(SplinkDialect):
+    @property
+    def name(self):
+        return "postgres"
+
+    @property
+    def levenshtein_function_name(self):
+        return "levenshtein"
+
+
+class AthenaDialect(SplinkDialect):
+    @property
+    def name(self):
+        return "athena"
+
+    @property
+    def sqlglot_name(self):
+        return "presto"
+
+    @property
+    def _levenshtein_name(self):
+        return "levenshtein_distance"
+
+
+dialect_lookup = {
+    "duckdb": DuckDBDialect(),
+    "spark": SparkDialect(),
+    "sqlite": SqliteDialect(),
+    "postgres": PostgresDialect(),
+    "athena": AthenaDialect(),
+}

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -223,7 +223,7 @@ class Linker:
         else:
             self._validate_settings_components(settings_dict)
             settings_dict = deepcopy(settings_dict)
-            self._insantiate_comparison_levels(settings_dict)
+            self._instantiate_comparison_levels(settings_dict)
             self._setup_settings_objs(settings_dict)
 
         homogenised_tables, homogenised_aliases = self._register_input_tables(
@@ -517,7 +517,7 @@ class Linker:
         if validate_settings:
             InvalidColumnsLogger(self).construct_output_logs()
 
-    def _insantiate_comparison_levels(self, settings_dict):
+    def _instantiate_comparison_levels(self, settings_dict):
         """
         Mutate our settings_dict, so that any ComparisonLevelCreator
         instances are instead replaced with ComparisonLevels

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -531,7 +531,6 @@ class Linker:
                 if not isinstance(level, dict):
                     comparison_levels[idx] = level.get_comparison_level(dialect)
 
-
     def _initialise_df_concat(self, materialise=False):
         cache = self._intermediate_table_cache
         concat_df = None

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -218,9 +218,12 @@ class Linker:
             # feed it a blank settings dictionary
             self._setup_settings_objs(None)
             self.load_settings(settings_dict)
+
+            # TODO: deal with instantiating comparison levels in this path
         else:
             self._validate_settings_components(settings_dict)
             settings_dict = deepcopy(settings_dict)
+            self._insantiate_comparison_levels(settings_dict)
             self._setup_settings_objs(settings_dict)
 
         homogenised_tables, homogenised_aliases = self._register_input_tables(
@@ -513,6 +516,21 @@ class Linker:
         # Constructs output logs for our various settings inputs
         if validate_settings:
             InvalidColumnsLogger(self).construct_output_logs()
+
+    def _insantiate_comparison_levels(self, settings_dict):
+        """
+        Mutate our settings_dict, so that any ComparisonLevelCreator
+        instances are instead replaced with ComparisonLevels
+        """
+        dialect = self._sql_dialect
+        # TODO: handle case where dict is in fact a Comparison object
+        for comparison_dict in settings_dict["comparisons"]:
+            comparison_levels = comparison_dict["comparison_levels"]
+            for idx, level in enumerate(comparison_levels):
+                # if we have a ComparisonLevelCreator
+                if not isinstance(level, dict):
+                    comparison_levels[idx] = level.get_comparison_level(dialect)
+
 
     def _initialise_df_concat(self, materialise=False):
         cache = self._intermediate_table_cache

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,19 +10,15 @@ from sqlalchemy.types import (
 )
 
 import splink.duckdb.blocking_rule_library as brl_duckdb
-import splink.duckdb.comparison_level_library as cll_duckdb
 import splink.duckdb.comparison_library as cl_duckdb
 import splink.duckdb.comparison_template_library as ctl_duckdb
 import splink.postgres.blocking_rule_library as brl_postgres
-import splink.postgres.comparison_level_library as cll_postgres
 import splink.postgres.comparison_library as cl_postgres
 import splink.postgres.comparison_template_library as ctl_postgres
 import splink.spark.blocking_rule_library as brl_spark
-import splink.spark.comparison_level_library as cll_spark
 import splink.spark.comparison_library as cl_spark
 import splink.spark.comparison_template_library as ctl_spark
 import splink.sqlite.blocking_rule_library as brl_sqlite
-import splink.sqlite.comparison_level_library as cll_sqlite
 import splink.sqlite.comparison_library as cl_sqlite
 import splink.sqlite.comparison_template_library as ctl_sqlite
 from splink.duckdb.linker import DuckDBLinker
@@ -54,10 +50,6 @@ class TestHelper(ABC):
     def load_frame_from_parquet(self, path):
         return pd.read_parquet(path)
 
-    @property
-    @abstractmethod
-    def cll(self):
-        pass
 
     @property
     @abstractmethod
@@ -86,10 +78,6 @@ class DuckDBTestHelper(TestHelper):
     @property
     def date_format(self):
         return "%Y-%m-%d"
-
-    @property
-    def cll(self):
-        return cll_duckdb
 
     @property
     def cl(self):
@@ -130,9 +118,6 @@ class SparkTestHelper(TestHelper):
         df.persist()
         return df
 
-    @property
-    def cll(self):
-        return cll_spark
 
     @property
     def cl(self):
@@ -178,9 +163,6 @@ class SQLiteTestHelper(TestHelper):
     def load_frame_from_parquet(self, path):
         return self.convert_frame(super().load_frame_from_parquet(path))
 
-    @property
-    def cll(self):
-        return cll_sqlite
 
     @property
     def cl(self):
@@ -238,10 +220,6 @@ class PostgresTestHelper(TestHelper):
 
     def load_frame_from_parquet(self, path):
         return self.convert_frame(super().load_frame_from_parquet(path))
-
-    @property
-    def cll(self):
-        return cll_postgres
 
     @property
     def cl(self):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,18 +9,18 @@ from sqlalchemy.types import (
     TEXT,
 )
 
-import splink.duckdb.blocking_rule_library as brl_duckdb
-import splink.duckdb.comparison_library as cl_duckdb
-import splink.duckdb.comparison_template_library as ctl_duckdb
-import splink.postgres.blocking_rule_library as brl_postgres
-import splink.postgres.comparison_library as cl_postgres
-import splink.postgres.comparison_template_library as ctl_postgres
-import splink.spark.blocking_rule_library as brl_spark
-import splink.spark.comparison_library as cl_spark
-import splink.spark.comparison_template_library as ctl_spark
-import splink.sqlite.blocking_rule_library as brl_sqlite
-import splink.sqlite.comparison_library as cl_sqlite
-import splink.sqlite.comparison_template_library as ctl_sqlite
+# import splink.duckdb.blocking_rule_library as brl_duckdb
+# import splink.duckdb.comparison_library as cl_duckdb
+# import splink.duckdb.comparison_template_library as ctl_duckdb
+# import splink.postgres.blocking_rule_library as brl_postgres
+# import splink.postgres.comparison_library as cl_postgres
+# import splink.postgres.comparison_template_library as ctl_postgres
+# import splink.spark.blocking_rule_library as brl_spark
+# import splink.spark.comparison_library as cl_spark
+# import splink.spark.comparison_template_library as ctl_spark
+# import splink.sqlite.blocking_rule_library as brl_sqlite
+# import splink.sqlite.comparison_library as cl_sqlite
+# import splink.sqlite.comparison_template_library as ctl_sqlite
 from splink.duckdb.linker import DuckDBLinker
 from splink.postgres.linker import PostgresLinker
 from splink.spark.linker import SparkLinker
@@ -50,16 +50,15 @@ class TestHelper(ABC):
     def load_frame_from_parquet(self, path):
         return pd.read_parquet(path)
 
+    # @property
+    # @abstractmethod
+    # def cl(self):
+    #     pass
 
-    @property
-    @abstractmethod
-    def cl(self):
-        pass
-
-    @property
-    @abstractmethod
-    def ctl(self):
-        pass
+    # @property
+    # @abstractmethod
+    # def ctl(self):
+    #     pass
 
     @property
     @abstractmethod
@@ -79,13 +78,13 @@ class DuckDBTestHelper(TestHelper):
     def date_format(self):
         return "%Y-%m-%d"
 
-    @property
-    def cl(self):
-        return cl_duckdb
+    # @property
+    # def cl(self):
+    #     return cl_duckdb
 
-    @property
-    def ctl(self):
-        return ctl_duckdb
+    # @property
+    # def ctl(self):
+    #     return ctl_duckdb
 
     @property
     def brl(self):
@@ -118,14 +117,13 @@ class SparkTestHelper(TestHelper):
         df.persist()
         return df
 
+    # @property
+    # def cl(self):
+    #     return cl_spark
 
-    @property
-    def cl(self):
-        return cl_spark
-
-    @property
-    def ctl(self):
-        return ctl_spark
+    # @property
+    # def ctl(self):
+    #     return ctl_spark
 
     @property
     def brl(self):
@@ -163,14 +161,13 @@ class SQLiteTestHelper(TestHelper):
     def load_frame_from_parquet(self, path):
         return self.convert_frame(super().load_frame_from_parquet(path))
 
+    # @property
+    # def cl(self):
+    #     return cl_sqlite
 
-    @property
-    def cl(self):
-        return cl_sqlite
-
-    @property
-    def ctl(self):
-        return ctl_sqlite
+    # @property
+    # def ctl(self):
+    #     return ctl_sqlite
 
     @property
     def brl(self):
@@ -221,13 +218,13 @@ class PostgresTestHelper(TestHelper):
     def load_frame_from_parquet(self, path):
         return self.convert_frame(super().load_frame_from_parquet(path))
 
-    @property
-    def cl(self):
-        return cl_postgres
+    # @property
+    # def cl(self):
+    #     return cl_postgres
 
-    @property
-    def ctl(self):
-        return ctl_postgres
+    # @property
+    # def ctl(self):
+    #     return ctl_postgres
 
     @property
     def brl(self):

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -1,0 +1,51 @@
+import pandas as pd
+
+import splink.comparison_level_library as cll
+
+from .decorator import mark_with_dialects_excluding
+
+
+@mark_with_dialects_excluding()
+def test_cll_creators(dialect, test_helpers):
+    helper = test_helpers[dialect]
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            {
+                "output_column_name": "first_name",
+                "comparison_levels": [
+                    cll.NullLevel("first_name"),
+                    cll.ExactMatchLevel(
+                        "first_name",
+                        term_frequency_adjustments=True
+                    ),
+                    cll.LevenshteinLevel("first_name", 2),
+                    cll.ElseLevel()
+                ]
+            },
+            {
+                "output_column_name": "surname",
+                "comparison_levels": [
+                    cll.NullLevel("surname"),
+                    cll.ExactMatchLevel("surname", term_frequency_adjustments=True),
+                    cll.LevenshteinLevel("surname", 2),
+                    cll.ElseLevel()
+                ]
+            },
+            {
+                "output_column_name": "city",
+                "comparison_levels": [
+                    cll.NullLevel("city"),
+                    cll.ExactMatchLevel("city", term_frequency_adjustments=True),
+                    cll.LevenshteinLevel("city", 1),
+                    cll.LevenshteinLevel("city", 2),
+                    cll.ElseLevel()
+                ]
+            }
+        ]
+    }
+
+    linker = helper.Linker(df, settings)
+    linker.predict()

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -7,7 +7,7 @@ comparison_first_name = {
     "comparison_levels": [
         cll.NullLevel("first_name"),
         cll.ExactMatchLevel("first_name", term_frequency_adjustments=True),
-        # cll.LevenshteinLevel("first_name", 2),
+        cll.LevenshteinLevel("first_name", 2),
         cll.ElseLevel(),
     ],
 }
@@ -16,7 +16,7 @@ comparison_surname = {
     "comparison_levels": [
         cll.NullLevel("surname"),
         cll.ExactMatchLevel("surname", term_frequency_adjustments=True),
-        # cll.LevenshteinLevel("surname", 2),
+        cll.LevenshteinLevel("surname", 2),
         cll.ElseLevel(),
     ],
 }
@@ -25,8 +25,8 @@ comparison_city = {
     "comparison_levels": [
         cll.NullLevel("city"),
         cll.ExactMatchLevel("city", term_frequency_adjustments=True),
-        # cll.LevenshteinLevel("city", 1),
-        # cll.LevenshteinLevel("city", 2),
+        cll.LevenshteinLevel("city", 1),
+        cll.LevenshteinLevel("city", 2),
         cll.ElseLevel(),
     ],
 }
@@ -51,4 +51,4 @@ def test_cll_creators_instantiate_levels(dialect):
     cll.NullLevel("city").get_comparison_level(dialect)
     cll.ElseLevel().get_comparison_level(dialect)
     cll.ExactMatchLevel("city").get_comparison_level(dialect)
-    # cll.LevenshteinLevel("city", 5).get_comparison_level(dialect)
+    cll.LevenshteinLevel("city", 5).get_comparison_level(dialect)

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -1,51 +1,58 @@
-import pandas as pd
-
 import splink.comparison_level_library as cll
 
 from .decorator import mark_with_dialects_excluding
 
+comparison_first_name = {
+    "output_column_name": "first_name",
+    "comparison_levels": [
+        cll.NullLevel("first_name"),
+        cll.ExactMatchLevel("first_name",
+            # term_frequency_adjustments=True
+        ),
+        # cll.LevenshteinLevel("first_name", 2),
+        cll.ElseLevel()
+    ]
+}
+comparison_surname = {
+    "output_column_name": "surname",
+    "comparison_levels": [
+        cll.NullLevel("surname"),
+        cll.ExactMatchLevel("surname"),# term_frequency_adjustments=True),
+        # cll.LevenshteinLevel("surname", 2),
+        cll.ElseLevel()
+    ]
+}
+comparison_city = {
+    "output_column_name": "city",
+    "comparison_levels": [
+        cll.NullLevel("city"),
+        cll.ExactMatchLevel("city"),# term_frequency_adjustments=True),
+        # cll.LevenshteinLevel("city", 1),
+        # cll.LevenshteinLevel("city", 2),
+        cll.ElseLevel()
+    ]
+}
+
+settings = {
+    "link_type": "dedupe_only",
+    "comparisons": [
+        comparison_first_name,
+        comparison_surname,
+        comparison_city
+    ]
+}
 
 @mark_with_dialects_excluding()
-def test_cll_creators(dialect, test_helpers):
+def test_cll_creators_run_predict(dialect, test_helpers):
     helper = test_helpers[dialect]
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
-    settings = {
-        "link_type": "dedupe_only",
-        "comparisons": [
-            {
-                "output_column_name": "first_name",
-                "comparison_levels": [
-                    cll.NullLevel("first_name"),
-                    cll.ExactMatchLevel(
-                        "first_name",
-                        term_frequency_adjustments=True
-                    ),
-                    cll.LevenshteinLevel("first_name", 2),
-                    cll.ElseLevel()
-                ]
-            },
-            {
-                "output_column_name": "surname",
-                "comparison_levels": [
-                    cll.NullLevel("surname"),
-                    cll.ExactMatchLevel("surname", term_frequency_adjustments=True),
-                    cll.LevenshteinLevel("surname", 2),
-                    cll.ElseLevel()
-                ]
-            },
-            {
-                "output_column_name": "city",
-                "comparison_levels": [
-                    cll.NullLevel("city"),
-                    cll.ExactMatchLevel("city", term_frequency_adjustments=True),
-                    cll.LevenshteinLevel("city", 1),
-                    cll.LevenshteinLevel("city", 2),
-                    cll.ElseLevel()
-                ]
-            }
-        ]
-    }
-
-    linker = helper.Linker(df, settings)
+    linker = helper.Linker(df, settings, **helper.extra_linker_args())
     linker.predict()
+
+@mark_with_dialects_excluding()
+def test_cll_creators_instantiate_levels(dialect):
+    cll.NullLevel("city").get_comparison_level(dialect)
+    cll.ElseLevel().get_comparison_level(dialect)
+    cll.ExactMatchLevel("city").get_comparison_level(dialect)
+    # cll.LevenshteinLevel("city", 5).get_comparison_level(dialect)

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -6,41 +6,36 @@ comparison_first_name = {
     "output_column_name": "first_name",
     "comparison_levels": [
         cll.NullLevel("first_name"),
-        cll.ExactMatchLevel("first_name",
-            # term_frequency_adjustments=True
-        ),
+        cll.ExactMatchLevel("first_name", term_frequency_adjustments=True),
         # cll.LevenshteinLevel("first_name", 2),
-        cll.ElseLevel()
-    ]
+        cll.ElseLevel(),
+    ],
 }
 comparison_surname = {
     "output_column_name": "surname",
     "comparison_levels": [
         cll.NullLevel("surname"),
-        cll.ExactMatchLevel("surname"),# term_frequency_adjustments=True),
+        cll.ExactMatchLevel("surname", term_frequency_adjustments=True),
         # cll.LevenshteinLevel("surname", 2),
-        cll.ElseLevel()
-    ]
+        cll.ElseLevel(),
+    ],
 }
 comparison_city = {
     "output_column_name": "city",
     "comparison_levels": [
         cll.NullLevel("city"),
-        cll.ExactMatchLevel("city"),# term_frequency_adjustments=True),
+        cll.ExactMatchLevel("city", term_frequency_adjustments=True),
         # cll.LevenshteinLevel("city", 1),
         # cll.LevenshteinLevel("city", 2),
-        cll.ElseLevel()
-    ]
+        cll.ElseLevel(),
+    ],
 }
 
 settings = {
     "link_type": "dedupe_only",
-    "comparisons": [
-        comparison_first_name,
-        comparison_surname,
-        comparison_city
-    ]
+    "comparisons": [comparison_first_name, comparison_surname, comparison_city],
 }
+
 
 @mark_with_dialects_excluding()
 def test_cll_creators_run_predict(dialect, test_helpers):
@@ -49,6 +44,7 @@ def test_cll_creators_run_predict(dialect, test_helpers):
 
     linker = helper.Linker(df, settings, **helper.extra_linker_args())
     linker.predict()
+
 
 @mark_with_dialects_excluding()
 def test_cll_creators_instantiate_levels(dialect):


### PR DESCRIPTION
Implements `ComparisonLevelBuilder` base class, as well as subclasses for:
* `NullLevel`
* `ElseLevel`
* `ExactMatchLevel`
* `LevenshteinLevel`

Starting work on #1679, and particularly based on the mini-implementation in [this comment](https://github.com/moj-analytical-services/splink/issues/1679#issuecomment-1788570795).

WIP - a few things not done but thought it would be good to get some early eyes before doing too much polishing.
In particular to do:
- [ ] docstrings fleshed out
- [ ] possibly revise implementation of `create_level_dict` / `configure`
- [ ] possible further hiding of dialect from subclasses (see comment 👇 )