### PR TITLE
No super in comparison levels

### DIFF
--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -4,18 +4,9 @@ from typing import final
 
 from .comparison_level import ComparisonLevel
 from .dialects import SplinkDialect
-from .input_column import InputColumn
 
 
 class ComparisonLevelCreator(ABC):
-    def __init__(self, col_name: str = None):
-        """
-        Class to author ComparisonLevels
-        Args:
-            col_name (str): Input column name
-        """
-        self.col_name = col_name
-
     @abstractmethod
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         pass
@@ -46,10 +37,6 @@ class ComparisonLevelCreator(ABC):
                 level_dict[attr] = value
 
         return level_dict
-
-    @final
-    def input_column(self, sql_dialect: SplinkDialect) -> InputColumn:
-        return InputColumn(self.col_name, sql_dialect=sql_dialect.sqlglot_name)
 
     @final
     def configure(


### PR DESCRIPTION
I've gone through all the existing implemented comparison levels to remove the use of super and make them as consistent as possible

<details><summary>useful testing script</summary>

```python
from splink.datasets import splink_datasets
from splink.comparison_level_creator import ComparisonLevelCreator
from splink.duckdb.linker import DuckDBLinker


import splink.comparison_level_library as cll

# cll.DistanceInKMLevel("coords['lat']", "coords['long']", 2).create_level_dict("duckdb")

import inspect

# Assuming 'cll' is the module containing your classes
classes = [
    item
    for item in inspect.getmembers(cll, inspect.isclass)
    if issubclass(item[1], ComparisonLevelCreator)
]
for name, _class in classes:
    print(name, _class)

df = splink_datasets.fake_1000

comparison_first_name = {
    "output_column_name": "first_name",
    "comparison_description": "First name jaro dmeta",
    "comparison_levels": [
        cll.NullLevel("first_name"),
        cll.ColumnsReversedLevel("first_name", "surname"),
        cll.ExactMatchLevel("first_name"),
        cll.JaroLevel("first_name", 0.9),
        cll.JaccardLevel("first_name", 0.9),
        cll.JaroWinklerLevel("first_name", 0.9),
        cll.LevenshteinLevel("first_name", 2),
        cll.DamerauLevenshteinLevel("first_name", 2),
        cll.DatediffLevel("dob", 2),
        cll.DistanceInKMLevel("coords['lat']", "coords['long']", 2),
        cll.ElseLevel(),
    ],
}



for be in ["duckdb", "athena", "sqlite", "spark", "postgres"]:
    print(f"------{be}------")

    for c in comparison_first_name["comparison_levels"]:
        try:
            print("   ----")
            print("   " + c.create_level_dict(be)["sql_condition"])
            print("   " + c.create_level_dict(be)["label_for_charts"])
        except Exception as e:
            print(f"   Error: {e}")
            print(f"   No {c.__class__.__name__} for {be}")

```

</details>