### PR TITLE
Splink4: Distance in km level

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -3,6 +3,7 @@ from typing import List, Union
 from sqlglot import parse_one
 
 from .comparison_level_creator import ComparisonLevelCreator
+from .comparison_level_sql import great_circle_distance_km_sql
 from .dialects import SplinkDialect
 from .input_column import InputColumn
 
@@ -233,3 +234,56 @@ class JaroWinklerLevel(ComparisonLevelCreator):
         return (
             f"Jaro-Winkler distance of '{self.col_name} >= {self.distance_threshold}'"
         )
+
+
+class DistanceInKMLevel(ComparisonLevelCreator):
+    def __init__(
+        self,
+        lat_col: str,
+        long_col: str,
+        km_threshold: int | float,
+        not_null: bool = False,
+    ):
+        """Use the haversine formula to transform comparisons of lat,lngs
+        into distances measured in kilometers
+
+        Arguments:
+            lat_col (str): The name of a latitude column or the respective array
+                or struct column column containing the information
+                For example: long_lat['lat'] or long_lat[0]
+            long_col (str): The name of a longitudinal column or the respective array
+                or struct column column containing the information, plus an index.
+                For example: long_lat['long'] or long_lat[1]
+            km_threshold (int): The total distance in kilometers to evaluate your
+                comparisons against
+            not_null (bool): If true, ensure no attempt is made to compute this if
+              any inputs are null. This is only necessary if you are not
+                capturing nulls elsewhere in your comparison level.
+
+        """
+        self.lat_col = lat_col
+        self.long_col = long_col
+        self.km_threshold = km_threshold
+        self.not_null = not_null
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        lat_col_ic = input_column_factory(self.lat_col, sql_dialect)
+        long_col_ic = input_column_factory(self.long_col, sql_dialect)
+        lat_l, lat_r = lat_col_ic.names_l_r()
+        long_l, long_r = long_col_ic.names_l_r()
+
+        distance_km_sql = (
+            f"{great_circle_distance_km_sql(lat_l, lat_r, long_l, long_r)} "
+            f"<= {self.km_threshold}"
+        )
+
+        if self.not_null:
+            null_sql = " AND ".join(
+                [f"{c} is not null" for c in [lat_r, lat_l, long_l, long_r]]
+            )
+            distance_km_sql = f"({null_sql}) AND {distance_km_sql}"
+
+        return distance_km_sql
+
+    def create_label_for_charts(self) -> str:
+        return (f"Distance less than {self.km_threshold}km",)

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -286,4 +286,4 @@ class DistanceInKMLevel(ComparisonLevelCreator):
         return distance_km_sql
 
     def create_label_for_charts(self) -> str:
-        return (f"Distance less than {self.km_threshold}km",)
+        return f"Distance less than {self.km_threshold}km"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -241,7 +241,7 @@ class DistanceInKMLevel(ComparisonLevelCreator):
         self,
         lat_col: str,
         long_col: str,
-        km_threshold: int | float,
+        km_threshold: Union[int, float],
         not_null: bool = False,
     ):
         """Use the haversine formula to transform comparisons of lat,lngs

--- a/splink/comparison_level_sql.py
+++ b/splink/comparison_level_sql.py
@@ -13,8 +13,13 @@ def great_circle_distance_km_sql(lat_l, lat_r, long_l, long_r):
     # e.g. for (29.7517, -95.4054) results in 1.0000000000000002
     # This causes an error in the acos function, so we need to clip to [-1, 1]
     # See https://github.com/moj-analytical-services/splink/issues/1005
+    # Can't use least(greatest) because not supported in sqlite
     partial_distance_sql = f"""
-        LEAST(GREATEST({partial_distance_sql}, -1), 1)
+        case
+            when ({partial_distance_sql}) > 1 then 1
+            when ({partial_distance_sql}) < -1 then -1
+            else ({partial_distance_sql})
+        end
     """
 
     distance_km_sql = f"""

--- a/splink/comparison_level_sql.py
+++ b/splink/comparison_level_sql.py
@@ -1,0 +1,28 @@
+def great_circle_distance_km_sql(lat_l, lat_r, long_l, long_r):
+    # Earth mean radius = 6371 km
+    # see e.g. https://www.wolframalpha.com/input?i=earth+mean+radius+in+km
+    EARTH_RADIUS_KM = 6371
+
+    partial_distance_sql = f"""
+        sin( radians({lat_l}) ) * sin( radians({lat_r}) ) +
+        cos( radians({lat_l}) ) * cos( radians({lat_r}) )
+            * cos( radians({long_r} - {long_l}) )
+    """
+    # The above should theoretically be in the range [-1, 1], but
+    # due to rounding errors values can be slightly outside this range.
+    # e.g. for (29.7517, -95.4054) results in 1.0000000000000002
+    # This causes an error in the acos function, so we need to clip to [-1, 1]
+    # See https://github.com/moj-analytical-services/splink/issues/1005
+    partial_distance_sql = f"""
+        LEAST(GREATEST({partial_distance_sql}, -1), 1)
+    """
+
+    distance_km_sql = f"""
+        cast(
+            acos(
+                {partial_distance_sql}
+            ) * {EARTH_RADIUS_KM}
+            as float
+        )
+    """
+    return distance_km_sql


### PR DESCRIPTION
I thought of changing the sql for the clip [-1,1] to a minmax, but it doesn't work because greatest and least are unsupported by sqlite.

```
from sqlglot import Dialect, Dialects, parse_one

query = parse_one("SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)")

for dialect in sorted(Dialects._member_map_.values()):
    print(f"{dialect.name}: {Dialect.get(dialect)().generate(query)}")
```

```

DIALECT: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
BIGQUERY: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
CLICKHOUSE: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
DATABRICKS: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
Doris: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
DRILL: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
DUCKDB: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
HIVE: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
MYSQL: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
ORACLE: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
POSTGRES: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
PRESTO: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
REDSHIFT: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
SNOWFLAKE: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
SPARK: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
SPARK2: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
SQLITE: SELECT GREATEST(partial_distance_sql, -1)
STARROCKS: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
TABLEAU: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
TERADATA: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
TRINO: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)
TSQL: SELECT LEAST(GREATEST(partial_distance_sql, -1), 1)


```