### PR TITLE
Fix spark fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,7 @@ def pytest_collection_modifyitems(items, config):
                 item.add_marker(mark)
 
 
-@pytest.fixture(scope="module")
-def spark():
+def _make_spark():
     from pyspark import SparkConf, SparkContext
     from pyspark.sql import SparkSession
 
@@ -56,7 +55,12 @@ def spark():
 
     spark = SparkSession(sc)
     spark.sparkContext.setCheckpointDir("./tmp_checkpoints")
+    return spark
 
+
+@pytest.fixture(scope="module")
+def spark():
+    spark = _make_spark()
     yield spark
 
 
@@ -71,14 +75,14 @@ def df_spark(spark):
 # see e.g. https://stackoverflow.com/a/42400786/11811947
 # ruff: noqa: F811
 @pytest.fixture
-def test_helpers(spark, pg_engine):
+def test_helpers(pg_engine):
     # LazyDict to lazy-load helpers
     # That way we do not instantiate helpers we do not need
     # e.g. running only duckdb tests we don't need PostgresTestHelper
     # so we can run duckdb tests in environments w/o access to postgres
     return LazyDict(
         duckdb=(DuckDBTestHelper, []),
-        spark=(SparkTestHelper, [spark]),
+        spark=(SparkTestHelper, [_make_spark]),
         sqlite=(SQLiteTestHelper, []),
         postgres=(PostgresTestHelper, [pg_engine]),
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -105,8 +105,8 @@ class DuckDBTestHelper(TestHelper):
 
 
 class SparkTestHelper(TestHelper):
-    def __init__(self, spark):
-        self.spark = spark
+    def __init__(self, spark_creator_function):
+        self.spark = spark_creator_function()
 
     @property
     def Linker(self):


### PR DESCRIPTION

### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Previously `test_helpers` depended on the `spark` fixture. That means this gets created whenever we request the `test_helpers` fixture, which is slow (and particularly annoying if you're just running e.g. `duckdb` tests).



### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->

Now both `test_helpers` and `spark` fixtures use a helper function, with the upshot that `spark` is only created in `test_helpers` whenever a `SparkTestHelper` is instantiated (which should only happen when you are running `spark` tests, due to `LazyDict`)



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


