### PR TITLE
Explicitly cast postgres function return values

### DIFF
--- a/splink/postgres/linker.py
+++ b/splink/postgres/linker.py
@@ -263,7 +263,7 @@ class PostgresLinker(Linker):
         sql = f"""
         CREATE OR REPLACE FUNCTION ave_months_between(x date, y date)
         RETURNS float8 AS $$
-        SELECT datediff(x, y)/{ave_length_month};
+        SELECT (datediff(x, y)/{ave_length_month})::float8;
         $$ LANGUAGE SQL IMMUTABLE;
         """
         self._run_sql_execution(sql)
@@ -273,7 +273,7 @@ class PostgresLinker(Linker):
             x {dateish_type}, y {dateish_type}
         )
         RETURNS integer AS $$
-        SELECT ave_months_between(DATE(x), DATE(y));
+        SELECT (ave_months_between(DATE(x), DATE(y)))::int;
         $$ LANGUAGE SQL IMMUTABLE;
         """
         for dateish_type in ("timestamp", "timestamp with time zone"):


### PR DESCRIPTION
Two database functions fail in some versions of postgres, because their output is not explicitly cast to match the expected function return value type.  This change simply does the explicit casting to match.

### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->

Closes #1685 


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->

The original issue was with the `ave_months_between` function that returned `float8` values.  I fixed that one and then the integer version failed in the same way, so i fixed that one too.

After doing that, I was able to successfully instantiate a `PostgresLinker` object, and I confirmed that the database functions were all created successfully

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)

Note - i ran the linter and it did report some stuff, but nothing in the two places changed by this commit (of course, since it was such a simple change to some string values). so I considered those linter messages to be irrelevant here.

