### PR TITLE
[BUG] Delete cached tables before resetting the cache

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -3636,12 +3636,12 @@ class Linker:
         # As a result, any previously cached tables will not be found
         self._cache_uid = ascii_uid(8)
 
-        # As a result, any previously cached tables will not be found
-        self._intermediate_table_cache.invalidate_cache()
-
         # Drop any existing splink tables from the database
         # Note, this is not actually necessary, it's just good housekeeping
         self.delete_tables_created_by_splink_from_db()
+
+        # As a result, any previously cached tables will not be found
+        self._intermediate_table_cache.invalidate_cache()
 
     def register_table_input_nodes_concat_with_tf(self, input_data, overwrite=False):
         """Register a pre-computed version of the input_nodes_concat_with_tf table that


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC


### Give a brief description for the solution you have provided
I may be mistaken, but `invalidate_cache()` currently only cleans up the cached dictionary and leaves any tables created by Splink behind.

I would have guessed that we in fact want it to work by:
**Deleting the tables saved in the cache** -> **Clean up the caching dictionary**.

This PR simply reorders the cache invalidation steps to resolve this.

Please close this if it is working as intended.

<details>
<summary></b>Test Code</b></summary>

Running this on master causes the query `select * from {test}` to run twice.
This PR deletes this cached table and will result in an error.

```python
from splink.duckdb.duckdb_linker import DuckDBLinker
import pandas as pd

from tests.basic_settings import get_settings_dict

df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")

linker = DuckDBLinker(
    df,
    get_settings_dict(),
)

linker._initialise_df_concat_with_tf()

linker.compute_tf_table("first_name")
linker._intermediate_table_cache

linker.predict()

# Exclude tables that the user doesn't want to delete
cached_tables = linker._intermediate_table_cache
test = list(cached_tables.values())[0].physical_name
display(linker._con.query(f"select * from {test}"))
linker.invalidate_cache()
display(linker._con.query(f"select * from {test}"))
```

</details>
