### PR TITLE
Splink4: Additional string distance levels (damerau-lev, jaro and jaccard)

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -140,6 +140,34 @@ class LevenshteinLevel(ComparisonLevelCreator):
         return f"Levenshtein distance of {self.col_name} <= {self.distance_threshold}"
 
 
+class DamerauLevenshteinLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: int):
+        """A comparison level using a Damerau-Levenshtein distance function
+
+        e.g. damerau_levenshtein(val_l, val_r) <= distance_threshold
+
+        Args:
+            col_name (str): Input column name
+            distance_threshold (int): The threshold to use to assess
+                similarity
+        """
+        super().__init__(col_name)
+        self.distance_threshold = distance_threshold
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        col = self.input_column(sql_dialect)
+        dm_lev_fn = sql_dialect.damerau_levenshtein_function_name
+        return (
+            f"{dm_lev_fn}({col.name_l()}, {col.name_r()}) <= {self.distance_threshold}"
+        )
+
+    def create_label_for_charts(self) -> str:
+        return (
+            f"Damerau-Levenshtein distance of {self.col_name} "
+            f"<= {self.distance_threshold}"
+        )
+
+
 class DatediffLevel(ComparisonLevelCreator):
     def __init__(
         self,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -293,6 +293,35 @@ class JaroLevel(ComparisonLevelCreator):
         return f"Jaro distance of '{self.col_name} >= {self.distance_threshold}'"
 
 
+class JaccardLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
+        """A comparison level using a Jaccard distance function
+
+        e.g. `jaccard(val_l, val_r) >= distance_threshold`
+
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+        """
+
+        super().__init__(col_name)
+        self.distance_threshold = validate_distance_threshold(
+            lower_bound=0,
+            upper_bound=1,
+            distance_threshold=distance_threshold,
+            level_name=self.__class__.__name__,
+        )
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        col_l, col_r = self.input_column(sql_dialect).names_l_r()
+        j_fn = sql_dialect._jaccard_function_name
+        return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
+
+    def create_label_for_charts(self) -> str:
+        return f"Jaccard distance of '{self.col_name} >= {self.distance_threshold}'"
+
+
 class DistanceInKMLevel(ComparisonLevelCreator):
     def __init__(
         self,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -155,7 +155,7 @@ class DamerauLevenshteinLevel(ComparisonLevelCreator):
         self.distance_threshold = distance_threshold
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col = self.input_column(sql_dialect)
+        col_l, col_r = self.input_column(sql_dialect).names_l_r
         dm_lev_fn = sql_dialect.damerau_levenshtein_function_name
         return (
             f"{dm_lev_fn}({col.name_l()}, {col.name_r()}) <= {self.distance_threshold}"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -155,17 +155,104 @@ class DamerauLevenshteinLevel(ComparisonLevelCreator):
         self.distance_threshold = distance_threshold
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col_l, col_r = self.input_column(sql_dialect).names_l_r
+        col = self.input_column(sql_dialect)
         dm_lev_fn = sql_dialect.damerau_levenshtein_function_name
-        return (
-            f"{dm_lev_fn}({col.name_l()}, {col.name_r()}) <= {self.distance_threshold}"
-        )
+        return f"{dm_lev_fn}({col.name_l}, {col.name_r}) <= {self.distance_threshold}"
 
     def create_label_for_charts(self) -> str:
         return (
             f"Damerau-Levenshtein distance of {self.col_name} "
             f"<= {self.distance_threshold}"
         )
+
+
+class JaroWinklerLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
+        """A comparison level using a Jaro-Winkler distance function
+
+        e.g. `jaro_winkler(val_l, val_r) >= distance_threshold`
+
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+        """
+
+        super().__init__(col_name)
+        self.distance_threshold = validate_distance_threshold(
+            lower_bound=0,
+            upper_bound=1,
+            distance_threshold=distance_threshold,
+            level_name=self.__class__.__name__,
+        )
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        col = self.input_column(sql_dialect)
+        jw_fn = sql_dialect.jaro_winkler_function_name
+        return f"{jw_fn}({col.name_l}, {col.name_r}) >= {self.distance_threshold}"
+
+    def create_label_for_charts(self) -> str:
+        return (
+            f"Jaro-Winkler distance of '{self.col_name} >= {self.distance_threshold}'"
+        )
+
+
+class JaroLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
+        """A comparison level using a Jaro distance function
+
+        e.g. `jaro(val_l, val_r) >= distance_threshold`
+
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+        """
+
+        super().__init__(col_name)
+        self.distance_threshold = validate_distance_threshold(
+            lower_bound=0,
+            upper_bound=1,
+            distance_threshold=distance_threshold,
+            level_name=self.__class__.__name__,
+        )
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        col = self.input_column(sql_dialect)
+        j_fn = sql_dialect.jaro_function_name
+        return f"{j_fn}({col.name_l}, {col.name_r}) >= {self.distance_threshold}"
+
+    def create_label_for_charts(self) -> str:
+        return f"Jaro distance of '{self.col_name} >= {self.distance_threshold}'"
+
+
+class JaccardLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
+        """A comparison level using a Jaccard distance function
+
+        e.g. `jaccard(val_l, val_r) >= distance_threshold`
+
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+        """
+
+        super().__init__(col_name)
+        self.distance_threshold = validate_distance_threshold(
+            lower_bound=0,
+            upper_bound=1,
+            distance_threshold=distance_threshold,
+            level_name=self.__class__.__name__,
+        )
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        col_l, col_r = self.input_column(sql_dialect).names_l_r
+        j_fn = sql_dialect._jaccard_function_name
+        return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
+
+    def create_label_for_charts(self) -> str:
+        return f"Jaccard distance of '{self.col_name} >= {self.distance_threshold}'"
 
 
 class DatediffLevel(ComparisonLevelCreator):
@@ -231,95 +318,6 @@ class DatediffLevel(ComparisonLevelCreator):
             f"Date difference of '{self.col_name} <= "
             f"{self.date_threshold} {self.date_metric}'"
         )
-
-
-class JaroWinklerLevel(ComparisonLevelCreator):
-    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
-        """A comparison level using a Jaro-Winkler distance function
-
-        e.g. `jaro_winkler(val_l, val_r) >= distance_threshold`
-
-        Args:
-            col_name (str): Input column name
-            distance_threshold (Union[int, float]): The threshold to use to assess
-                similarity
-        """
-
-        super().__init__(col_name)
-        self.distance_threshold = validate_distance_threshold(
-            lower_bound=0,
-            upper_bound=1,
-            distance_threshold=distance_threshold,
-            level_name=self.__class__.__name__,
-        )
-
-    def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col_l, col_r = self.input_column(sql_dialect).names_l_r
-        jw_fn = sql_dialect.jaro_winkler_function_name
-        return f"{jw_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
-
-    def create_label_for_charts(self) -> str:
-        return (
-            f"Jaro-Winkler distance of '{self.col_name} >= {self.distance_threshold}'"
-        )
-
-
-class JaroLevel(ComparisonLevelCreator):
-    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
-        """A comparison level using a Jaro distance function
-
-        e.g. `jaro(val_l, val_r) >= distance_threshold`
-
-        Args:
-            col_name (str): Input column name
-            distance_threshold (Union[int, float]): The threshold to use to assess
-                similarity
-        """
-
-        super().__init__(col_name)
-        self.distance_threshold = validate_distance_threshold(
-            lower_bound=0,
-            upper_bound=1,
-            distance_threshold=distance_threshold,
-            level_name=self.__class__.__name__,
-        )
-
-    def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col_l, col_r = self.input_column(sql_dialect).names_l_r
-        j_fn = sql_dialect.jaro_function_name
-        return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
-
-    def create_label_for_charts(self) -> str:
-        return f"Jaro distance of '{self.col_name} >= {self.distance_threshold}'"
-
-
-class JaccardLevel(ComparisonLevelCreator):
-    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
-        """A comparison level using a Jaccard distance function
-
-        e.g. `jaccard(val_l, val_r) >= distance_threshold`
-
-        Args:
-            col_name (str): Input column name
-            distance_threshold (Union[int, float]): The threshold to use to assess
-                similarity
-        """
-
-        super().__init__(col_name)
-        self.distance_threshold = validate_distance_threshold(
-            lower_bound=0,
-            upper_bound=1,
-            distance_threshold=distance_threshold,
-            level_name=self.__class__.__name__,
-        )
-
-    def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col_l, col_r = self.input_column(sql_dialect).names_l_r
-        j_fn = sql_dialect._jaccard_function_name
-        return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
-
-    def create_label_for_charts(self) -> str:
-        return f"Jaccard distance of '{self.col_name} >= {self.distance_threshold}'"
 
 
 class DistanceInKMLevel(ComparisonLevelCreator):

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -314,7 +314,7 @@ class JaccardLevel(ComparisonLevelCreator):
         )
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col_l, col_r = self.input_column(sql_dialect).names_l_r()
+        col_l, col_r = self.input_column(sql_dialect).names_l_r
         j_fn = sql_dialect._jaccard_function_name
         return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -285,7 +285,7 @@ class JaroLevel(ComparisonLevelCreator):
         )
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        col_l, col_r = self.input_column(sql_dialect).names_l_r()
+        col_l, col_r = self.input_column(sql_dialect).names_l_r
         j_fn = sql_dialect.jaro_function_name
         return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -264,6 +264,35 @@ class JaroWinklerLevel(ComparisonLevelCreator):
         )
 
 
