### PR TITLE
(Splink 4) Fix datediff level now super is removed

### DIFF
--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractproperty
 from typing import TYPE_CHECKING
 
+from .input_column import InputColumn
+
 if TYPE_CHECKING:
     from .comparison_level_creator import ComparisonLevelCreator
 
@@ -142,16 +144,15 @@ class PostgresDialect(SplinkDialect):
         if clc.date_format is None:
             clc.date_format = "yyyy-MM-dd"
 
-        col_name_l = clc.input_column(self).name_l()
-        col_name_r = clc.input_column(self).name_r()
+        col = InputColumn(clc.col_name, sql_dialect=self.sqlglot_name)
 
         if clc.cast_strings_to_date:
             datediff_args = f"""
-                to_date({col_name_l}, '{clc.date_format}'),
-                to_date({col_name_r}, '{clc.date_format}')
+                to_date({col.name_l}, '{clc.date_format}'),
+                to_date({col.name_r}, '{clc.date_format}')
             """
         else:
-            datediff_args = f"{col_name_l}, {col_name_r}"
+            datediff_args = f"{col.name_l}, {col.name_r}"
 
         if clc.date_metric == "day":
             date_f = f"""


### PR DESCRIPTION
There was a bug in the datediff level that resulted from me removing `__super__`

<details>
<summary>
test script
</summary>

```python
from splink.datasets import splink_datasets
from splink.comparison_level_creator import ComparisonLevelCreator
import splink.comparison_level_library as cll

import inspect

classes = [
    item
    for item in inspect.getmembers(cll, inspect.isclass)
    if issubclass(item[1], ComparisonLevelCreator)
]
for name, _class in classes:
    print(name, _class)

df = splink_datasets.fake_1000

comparison_first_name = {
    "output_column_name": "first_name",
    "comparison_description": "First name jaro dmeta",
    "comparison_levels": [
        cll.DatediffLevel("dob", 2),
        cll.DatediffLevel("dob", 2, cast_strings_to_date=True),
    ],
}


for be in ["duckdb", "athena", "spark", "postgres"]:
    print(f"------{be}------")

    for c in comparison_first_name["comparison_levels"]:

        print("   ----")
        print("   " + c.create_level_dict(be)["sql_condition"])
        print("   " + c.create_level_dict(be)["label_for_charts"])


for be in ["sqlite"]:
    print(f"------{be}------")

    for c in comparison_first_name["comparison_levels"]:

        print("   ----")
        print("   " + c.create_level_dict(be)["sql_condition"])
        print("   " + c.create_level_dict(be)["label_for_charts"])

```

</details>