### PR TITLE
Add `distance_threshold` check

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -4,6 +4,22 @@ from .comparison_level_creator import ComparisonLevelCreator
 from .dialects import SplinkDialect
 
 
+def validate_distance_threshold(
+    lower_bound: Union[int, float],
+    upper_bound: Union[int, float],
+    distance_threshold: Union[int, float],
+    level_name: str,
+) -> Union[int, float]:
+    """Check if a distance threshold falls between two bounds."""
+    if lower_bound <= distance_threshold <= upper_bound:
+        return distance_threshold
+    else:
+        raise ValueError(
+            "'distance_threshold' must be between "
+            f"{lower_bound} and {upper_bound} for {level_name}"
+        )
+
+
 class NullLevel(ComparisonLevelCreator):
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         col = self.input_column(sql_dialect)
@@ -84,7 +100,12 @@ class JaroWinklerLevel(ComparisonLevelCreator):
                 similarity
         """
         self.col_name = col_name
-        self.distance_threshold = distance_threshold
+        self.distance_threshold = validate_distance_threshold(
+            lower_bound=0,
+            upper_bound=1,
+            distance_threshold=distance_threshold,
+            level_name=self.__class__.__name__,
+        )
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         col_l, col_r = self.input_column(sql_dialect).names_l_r()


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
https://github.com/moj-analytical-services/splink/pull/1717


### Give a brief description for the solution you have provided
Adds a quick validation check to the `distance_threshold` value, erroring out should an invalid threshold be entered by the user.

<details>
<summary>Error demo</summary>

```python
import splink.comparison_level_library as cll

# Passes
cll.JaroWinklerLevel("test", 0.8).get_comparison_level("duckdb")

# Errors
cll.JaroWinklerLevel("test", 1.2)
```

</details>

I'm happy to close this if you'd rather not add this in, or, would rather add it in at a later date.

**Note** - we may want to change the function to only check values between 0 and 1 (remove the upper and lower bound args), making the code easier to read, but reducing flexibility. However, given our current suite of distance functions, I believe this is fine (the lev function family really only wants to check that n > 0).

### PR Checklist

- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


