### PR TITLE
fix docstrings to use .to_dict() instead of .spec

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -3011,7 +3011,7 @@ class Linker:
             ```py
             from splink.charts import save_offline_chart
             c = linker.missingness_chart()
-            save_offline_chart(c.spec, "test_chart.html")
+            save_offline_chart(c.to_dict(), "test_chart.html")
             ```
             View resultant html file in Jupyter (or just load it in your browser)
             ```py
@@ -3045,7 +3045,7 @@ class Linker:
             ```py
             from splink.charts import save_offline_chart
             c = linker.completeness_chart()
-            save_offline_chart(c.spec, "test_chart.html")
+            save_offline_chart(c.to_dict(), "test_chart.html")
             ```
             View resultant html file in Jupyter (or just load it in your browser)
             ```py
@@ -3283,7 +3283,7 @@ class Linker:
             ```py
             from splink.charts import save_offline_chart
             c = linker.match_weights_chart()
-            save_offline_chart(c.spec, "test_chart.html")
+            save_offline_chart(c.to_dict(), "test_chart.html")
             ```
             View resultant html file in Jupyter (or just load it in your browser)
             ```py
@@ -3359,7 +3359,7 @@ class Linker:
             ```py
             from splink.charts import save_offline_chart
             c = linker.match_weights_chart()
-            save_offline_chart(c.spec, "test_chart.html")
+            save_offline_chart(c.to_dict(), "test_chart.html")
             ```
             View resultant html file in Jupyter (or just load it in your browser)
             ```py


### PR DESCRIPTION
### Type of PR

- [ x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
To fix #1441 


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


