### PR TITLE
When you go to open an issue, add a link to discussions below our issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Discussions
+    url: https://github.com/moj-analytical-services/splink/discussions
+    about: Please ask and answer general questions here.


### PR DESCRIPTION
Like duckdb here
https://github.com/duckdb/duckdb/blob/main/.github/ISSUE_TEMPLATE/config.yml

<img width="1247" alt="image" src="https://github.com/moj-analytical-services/splink/assets/2608005/35b16153-f1d0-40c5-96e0-002ea176b86d">