+class JaroLevel(ComparisonLevelCreator):
+    def __init__(self, col_name: str, distance_threshold: Union[int, float]):
+        """A comparison level using a Jaro distance function
+
+        e.g. `jaro(val_l, val_r) >= distance_threshold`
+
+        Args:
+            col_name (str): Input column name
+            distance_threshold (Union[int, float]): The threshold to use to assess
+                similarity
+        """
+
+        super().__init__(col_name)
+        self.distance_threshold = validate_distance_threshold(
+            lower_bound=0,
+            upper_bound=1,
+            distance_threshold=distance_threshold,
+            level_name=self.__class__.__name__,
+        )
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        col_l, col_r = self.input_column(sql_dialect).names_l_r()
+        j_fn = sql_dialect.jaro_function_name
+        return f"{j_fn}({col_l}, {col_r}) >= {self.distance_threshold}"
+
+    def create_label_for_charts(self) -> str:
+        return f"Jaro distance of '{self.col_name} >= {self.distance_threshold}'"
+
+
 class DistanceInKMLevel(ComparisonLevelCreator):
     def __init__(
         self,

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -36,6 +36,12 @@ class SplinkDialect(ABC):
             f"Backend '{self.name}' does not have a 'Jaro-Winkler' function"
         )
 
+    @property
+    def jaro_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.name}' does not have a 'Jaro' function"
+        )
+
 
 class DuckDBDialect(SplinkDialect):
     @property
