### PR TITLE
Add expressions to input column

### DIFF
--- a/splink/comparison_helpers_utils.py
+++ b/splink/comparison_helpers_utils.py
@@ -1,4 +1,8 @@
 import re
+from functools import wraps
+from typing import Any, List
+
+from .dialects import SplinkDialect
 
 
 def distance_match(distance, threshold):
@@ -20,3 +24,44 @@ def threshold_match(comparator, score, distance_threshold, similarity_threshold)
         return distance_match(score, distance_threshold)
     elif re.search("similarity", comparator):
         return similarity_match(score, similarity_threshold)
+
+
+def unsupported_splink_dialects(unsupported_dialects: List[str]):
+    def decorator(func):
+        def wrapper(self, splink_dialect: SplinkDialect, *args, **kwargs):
+            if splink_dialect.name in unsupported_dialects:
+                raise ValueError(
+                    f"Dialect '{splink_dialect.name}' is not supported "
+                    f"for {self.__class__.__name__}"
+                )
+            return func(self, splink_dialect, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def unsupported_splink_dialect_expression(unsupported_dialects: List[str]):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(self, expression_argument: Any, *args, **kwargs):
+            method_name = func.__name__
+
+            if self._sql_dialect is None:
+                raise ValueError(
+                    f"'{method_name}' requires a valid dialect be "
+                    f"passed to the {self.__class__.__name__} class.\n"
+                    "Add a valid dialect using `.register_dialect(<dialect>)` "
+                    "before continuing."
+                )
+
+            if self._sql_dialect.name in unsupported_dialects and expression_argument:
+                raise ValueError(
+                    f"Dialect '{self._sql_dialect.name}' does not support "
+                    f"{method_name}"
+                )
+            return func(self, expression_argument, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -14,7 +14,7 @@ from sqlglot.optimizer.simplify import simplify
 
 from .constants import LEVEL_NOT_OBSERVED_TEXT
 from .default_from_jsonschema import default_value_from_schema
-from .input_column import InputColumn, sqlglot_tree_signature
+from .input_column import InputColumn
 from .misc import (
     dedupe_preserving_order,
     interpolate,
@@ -22,6 +22,7 @@ from .misc import (
     match_weight_to_bayes_factor,
 )
 from .parse_sql import get_columns_used_from_sql
+from .sql_transform import sqlglot_tree_signature
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:
@@ -719,7 +720,7 @@ class ComparisonLevel:
     @property
     def _human_readable_succinct(self):
         sql = self._abbreviated_sql(75)
-        return f"Comparison level '{self.label_for_charts}' using SQL rule: {sql}"
+        return f"Comparison level: {self.label_for_charts} using SQL rule: {sql}"
 
     @property
     def human_readable_description(self):

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -49,7 +49,7 @@ class ComparisonLevelCreator(ABC):
 
     @final
     def input_column(self, sql_dialect: SplinkDialect) -> InputColumn:
-        return InputColumn(self.col_name, sql_dialect=sql_dialect.sqlglot_name)
+        return InputColumn(self.col_name, sql_dialect=sql_dialect)
 
     @final
     def configure(

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -1,29 +1,11 @@
-from typing import List, Union
+from typing import Union
 
 from sqlglot import parse_one
 
+from .comparison_helpers_utils import unsupported_splink_dialects
 from .comparison_level_creator import ComparisonLevelCreator
 from .dialects import SplinkDialect
 from .input_column import InputColumn
-
-
-def input_column_factory(name, splink_dialect: SplinkDialect):
-    return InputColumn(name, sql_dialect=splink_dialect.sqlglot_name)
-
-
-def unsupported_splink_dialects(unsupported_dialects: List[str]):
-    def decorator(func):
-        def wrapper(self, splink_dialect: SplinkDialect, *args, **kwargs):
-            if splink_dialect.name in unsupported_dialects:
-                raise ValueError(
-                    f"Dialect {splink_dialect.name} is not supported "
-                    f"for {self.__class__.__name__}"
-                )
-            return func(self, splink_dialect, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 def validate_distance_threshold(
@@ -104,8 +86,8 @@ class ColumnsReversedLevel(ComparisonLevelCreator):
         self.col_name_2 = col_name_2
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        input_column_1 = input_column_factory(self.col_name_1, sql_dialect)
-        input_column_2 = input_column_factory(self.col_name_2, sql_dialect)
+        input_column_1 = InputColumn(self.col_name_1, sql_dialect)
+        input_column_2 = InputColumn(self.col_name_2, sql_dialect)
 
         return (
             f"{input_column_1.name_l} = {input_column_2.name_r} "

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,56 +1,152 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from typing import List
 
 import sqlglot
 import sqlglot.expressions as exp
-from sqlglot.errors import ParseError
-from sqlglot.expressions import Expression
+from sqlglot.errors import ParseError, TokenError
 
+from .comparison_helpers_utils import unsupported_splink_dialect_expression
 from .default_from_jsonschema import default_value_from_schema
+from .dialects import SplinkDialect
+from .misc import is_castable_to_int
 
 
-def sqlglot_tree_signature(tree):
+@dataclass
+class ColumnBuilder:
+    """A builder class that allows you to copy and modify an input column.
+
+    Modifications copy the base column and can be chained to produce a fresh
+    version of the column.
+
+    Columns can also be wrapped in SQLglot expressions by appending them to the
+    base class.
     """
-    A short string representation of a SQLglot tree.
 
-    Allows you to easily check that a tree contains certain nodes
+    name: str
+    table: str = None
+    quoted: bool = True
+    bracket_index: exp.Bracket = None  # the JSON index in 'surname['lat']'
+    column_expressions: List[exp.Expression] = field(default_factory=list)
+    return_column_with_expressions: bool = True
 
-    For instance, the string "robin['hi']" becomes:
-    'bracket column literal identifier'
-    """
-    return " ".join(n[0].key for n in tree.walk())
+    def unquote(self):
+        return replace(self, quoted=False)
 
+    def exclude_expressions(self):
+        return replace(self, return_column_with_expressions=False)
 
-def add_suffix(tree, suffix) -> Expression:
-    tree = tree.copy()
-    identifier_string = tree.find(exp.Identifier).this
-    identifier_string = f"{identifier_string}{suffix}"
-    tree.find(exp.Identifier).args["this"] = identifier_string
-    return tree
+    def change_name(self, new_name: str):
+        return replace(self, name=new_name)
 
+    def add_prefix(self, prefix: str):
+        return replace(self, name=prefix + self.name) if prefix else self
 
-def add_prefix(tree, prefix) -> Expression:
-    tree = tree.copy()
-    identifier_string = tree.find(exp.Identifier).this
-    identifier_string = f"{prefix}{identifier_string}"
-    tree.find(exp.Identifier).args["this"] = identifier_string
-    return tree
+    def add_suffix(self, suffix: str):
+        return replace(self, name=self.name + suffix) if suffix else self
 
+    def add_table(self, table: str):
+        return replace(self, table=table) if table else self
 
-def add_table(tree, tablename) -> Expression:
-    tree = tree.copy()
-    table_identifier = exp.Identifier(this=tablename, quoted=True)
-    identifier = tree.find(exp.Column)
-    identifier.args["table"] = table_identifier
-    return tree
+    def add_alias(self, alias: str) -> exp.Alias:
+        """Alias expects a SQLglot Identifier class or a str.
 
+        For safety, only pass strings to ensure we capture the entire
+        column reference, not just the identifier.
 
-def remove_quotes_from_identifiers(tree) -> Expression:
-    tree = tree.copy()
-    for identifier in tree.find_all(exp.Identifier):
-        identifier.args["quoted"] = False
-    return tree
+        For example, col['lat'] is made up of both an identifier and bracket
+        index; the latter of which would be lost if passing identifiers.
+        """
+        # The identifier should be quoted or unquoted before being passed.
+        # This is to ensure we get the correct output.
+        alias = exp.Identifier(this=alias, quoted=self.quoted)
+        return self.build_column_tree_with_expressions().as_(alias)
+
+    def add_bracket_index(self, index_name: str):
+        is_string = not is_castable_to_int(index_name)
+        literal = exp.Literal(this=index_name, is_string=is_string)
+
+        self.bracket_index = exp.Bracket(expressions=[literal])
+        return self
+
+    def append_expression(self, expression: exp.Expression):
+        self.column_expressions.append(expression)
+        self.remove_duplicate_expressions()
+        return self
+
+    def remove_duplicate_expressions(self):
+        """
+        Remove duplicate expressions from the column expressions list.
+
+        Ordering is determined by the sequence of appends; the most recently added
+        items to the list are retained and appear as the outermost branches
+        in the SQL expression tree.
+        """
+        seen_types = set()
+        # Iterate from right to left
+        for index in range(len(self.column_expressions) - 1, -1, -1):
+            if type(self.column_expressions[index]) in seen_types:
+                del self.column_expressions[index]
+            else:
+                seen_types.add(type(self.column_expressions[index]))
+
+        return self.column_expressions
+
+    @property
+    def column_tree(self):
+        # Create our column representation
+        column = sqlglot.column(col=self.name, table=self.table, quoted=self.quoted)
+        # Column is made up of the identifier + bracket index (if it exists)
+        if self.bracket_index:
+            self.bracket_index.set("this", column)
+            return self.bracket_index
+        else:
+            return column
+
+    def build_column_tree_with_expressions(self) -> sqlglot.Expression:
+        """Constructs an SQLglot expression tree by combining a column expression
+        with a sequence of SQLglot expressions.
+
+        This method iteratively sets the column value for each expression,
+        starting from the provided column and extending to the most recently
+        added expression.
+
+        Expressions are modified in-place to avoid copying. This only works
+        for expressions expecting a single child - i.e. any value that only
+        expects a single "this" key.
+        """
+        column = self.column_tree
+        column_expressions = deepcopy(self.column_expressions)
+
+        if column_expressions and self.return_column_with_expressions:
+            # Recursively select the innermost element of the expression tree and
+            # add it to our sqlglot column through a simple find and replace.
+
+            # This is possible as our expressions are all functions expecting a single
+            # column argument, which we can add a placeholder for and replace.
+            for expression in column_expressions:
+                expression.find(exp.Column).replace(column)
+                # Update the column
+                column = expression
+
+        return column
+
+    @classmethod
+    def with_sqlglot_column(cls, column: exp.Column, bracket_index: exp.Bracket = None):
+        return cls(column.name, bracket_index=bracket_index)
+
+    def __repr__(self):
+        # Extract the types of expressions within self.expressions
+        expression_types = [type(expr).__name__ for expr in self.column_expressions]
+
+        return (
+            f"{self.__class__.__name__}("
+            f"name='{self.name}', Quoted={self.quoted}, "
+            f"bracket_index={self.bracket_index}, "
+            f"expression_types={expression_types})"
+        )
 
 
 class InputColumn:
@@ -58,55 +154,54 @@ class InputColumn:
     Represents a SQL column or column reference
     Handles SQL dialect-specific issues such as identifier quoting.
 
-    The input should be the raw identifier, without SQL-specific identifier quotes.
-
-    For example, if a column is named 'first name' (with a space), the input should be
-    'first name', not '"first name"'.
+    The input can be either the raw identifier, or an identifier with
+    SQL-specific identifier quotes.
 
     Examples of valid inputs include:
     - 'first_name'
-    - 'first name'
+    - 'first[name'
+    - '"first name"'
     - 'coordinates['lat']'
+    - '"sur NAME"['lat']
     - 'coordinates[1]'
-
     """
 
     def __init__(
-        self, raw_column_name_or_column_reference, settings_obj=None, sql_dialect=None
+        self,
+        raw_column_name_or_column_reference: str,
+        settings_obj=None,
+        sql_dialect: str | SplinkDialect = None,  # TODO: should this be a required arg?
     ):
         # If settings_obj is None, then default values will be used
         # from the jsonschama
         self._settings_obj = settings_obj
 
-        if sql_dialect:
-            self._sql_dialect = sql_dialect
-        elif settings_obj:
-            self._sql_dialect = self._settings_obj._sql_dialect
-        else:
-            self._sql_dialect = None
+        self.register_dialect(sql_dialect)
 
-        self.input_name = self._quote_if_sql_keyword(
+        self.column_builder = self._parse_input_name_to_sqlglot_tree(
             raw_column_name_or_column_reference
         )
 
-        self.input_name_as_tree = self.parse_input_name_to_sqlglot_tree()
+    def register_dialect(self, sql_dialect: str | SplinkDialect):
+        if not sql_dialect and self._settings_obj:
+            sql_dialect = self._settings_obj._sql_dialect
 
-        for identifier in self.input_name_as_tree.find_all(exp.Identifier):
-            identifier.args["quoted"] = True
+        if type(sql_dialect) == str:
+            sql_dialect = SplinkDialect.from_string(sql_dialect)
 
-    def quote(self) -> "InputColumn":
-        self_copy = deepcopy(self)
-        for identifier in self_copy.input_name_as_tree.find_all(exp.Identifier):
-            identifier.args["quoted"] = True
-        return self_copy
+        self._sql_dialect = sql_dialect
+        self.sqlglot_name = sql_dialect.sqlglot_name if sql_dialect else None
 
-    def unquote(self) -> "InputColumn":
-        self_copy = deepcopy(self)
-        for identifier in self_copy.input_name_as_tree.find_all(exp.Identifier):
-            identifier.args["quoted"] = False
-        return self_copy
+    def from_settings_obj_else_default(self, key, schema_key=None):
+        # Covers the case where no settings obj is set on the comparison level
+        if self._settings_obj:
+            return getattr(self._settings_obj, key)
+        else:
+            if not schema_key:
+                schema_key = key
+            return default_value_from_schema(schema_key, "root")
 
-    def parse_input_name_to_sqlglot_tree(self) -> Expression:
+    def _parse_input_name_to_sqlglot_tree(self, name: str) -> ColumnBuilder:
         """
         Parses the input name into a SQLglot expression tree.
 
@@ -118,89 +213,149 @@ class InputColumn:
         Note: We do not support inputs like 'SUR name[1]', in this case the user
         would have to quote e.g. `SUR name`[1]
         """
-
-        q_s, q_e = _get_dialect_quotes(self._sql_dialect)
+        q_s, q_e = _get_dialect_quotes(self.sqlglot_name)
 
         try:
-            tree = sqlglot.parse_one(self.input_name, read=self._sql_dialect)
-        except ParseError:
-            tree = sqlglot.parse_one(
-                f"{q_s}{self.input_name}{q_e}", read=self._sql_dialect
-            )
+            tree = sqlglot.parse_one(name, read=self.sqlglot_name)
+        except (ParseError, TokenError):
+            # The parse statement will error in cases such as: sur "name"['lat']
+            sqlglot.parse_one(f"{q_s}{name}{q_e}", read=self.sqlglot_name)
+            identifier, index = self.manually_split_identifier_and_index(name)
 
-        tree_signature = sqlglot_tree_signature(tree)
-        valid_signatures = ["column identifier", "bracket column literal identifier"]
+            # Construct the column manually if it can be parsed with quotes.
+            # This is useful for illegal columns such as test[ing, test'ing, test"ing
+            if index:
+                return ColumnBuilder(identifier).add_bracket_index(index)
+            else:
+                return ColumnBuilder(identifier)
 
-        if tree_signature in valid_signatures:
-            return tree
+        return self._parse_column_identifier(name, tree)
+
+    def _parse_column_identifier(
+        self, name: str, tree: sqlglot.Expression
+    ) -> ColumnBuilder:
+        # Columns which contains spaces will be registered as aliases.
+        # Check that no quotes have been applied to either end of the name:
+        # - "sur" name, sur "name" are both invalid column names
+        if tree.find(exp.Alias):
+            if any([identifier.quoted for identifier in tree.find_all(exp.Identifier)]):
+                raise ParseError(
+                    f"The supplied column name '{name}' contains quotes and cannot be "
+                    "parsed as a valid SQL identifier."
+                )
+
+        if tree.find(exp.Bracket):
+            # Pop the column, leaving the bracket as the remaining section of the tree
+            column_tree = tree.find(exp.Column).pop()
+            return ColumnBuilder.with_sqlglot_column(column_tree, bracket_index=tree)
+
+        # If the column has already been quoted, then parse it
+        if tree.find(exp.Identifier).args.get("quoted"):
+            return ColumnBuilder.with_sqlglot_column(tree)
+
+        # If our column does not contain a quoted identifier, we can safely return
+        # the column builder
+        return ColumnBuilder(name)
+
+    @staticmethod
+    def manually_split_identifier_and_index(identifier: str):
+        # Manually pull out the bracket index for an unparseable column.
+        # This ensures we correctly parse cases such as: sur name['lat']
+        if identifier.endswith("]") and "[" in identifier:
+            split_index = identifier.rfind("[")
+            before_bracket = identifier[:split_index].strip()
+            after_bracket = identifier[split_index:].strip("[]'")
+            return before_bracket, after_bracket
         else:
-            # e.g. SUR name parses to 'alias column identifier identifier'
-            # but we want "SUR name"
-            tree = sqlglot.parse_one(
-                f"{q_s}{self.input_name}{q_e}", read=self._sql_dialect
-            )
-            return tree
-
-    def from_settings_obj_else_default(self, key, schema_key=None):
-        # Covers the case where no settings obj is set on the comparison level
-        if self._settings_obj:
-            return getattr(self._settings_obj, key)
-        else:
-            if not schema_key:
-                schema_key = key
-            return default_value_from_schema(schema_key, "root")
+            return identifier.strip("[],"), None
 
     @property
-    def gamma_prefix(self) -> str:
-        return self.from_settings_obj_else_default(
-            "_gamma_prefix", "comparison_vector_value_column_prefix"
-        )
-
-    @property
-    def bf_prefix(self) -> str:
+    def _bf_prefix(self):
         return self.from_settings_obj_else_default(
             "_bf_prefix", "bayes_factor_column_prefix"
         )
 
     @property
-    def tf_prefix(self) -> str:
+    def _tf_prefix(self):
         return self.from_settings_obj_else_default(
             "_tf_prefix", "term_frequency_adjustment_column_prefix"
         )
 
-    @property
-    def name(self) -> str:
-        return self.input_name_as_tree.sql(dialect=self._sql_dialect)
+    def _copy_with_new_column_builder(self, new_builder) -> InputColumn:
+        input_column_copy = deepcopy(self)
+        input_column_copy.column_builder = new_builder
+        return input_column_copy
 
-    @property
-    def name_l(self) -> str:
-        return add_suffix(self.input_name_as_tree, suffix="_l").sql(
-            dialect=self._sql_dialect
+    def change_input_column_names(self, new_name: str):
+        return self._copy_with_new_column_builder(
+            self.column_builder.change_name(new_name)
         )
 
-    @property
-    def name_r(self) -> str:
-        return add_suffix(self.input_name_as_tree, suffix="_r").sql(
-            dialect=self._sql_dialect
+    def unquote(self) -> InputColumn:
+        return self._copy_with_new_column_builder(self.column_builder.unquote())
+
+    def exclude_expressions(self) -> InputColumn:
+        return self._copy_with_new_column_builder(
+            self.column_builder.exclude_expressions()
         )
 
+    def add_bracket_index_to_col(self, index_name: str):
+        """
+        Manually add a bracket index onto your column - ['idx'].
+
+        This allows you to use illegal name and bracket combinations such as
+        'SUR NAME['lat']', without needing to add quotes to the column identifier.
+        """
+        self.column_builder = self.column_builder.add_bracket_index(index_name)
+
     @property
-    def names_l_r(self) -> list[str]:
+    def as_base_dialect(self) -> InputColumn:
+        input_column_copy = deepcopy(self)
+        input_column_copy.sqlglot_name = None
+        return input_column_copy
+
+    def column_tree_to_sql(self, column_tree: ColumnBuilder) -> str:
+        return column_tree.build_column_tree_with_expressions().sql(self.sqlglot_name)
+
+    def _table_name_as(self, table: str, prefix: str = "", suffix: str = "") -> str:
+        # Remove quotes and expressions, if applied. This prevents
+        # the accidental addition of quotes to the alias.
+        # See: exp.Identifier(this='`test`', quoted=True).sql("spark")
+        column_builder = self.column_builder.exclude_expressions().unquote()
+        # Add both the prefix and suffix arguments to the column
+        alias_tree = column_builder.add_prefix(prefix).add_suffix(suffix)
+        alias_string = self.column_tree_to_sql(alias_tree)
+
+        column_with_table = self.column_builder.add_table(table).add_prefix(prefix)
+        tree = column_with_table.add_alias(alias_string)
+        return tree.sql(self.sqlglot_name)
+
+    @property
+    def name(self):
+        tree = self.column_builder
+        return self.column_tree_to_sql(tree)
+
+    @property
+    def name_l(self):
+        tree = self.column_builder.add_suffix("_l")
+        return self.column_tree_to_sql(tree)
+
+    @property
+    def name_r(self):
+        tree = self.column_builder.add_suffix("_r")
+        return self.column_tree_to_sql(tree)
+
+    @property
+    def names_l_r(self):
         return [self.name_l, self.name_r]
 
     @property
     def l_name_as_l(self) -> str:
-        name_with_l_table = add_table(self.input_name_as_tree, "l").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{name_with_l_table} as {self.name_l}"
+        return self._table_name_as(table="l", suffix="_l")
 
     @property
     def r_name_as_r(self) -> str:
-        name_with_r_table = add_table(self.input_name_as_tree, "r").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{name_with_r_table} as {self.name_r}"
+        return self._table_name_as(table="r", suffix="_r")
 
     @property
     def l_r_names_as_l_r(self) -> list[str]:
@@ -208,25 +363,23 @@ class InputColumn:
 
     @property
     def bf_name(self) -> str:
-        return add_prefix(self.input_name_as_tree, prefix=self.bf_prefix).sql(
-            dialect=self._sql_dialect
-        )
+        tree = self.column_builder.add_prefix(self._bf_prefix)
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name(self) -> str:
-        return add_prefix(self.input_name_as_tree, prefix=self.tf_prefix).sql(
-            dialect=self._sql_dialect
-        )
+        tree = self.column_builder.add_prefix(self._tf_prefix)
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name_l(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        return add_suffix(tree, suffix="_l").sql(dialect=self._sql_dialect)
+        tree = self.column_builder.add_prefix(self._tf_prefix).add_suffix("_l")
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name_r(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        return add_suffix(tree, suffix="_r").sql(dialect=self._sql_dialect)
+        tree = self.column_builder.add_prefix(self._tf_prefix).add_suffix("_r")
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name_l_r(self) -> list[str]:
@@ -234,29 +387,49 @@ class InputColumn:
 
     @property
     def l_tf_name_as_l(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        tf_name_with_l_table = add_table(tree, tablename="l").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{tf_name_with_l_table} as {self.tf_name_l}"
+        return self._table_name_as(table="l", prefix=self._tf_prefix, suffix="_l")
 
     @property
     def r_tf_name_as_r(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        tf_name_with_r_table = add_table(tree, tablename="r").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{tf_name_with_r_table} as {self.tf_name_r}"
+        return self._table_name_as(table="r", prefix=self._tf_prefix, suffix="_r")
 
     @property
     def l_r_tf_names_as_l_r(self) -> list[str]:
         return [self.l_tf_name_as_l, self.r_tf_name_as_r]
 
-    def _quote_if_sql_keyword(self, name: str) -> str:
-        if name not in {"group", "index"}:
-            return name
-        start, end = _get_dialect_quotes(self._sql_dialect)
-        return start + name + end
+    def lowercase_column(self, to_lowercase: bool) -> InputColumn:
+        if to_lowercase:
+            lowercase_sql = sqlglot.parse_one("lower(col)", self.sqlglot_name)
+            self.column_builder.append_expression(lowercase_sql)
+        return self
+
+    @unsupported_splink_dialect_expression(["postgres", "sqlite"])
+    def regex_extract(self, regex: str) -> InputColumn:
+        if regex:
+            regex_sql = f"regexp_extract(col, '{regex}', 0)"
+            self.column_builder.append_expression(
+                sqlglot.parse_one(regex_sql, self.sqlglot_name)
+            )
+        return self
+
+    @unsupported_splink_dialect_expression([])  # check if a dialect has been supplied
+    def str_to_date(self, cast_dates_to_string: bool, date_format: str):
+        if cast_dates_to_string:
+            str_to_date_function = self._sql_dialect.str_to_date
+            str_to_date_sql = f"{str_to_date_function}(col, '{date_format}')"
+
+            self.column_builder.append_expression(
+                sqlglot.parse_one(str_to_date_sql, self.sqlglot_name)
+            )
+        return self
+
+    @property
+    def reset_expressions(self):
+        """Reset the column expressions within the column builder."""
+        self.column_builder.column_expressions = []
+
+    def __repr__(self):
+        return f"InputColumn({self.column_builder.__repr__()})"
 
 
 def _get_dialect_quotes(dialect):

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -13,7 +13,7 @@ from statistics import median
 
 import sqlglot
 
-from splink.input_column import InputColumn, remove_quotes_from_identifiers
+from splink.input_column import InputColumn
 from splink.settings_validation.column_lookups import InvalidColumnsLogger
 from splink.settings_validation.valid_types import (
     InvalidTypesAndValuesLogger,
@@ -97,6 +97,7 @@ from .splink_comparison_viewer import (
     render_splink_comparison_viewer_html,
 )
 from .splink_dataframe import SplinkDataFrame
+from .sql_transform import remove_quotes_from_identifiers
 from .term_frequencies import (
     _join_tf_to_input_df_sql,
     colname_to_tf_tablename,

--- a/splink/misc.py
+++ b/splink/misc.py
@@ -204,3 +204,11 @@ def read_resource(path: str) -> str:
     # Also, if you use importlib.resources, then you have to add an
     # __init__.py file to every subdirectory, which is annoying.
     return pkgutil.get_data("splink", path).decode("utf-8")
+
+
+def is_castable_to_int(value):
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False

--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -2,7 +2,7 @@ import sqlglot
 import sqlglot.expressions as exp
 from sqlglot.expressions import Bracket, Column, Lambda
 
-from .input_column import remove_quotes_from_identifiers
+from .sql_transform import remove_quotes_from_identifiers
 
 
 def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -8,8 +8,9 @@ from typing import List
 
 import sqlglot
 
-from ..input_column import InputColumn, remove_quotes_from_identifiers
+from ..input_column import InputColumn
 from ..misc import ensure_is_list
+from ..sql_transform import remove_quotes_from_identifiers
 
 logger = logging.getLogger(__name__)
 

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -8,6 +8,25 @@ def sqlglot_transform_sql(sql, func, dialect=None):
     return transformed_tree.sql(dialect)
 
 
+def sqlglot_tree_signature(tree):
+    """
+    A short string representation of a SQLglot tree.
+
+    Allows you to easily check that a tree contains certain nodes
+
+    For instance, the string "robin['hi']" becomes:
+    'bracket column literal identifier'
+    """
+    return " ".join(n[0].key for n in tree.walk())
+
+
+def remove_quotes_from_identifiers(tree) -> exp.Expression:
+    tree = tree.copy()
+    for identifier in tree.find_all(exp.Identifier):
+        identifier.args["quoted"] = False
+    return tree
+
+
 def _add_l_or_r_to_identifier(node: exp.Expression):
     if not isinstance(node, exp.Identifier):
         return node

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -10,7 +10,8 @@ from numpy import arange, ceil, floor, log2
 from pandas import concat, cut
 
 from .charts import altair_or_json, load_chart_definition
-from .input_column import InputColumn, remove_quotes_from_identifiers
+from .input_column import InputColumn
+from .sql_transform import remove_quotes_from_identifiers
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -1,35 +1,273 @@
-from splink.input_column import InputColumn
+from dataclasses import dataclass
+from functools import partial
+
+import pytest
+from sqlglot.errors import ParseError, TokenError
+
+from splink.input_column import InputColumn, _get_dialect_quotes
+
+
+@dataclass
+class ColumnTestCase:
+    """A simple helper class to more easily faciliate a range of
+    tests on expected outputs from our array of InputColumn methods.
+
+    - input_column: name of your initial column
+    - name_out: The expected name, with placeholders
+    - alias: the alias in an `AS ...` statement
+    - sql_dialect: The dialect to use.
+    """
+
+    input_column: str
+    name_out: str
+    alias: str
+    sql_dialect: str  # Assuming sql_dialect is passed as an argument
+
+    def __post_init__(self):
+        # Retrieve dialect quotes
+        dialect_quotes, q = _get_dialect_quotes(self.sql_dialect)
+
+        # Format strings with dialect quotes
+        self.name_out = self.name_out.format(q=dialect_quotes)
+        self.name_with_table = q + "{table}" + q + "." + self.name_out
+        self.alias = self.alias.format(q=dialect_quotes, prefix="", suffix="")
+
+        # Format input_column with the formatted name
+        name = self.input_column.format(q=dialect_quotes)
+        self.input_column = InputColumn(name, sql_dialect=self.sql_dialect)
+
+    def expected_name(self, prefix: str, suffix: str):
+        return self.name_out.format(prefix=prefix, suffix=suffix)
+
+    def expected_table_and_alias(self, table: str, prefix: str, suffix: str):
+        table = self.name_with_table.format(table=table, prefix=prefix, suffix="")
+        alias = self.alias.format(prefix=prefix, suffix=suffix)
+        return f"{table} AS {alias}"
 
 
 def test_input_column():
     c = InputColumn("my_col")
     assert c.name == '"my_col"'
+    # Check we only unquote for a given column building instance
     assert c.unquote().name == "my_col"
-
+    # Quotes should now return...
     assert c.name_l == '"my_col_l"'
     assert c.tf_name_l == '"tf_my_col_l"'
-    assert c.unquote().quote().l_tf_name_as_l == '"l"."tf_my_col" as "tf_my_col_l"'
-    assert c.unquote().l_tf_name_as_l == '"l".tf_my_col as tf_my_col_l'
+    assert c.l_tf_name_as_l == '"l"."tf_my_col" AS "tf_my_col_l"'
+    # Removes quotes for table name, column name and the alias
+    assert c.unquote().l_tf_name_as_l == "l.tf_my_col AS tf_my_col_l"
 
     c = InputColumn("SUR name")
     assert c.name == '"SUR name"'
     assert c.name_r == '"SUR name_r"'
-    assert c.r_name_as_r == '"r"."SUR name" as "SUR name_r"'
+    assert c.r_name_as_r == '"r"."SUR name" AS "SUR name_r"'
 
     c = InputColumn("col['lat']")
 
-    name = """
+    identifier = """
     "col"['lat']
     """.strip()
-    assert c.name == name
+    assert c.name == identifier
 
     l_tf_name_as_l = """
-    "l"."tf_col"['lat'] as "tf_col_l"['lat']
+    "l"."tf_col"['lat'] AS "tf_col_l['lat']"
     """.strip()
     assert c.l_tf_name_as_l == l_tf_name_as_l
 
     assert c.unquote().name == "col['lat']"
-    assert c.unquote().quote().name == name
 
     c = InputColumn("first name", sql_dialect="spark")
     assert c.name == "`first name`"
+
+    # Check if adding a bracket index works for illegal names:
+    # - sur name['lat'] is illegal without brackets around "sur name"
+    col = InputColumn("sur name")
+    col.add_bracket_index_to_col("lat")
+    assert col.name == "\"sur name\"['lat']"
+
+    col = InputColumn("sur name")
+    col.add_bracket_index_to_col("0")  # int is cast as expected
+    assert col.name == '"sur name"[0]'
+
+
+@pytest.mark.parametrize("dialect", ["spark", "duckdb"])
+def test_input_column_without_expressions(dialect):
+    ColumnTester = partial(ColumnTestCase, sql_dialect=dialect)
+
+    # dir indicates the direction to be used for replacement
+    test_cases = (
+        ColumnTester(
+            # With raw identifier
+            input_column="test",
+            name_out="{q}{{prefix}}test{{suffix}}{q}",
+            alias="{q}{{prefix}}test{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # With a str bracket index
+            input_column="test['lat']",
+            name_out="{q}{{prefix}}test{{suffix}}{q}['lat']",
+            alias="{q}{{prefix}}test{{suffix}}['lat']{q}",
+        ),
+        ColumnTester(
+            # With spacey name + str bracket index
+            input_column="full name['surname']",
+            name_out="{q}{{prefix}}full name{{suffix}}{q}['surname']",
+            alias="{q}{{prefix}}full name{{suffix}}['surname']{q}",
+        ),
+        ColumnTester(
+            # With an int bracket index
+            input_column="test[0]",
+            name_out="{q}{{prefix}}test{{suffix}}{q}[0]",
+            alias="{q}{{prefix}}test{{suffix}}[0]{q}",
+        ),
+        ColumnTester(
+            # With spacey identifier
+            input_column="sur name",
+            name_out="{q}{{prefix}}sur name{{suffix}}{q}",
+            alias="{q}{{prefix}}sur name{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # Spacey identifier + quotes
+            input_column="{q}sur name{q}",
+            name_out="{q}{{prefix}}sur name{{suffix}}{q}",
+            alias="{q}{{prefix}}sur name{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # Illegal name in sqlglot
+            input_column="first]name",
+            name_out="{q}{{prefix}}first]name{{suffix}}{q}",
+            alias="{q}{{prefix}}first]name{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # SQL key argument
+            input_column="group",
+            name_out="{q}{{prefix}}group{{suffix}}{q}",
+            alias="{q}{{prefix}}group{{suffix}}{q}",
+        ),
+    )
+
+    # The following variation matrix only works because our `InputColumn` method
+    # names match the expected outputs,
+    # For example - Property name:`col.name_l` -> Expected output:`{col}_l`.
+    # If we change our method names, we will need to tweak how this operates.
+    table_prefix_suffix_variations = (
+        # table, prefix, suffix
+        ("l", "", "_l"),
+        ("r", "", "_r"),
+        ("l", "tf_", "_l"),  # tf
+        ("r", "tf_", "_r"),  # tf
+    )
+
+    for column in test_cases:
+        for table, prefix, suffix in table_prefix_suffix_variations:
+            # Input Column
+            input_column = column.input_column
+            # Return values
+            expected_name_l_r = column.expected_name(prefix, suffix)
+            expected_name_with_table_alias = column.expected_table_and_alias(
+                table, prefix, suffix
+            )
+            # Property names
+            column_prefix_suffix_method = f"{prefix}name{suffix}"
+            column_table_prefix_suffix_method = f"{table}_{prefix}name_as{suffix}"
+
+            # Check every combination is as we expect
+            assert (
+                getattr(input_column, column_prefix_suffix_method) == expected_name_l_r
+            )
+            assert (
+                getattr(input_column, column_table_prefix_suffix_method)
+                == expected_name_with_table_alias
+            )
+
+
+def test_input_column_with_expressions():
+    indexed_column = "test['lat']"
+    indexed_input_column = InputColumn(indexed_column, sql_dialect="duckdb")
+    # Add lowercase and regex
+    indexed_input_column.lowercase_column(True).regex_extract("\\d+")
+
+    regex_to_lower = r"""
+    REGEXP_EXTRACT(LOWER("l"."test"['lat']), '\d+', 0) AS "test_l['lat']"
+    """.strip()
+    assert indexed_input_column.l_name_as_l == regex_to_lower
+
+    # Reset and add: str_to_date -> lower
+    indexed_input_column.reset_expressions
+    indexed_input_column.lowercase_column(True).str_to_date(True, "dd mm yy")
+
+    strptime_to_lower = r"""
+    STRPTIME(LOWER("test_l"['lat']), 'dd mm yy')
+    """.strip()
+    assert indexed_input_column.name_l == strptime_to_lower
+
+    indexed_input_column.lowercase_column(True)
+    lower_strptime = r"""
+    LOWER(STRPTIME("test_l"['lat'], 'dd mm yy'))
+    """.strip()
+    assert indexed_input_column.name_l == lower_strptime
+    # Test reordering the str_to_date - we expect str_to_date to now be the outermost fn
+    assert (
+        indexed_input_column.str_to_date(True, "dd mm yy").name_l == strptime_to_lower
+    )
+
+    # Check that excluding expressions causes only the function to be produced
+    assert (
+        indexed_input_column.exclude_expressions().unquote().name_l == "test_l['lat']"
+    )
+
+    indexed_column = "sur name"
+    spacey_input_name = InputColumn(indexed_column, sql_dialect="postgres")
+
+    spacey_input_name.str_to_date(True, "dd-mmm-yyyy")
+
+    postgres_to_date = r"""
+    TO_DATE("sur name_r", 'dd-mmm-yyyy')
+    """.strip()
+    assert spacey_input_name.name_r == postgres_to_date
+    assert (
+        spacey_input_name.lowercase_column(True).name_r == f"LOWER({postgres_to_date})"
+    )
+
+    # Dialect agnostic functions should work as expected
+    assert InputColumn("test").lowercase_column(True).name == 'LOWER("test")'
+
+    # ERRORS: Check we get errors when an no dialect or an invalid dialect is passed
+    with pytest.raises(ValueError) as exc_info:
+        spacey_input_name.regex_extract("\\d+")
+    assert str(exc_info.value) == "Dialect 'postgres' does not support regex_extract"
+
+    with pytest.raises(ValueError) as exc_info:
+        InputColumn("test").regex_extract("\\d+")
+    assert str(exc_info.value).startswith("'regex_extract' requires a valid dialect")
+    with pytest.raises(ValueError) as exc_info:
+        InputColumn("test").str_to_date(True, "dd-mm-yy").name
+    assert str(exc_info.value).startswith("'str_to_date' requires a valid dialect")
+
+
+def test_illegal_names_error():
+    # Check some odd, but legal names all run without issue
+    odd_but_legal_names = (
+        "sur[test",
+        "sur#test",
+        "sur 'name'",
+        "sur[test['lat']",
+        "sur'name",
+        "sur,name",
+        "sur  name",
+        "my test column",
+    )
+    for name in odd_but_legal_names:
+        InputColumn(name).name_l
+
+    # Check some illegal names we want to raise ParserErrors
+    illegal_names = ('sur "name"', '"sur" name', '"sur" name[0]', "sur \"name\"['lat']")
+    for name in illegal_names:
+        with pytest.raises(ParseError):
+            InputColumn(name)
+
+    # TokenError
+    token_errors = ('"sur" name"', 'sur"name')
+    for name in token_errors:
+        with pytest.raises(TokenError):
+            InputColumn(name)


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
See my original comment - https://github.com/moj-analytical-services/splink/pull/1705#discussion_r1391019507.

### Main Changes:

This code functions similarly to the original InputColumn class. Changes to the column - such as adding a suffix - involve cloning the original column, modifying it, and returning the updated version.

The key change is the `ColumnBuilder` class, which stores important column information. The underlying data needed to produce the column can be easily duplicated and edited, before generating a sqlglot tree when requested.

Benefits include:
* Easier and more elegant transformation chaining, e.g., `col.add_suffix("_l").add_table("l")`.
* A more efficient way to duplicate column information. Instead of copying the entire `InputColumn` class, we now just replicate and use the `ColumnBuilder`.
* Clearer distinction between creating and building the input column, simplifying extension.
* Making `ColumnBuilder` a dataclass enhances code clarity, particularly through the use of `replace`.
* Allows specifying expressions in the InputColumn's main API, managed by the column builder.

<hr>

### Other changes of note

#### [`_parse_input_name_to_sqlglot_tree`](https://github.com/moj-analytical-services/splink/blob/ed724befd38f1517280643ce3c794addd9edf680/splink/input_column.py#L204)

I'm not convinced by this section of the code, and a slightly modified version of the [signature approach](https://github.com/moj-analytical-services/splink/blob/master/splink/input_column.py#L132) might be more readable.

In summary, the method tries to parse the input column. If unparseable, it attempts parsing with quotes, and if successful, passes the identifier (and index, if present) to the `ColumnBuilder`. This avoids any accidental bugs where we pass in a column which already contains quotes.

If sqlglot successfully parses the column:
1. Ensure the alias doesn't contain quotes - e.g., `"sur" name`.
2. Check for a bracket/JSON index and parse it.
3. Determine if the user has submitted a quoted column name.
4. If none of the above apply, return a `ColumnBuilder` using the input name.

Note: Unlike the original approach, this accepts quoted columns, necessitating additional checks.

### Toggleable Quotes and Expressions

To keep a consistent interface, features like unquoting, excluding expressions, and returning as a base dialect are now methods that can be toggled off temporarily when called.

This requires their use as part of a column building chain. For instance, to get an unquoted version of `name_l`, build it using `col.unquote().name_l`.

These methods can also be used concurrently to manipulate the output, such as `col.unquote().as_base_dialect.name_l`.

After the build, defaults are reset.

<hr>

### Smaller changes:
- `InputColumn` now accepts `SplinkDialect` as an argument.
- I've migrated the `unsupported_splink_dialects` decorators to -> [splink/comparison_helpers_utils.py](https://github.com/moj-analytical-services/splink/blob/ed724befd38f1517280643ce3c794addd9edf680/splink/comparison_helpers_utils.py#L29).
- `ColumnBuilder` comes with a `repr`, making the `InputColumn` easier to work with for devs.
- Fixes what I am pretty sure are some bugs with the older logic:
    - `Sur name[‘lat’]` was being transpiled into `"Sur name[‘lat’]_l"` and is now being returned as `"Sur name_l[‘lat’]"` - note that the solution to this is a [bit hacky](https://github.com/moj-analytical-services/splink/blob/ed724befd38f1517280643ce3c794addd9edf680/splink/input_column.py#L223).
    - `sur,name['lat']`, `"sur'name"` and other variations of these now work as expected.
    - Indexed columns would [previously report invalid SQL](https://github.com/moj-analytical-services/splink/blob/master/tests/test_input_column.py#L27C45-L27C45). Now, the whole alias is quoted.

See the [new tests](https://github.com/moj-analytical-services/splink/blob/add_expressions_to_input_column/tests/test_input_column.py) for more on how everything works in practice.
