### PR TITLE
fix: respect boto3_session when checking table existence from AthenaLinker

### DIFF
--- a/splink/athena/linker.py
+++ b/splink/athena/linker.py
@@ -270,6 +270,7 @@ class AthenaLinker(Linker):
         table_exists = wr.catalog.does_table_exist(
             database=db,
             table=tb,
+            boto3_session=self.boto3_session,
         )
         if not table_exists:
             raise wr.exceptions.InvalidTable(


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
closes #1732 



### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
Following the pattern of other `awswrangler` calls here, pass the `boto3_session` when checking for the existence of tables.


### PR Checklist

- [ ] Added documentation for changes
- [x] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