@@ -49,6 +55,10 @@ class DuckDBDialect(SplinkDialect):
     @property
     def damerau_levenshtein_function_name(self):
         return "damerau_levenshtein"
+
+    @property
+    def jaro_function_name(self):
+        return "jaro_similarity"
 
     @property
     def jaro_winkler_function_name(self):
@@ -67,6 +77,10 @@ class SparkDialect(SplinkDialect):
     @property
     def damerau_levenshtein_function_name(self):
         return "damerau_levenshtein"
+
+    @property
+    def _jaro_name(self):
+        return "jaro_sim"
 
     @property
     def jaro_winkler_function_name(self):

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -89,7 +89,7 @@ class SparkDialect(SplinkDialect):
         return "damerau_levenshtein"
 
     @property
-    def _jaro_name(self):
+    def jaro_function_name(self):
         return "jaro_sim"
 
     @property

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -64,6 +64,10 @@ class DuckDBDialect(SplinkDialect):
     def jaro_winkler_function_name(self):
         return "jaro_winkler_similarity"
 
+    @property
+    def jaccard_function_name(self):
+        return "jaccard"
+
 
 class SparkDialect(SplinkDialect):
     @property
@@ -85,6 +89,10 @@ class SparkDialect(SplinkDialect):
     @property
     def jaro_winkler_function_name(self):
         return "jaro_winkler"
+
+    @property
+    def jaccard_function_name(self):
+        return "jaccard"
 
 
 class SqliteDialect(SplinkDialect):

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -25,6 +25,12 @@ class SplinkDialect(ABC):
         )
 
     @property
+    def damerau_levenshtein_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.name}' does not have a 'Damerau-Levenshtein' function"
+        )
+
+    @property
     def jaro_winkler_function_name(self):
         raise NotImplementedError(
             f"Backend '{self.name}' does not have a 'Jaro-Winkler' function"
@@ -41,6 +47,10 @@ class DuckDBDialect(SplinkDialect):
         return "levenshtein"
 
     @property
+    def damerau_levenshtein_function_name(self):
+        return "damerau_levenshtein"
+
+    @property
     def jaro_winkler_function_name(self):
         return "jaro_winkler_similarity"
 
@@ -53,6 +63,10 @@ class SparkDialect(SplinkDialect):
     @property
     def levenshtein_function_name(self):
         return "levenshtein"
+
+    @property
+    def damerau_levenshtein_function_name(self):
+        return "damerau_levenshtein"
 
     @property
     def jaro_winkler_function_name(self):

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -42,6 +42,12 @@ class SplinkDialect(ABC):
             f"Backend '{self.name}' does not have a 'Jaro' function"
         )
 
+    @property
+    def jaccard_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.name}' does not have a 'Jaccard' function"
+        )
+
 
 class DuckDBDialect(SplinkDialect):
     @property


### PR DESCRIPTION
Added `damerau_levenshtein` `jaro` and `jaccard`


<details><summary>testing script</summary>
```python
from splink.datasets import splink_datasets
from splink.duckdb.linker import DuckDBLinker

from splink.comparison_level_library import (
    ExactMatchLevel,
    JaccardLevel,
    JaroLevel,
    JaroWinklerLevel,
    LevenshteinLevel,
    DamerauLevenshteinLevel,
    NullLevel,
    ElseLevel,
)

df = splink_datasets.fake_1000

comparison_first_name = {
    "output_column_name": "first_name",
    "comparison_description": "First name jaro dmeta",
    "comparison_levels": [
        NullLevel("first_name"),
        ExactMatchLevel("first_name"),
        JaroLevel("first_name", 0.9),
        JaccardLevel("first_name", 0.9),
        JaroWinklerLevel("first_name", 0.9),
        LevenshteinLevel("first_name", 2),
        DamerauLevenshteinLevel("first_name", 2),
        ElseLevel("first_name"),
    ],
}


for be in ["duckdb", "athena", "sqlite", "spark", "postgres"]:
    print(f"------{be}------")
    for c in comparison_first_name["comparison_levels"]:
        try:
            print("---")
            print(c.create_level_dict("sqlite")["sql_condition"])
            print(c.create_level_dict("sqlite")["label_for_charts"])
        except:
            pass

```
</details>