### PR TITLE
Introduce a `ColumnTreeBuilder` to aid in the construction of our column ASTs

### DIFF
--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -14,7 +14,7 @@ from sqlglot.optimizer.simplify import simplify
 
 from .constants import LEVEL_NOT_OBSERVED_TEXT
 from .default_from_jsonschema import default_value_from_schema
-from .input_column import InputColumn, sqlglot_tree_signature
+from .input_column import InputColumn
 from .misc import (
     dedupe_preserving_order,
     interpolate,
@@ -22,6 +22,7 @@ from .misc import (
     match_weight_to_bayes_factor,
 )
 from .parse_sql import get_columns_used_from_sql
+from .sql_transform import sqlglot_tree_signature
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 
 def _is_exact_match(sql_syntax_tree):
     signature = sqlglot_tree_signature(sql_syntax_tree)
-    if signature != "eq column column identifier identifier":
+
+    if signature != sqlglot_tree_signature(sqlglot.parse_one("col_l = col_r")):
         return False
 
     identifiers = []

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -163,11 +163,10 @@ class InputColumn:
             raw_column_name_or_column_reference
         )
 
-        self.sqlglot_dialect = sql_dialect
         self.col_builder: SqlglotColumnTreeBuilder = (
             SqlglotColumnTreeBuilder.from_raw_column_name_or_column_reference(
                 raw_column_name_or_column_reference,
-                sqlglot_dialect=self.sqlglot_dialect,
+                sqlglot_dialect=self.sql_dialect,
             )
         )
 

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -16,7 +16,16 @@ class SqlglotColumnTreeBuilder:
     Builds a sqlglot expression tree representing a column or column reference
     from its arguments.
 
-    Call `sql` with a sqlglot dialect to get the SQL string.
+    Since this is a frozen dataclass, it's easy to modify the column or column
+    reference using the `replace` method.
+
+    For instance, to add a `_l` to column_name, you can do:
+
+        new_column_name = self.col_builder.column_name + "_l"
+        replace(self.col_builder, column_name=new_column_name).sql
+
+
+    The `sql` property returns the sql string corresopnding to the tree
     """
 
     column_name: str
@@ -141,7 +150,6 @@ class InputColumn:
 
     Uses `SqlglotColumnTreeBuilder` to manipulate the sqlglot expression tree
     representing the column or column reference
-
 
     The input can be either the raw identifier, or an identifier with
     SQL-specific identifier quotes.

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -86,9 +86,7 @@ class ColumnTreeBuilder:
 
     @classmethod
     def from_raw_column_name_or_column_reference(
-        cls,
-        name: str,
-        sqlglot_name: str
+        cls, name: str, sqlglot_name: str
     ) -> ColumnTreeBuilder:
         """
         Parses a given input name into a ColumnTreeBuilder.
@@ -204,9 +202,8 @@ class InputColumn:
 
         # Generate a ColumnTreeBuilder from the input column
         tree_builder = ColumnTreeBuilder.from_raw_column_name_or_column_reference(
-                name=raw_column_name_or_column_reference,
-                sqlglot_name=sql_dialect
-            )
+            name=raw_column_name_or_column_reference, sqlglot_name=sql_dialect
+        )
         self.base_column_tree: ColumnTreeBuilder = tree_builder
 
     def register_dialect(self, sql_dialect: str):

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -162,8 +162,17 @@ class ColumnTreeBuilder:
 
 class InputColumn:
     """
-    Represents a SQL column or column reference
-    Handles SQL dialect-specific issues such as identifier quoting.
+    A wrapper class that simplifies interactions with a ColumnTreeBuilder instance.
+
+    This class serves as a simpler interface to the ColumnTreeBuilder, which is responsible
+    for building and returning a SQLglot expression tree representing SQL column references.
+    The InputColumn class provides user-friendly helper methods for commonly required
+    column manipulations and transformations.
+
+    Methods such as '.name_l' run the relevant of building steps on the tree
+    builder and convert the resulting tree into a valid SQL column reference. These methods
+    make it easier to perform operations like quoting, adding prefixes/suffixes, and
+    formatting column references according to specific SQL dialects.
 
     The input can be either the raw identifier, or an identifier with
     SQL-specific identifier quotes.

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -29,7 +29,7 @@ class SqlglotColumnTreeBuilder:
     """
 
     column_name: str
-    table: str = field(default=None, repr=False)
+    table: str = None
     quoted: bool = True
     bracket_index: int = None
     bracket_key: str = None

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -11,25 +11,6 @@ from sqlglot.expressions import Expression
 from .default_from_jsonschema import default_value_from_schema
 
 
-def sqlglot_tree_signature(tree):
-    """
-    A short string representation of a SQLglot tree.
-
-    Allows you to easily check that a tree contains certain nodes
-
-    For instance, the string "robin['hi']" becomes:
-    'bracket column literal identifier'
-    """
-    return " ".join(n[0].key for n in tree.walk())
-
-
-def remove_quotes_from_identifiers(tree) -> Expression:
-    tree = tree.copy()
-    for identifier in tree.find_all(exp.Identifier):
-        identifier.args["quoted"] = False
-    return tree
-
-
 @dataclass
 class ColumnTreeBuilder:
     """A builder class that allows you to copy and modify an input column.

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -79,14 +79,14 @@ class SqlglotColumnTreeBuilder:
             args["column_name"] = sqlglot_tree.find(exp.Identifier).args["this"]
             return args
 
-        def add_quotes_to_column_name(input_str):
+        def add_quotes_to_column_name(input_str, q_start, q_end):
             if input_str.rfind("[") != -1 and input_str.endswith("]"):
                 index = input_str.rfind("[")
                 name = input_str[:index]
                 key_or_index = input_str[index:]
-                return f'"{name}"{key_or_index}'
+                return f"{q_start}{name}{q_end}{key_or_index}"
             else:
-                return f'"{input_str}"'
+                return f"{q_start}{input_str}{q_end}"
 
         valid_signatures = {
             sqlglot_tree_signature(sqlglot.parse_one("col_name")),
@@ -109,7 +109,8 @@ class SqlglotColumnTreeBuilder:
         # properly escaped using identifier quotes so e.g. if there is a space in the
         # input_str, it will be incorrectly parsed.
         # Possible cases are: first name, lat long[1] or lat long['lat']
-        input_str = add_quotes_to_column_name(input_str)
+        q_start, q_end = _get_dialect_quotes(sqlglot_dialect)
+        input_str = add_quotes_to_column_name(input_str, q_start, q_end)
         try:
             tree = sqlglot.parse_one(input_str, dialect=sqlglot_dialect)
         except sqlglot.ParseError:

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -259,11 +259,11 @@ class InputColumn:
         # See: exp.Identifier(this='`test`', quoted=True).sql("spark")
         column_builder = self.base_column_tree.unquote()
         # Add both the prefix and suffix arguments to the column
-        alias_tree = column_builder.add_prefix(prefix).add_suffix(suffix)
-        alias_string = self.column_tree_to_sql(alias_tree)
+        column_alias_tree = column_builder.add_prefix(prefix).add_suffix(suffix)
+        column_alias_string = self.column_tree_to_sql(column_alias_tree)
 
         column_with_table = self.base_column_tree.add_table(table).add_prefix(prefix)
-        tree = column_with_table.add_alias(alias_string)
+        tree = column_with_table.add_alias(column_alias_string)
         return tree.sql(self.sqlglot_name)
 
     @property

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -175,7 +175,7 @@ class InputColumn:
         if not sql_dialect and self._settings_obj:
             sql_dialect = self._settings_obj._sql_dialect
 
-        self.sqlglot_name = sql_dialect
+        self.sql_dialect = sql_dialect
 
     def from_settings_obj_else_default(self, key, schema_key=None):
         # Covers the case where no settings obj is set on the comparison level
@@ -213,7 +213,7 @@ class InputColumn:
     @property
     def as_base_dialect(self) -> InputColumn:
         input_column_copy = deepcopy(self)
-        input_column_copy.sqlglot_name = None
+        input_column_copy.sql_dialect = None
         return input_column_copy
 
     @property
@@ -291,7 +291,7 @@ class InputColumn:
     def _quote_if_sql_keyword(self, name: str) -> str:
         if name not in {"group", "index"}:
             return name
-        start, end = _get_dialect_quotes(self.sqlglot_name)
+        start, end = _get_dialect_quotes(self.sql_dialect)
         return start + name + end
 
     def __repr__(self):

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -13,8 +13,9 @@ from .sql_transform import sqlglot_tree_signature
 @dataclass(frozen=True)
 class SqlglotColumnTreeBuilder:
     """
-    Builds a sqlglot expression tree represeting
-    a column or column reference from its arguments.
+    Builds a sqlglot expression tree representing a column or column reference
+    from its arguments.
+
     Call `sql` with a sqlglot dialect to get the SQL string.
     """
 
@@ -127,6 +128,13 @@ class SqlglotColumnTreeBuilder:
 class InputColumn:
     """
     Represents a column or column reference in the input data to Splink.
+
+    Handles identifier quotes for the user, so the user can e.g. provide column names
+    like "first name" instead of having to use '"first name"'.  The rationale is
+    that:
+    -  many users won't understand the difference between ` ' and " in SQL and are
+    unlikely to provide correct identifier quotes
+    - it's inconvenient and fiddly in Python to provide identifier quotes in a string
 
     Handles the various transformations needed by Splink such as adding `_l` and `_r`,
     table names etc.

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -123,6 +123,9 @@ class InputColumn:
 
         self.register_dialect(sql_dialect)
 
+        self.input_name: str = self._quote_if_sql_keyword(
+            raw_column_name_or_column_reference
+        )
         self.column_tree_builder: ColumnTreeBuilder = (
             self._parse_input_name_to_column_tree_builder(
                 raw_column_name_or_column_reference
@@ -325,6 +328,12 @@ class InputColumn:
     @property
     def l_r_tf_names_as_l_r(self) -> list[str]:
         return [self.l_tf_name_as_l, self.r_tf_name_as_r]
+
+    def _quote_if_sql_keyword(self, name: str) -> str:
+        if name not in {"group", "index"}:
+            return name
+        start, end = _get_dialect_quotes(self.sqlglot_name)
+        return start + name + end
 
     def __repr__(self):
         return (

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass, replace
 
 import sqlglot
 import sqlglot.expressions as exp
-from sqlglot.errors import ParseError
+from sqlglot.errors import ParseError, TokenError
 from sqlglot.expressions import Expression
 
 from .default_from_jsonschema import default_value_from_schema
@@ -22,30 +23,6 @@ def sqlglot_tree_signature(tree):
     return " ".join(n[0].key for n in tree.walk())
 
 
-def add_suffix(tree, suffix) -> Expression:
-    tree = tree.copy()
-    identifier_string = tree.find(exp.Identifier).this
-    identifier_string = f"{identifier_string}{suffix}"
-    tree.find(exp.Identifier).args["this"] = identifier_string
-    return tree
-
-
-def add_prefix(tree, prefix) -> Expression:
-    tree = tree.copy()
-    identifier_string = tree.find(exp.Identifier).this
-    identifier_string = f"{prefix}{identifier_string}"
-    tree.find(exp.Identifier).args["this"] = identifier_string
-    return tree
-
-
-def add_table(tree, tablename) -> Expression:
-    tree = tree.copy()
-    table_identifier = exp.Identifier(this=tablename, quoted=True)
-    identifier = tree.find(exp.Column)
-    identifier.args["table"] = table_identifier
-    return tree
-
-
 def remove_quotes_from_identifiers(tree) -> Expression:
     tree = tree.copy()
     for identifier in tree.find_all(exp.Identifier):
@@ -53,60 +30,140 @@ def remove_quotes_from_identifiers(tree) -> Expression:
     return tree
 
 
+@dataclass
+class ColumnTreeBuilder:
+    """A builder class that allows you to copy and modify an input column.
+
+    Modifications copy the base column and can be chained to produce a fresh
+    version of the column.
+
+    Columns can also be wrapped in SQLglot expressions by appending them to the
+    base class.
+    """
+
+    name: str
+    table: str = None
+    quoted: bool = True
+    column_reference: exp.Identifier = None  # the JSON index in 'surname['lat']'
+
+    def unquote(self):
+        return replace(self, quoted=False)
+
+    def exclude_expressions(self):
+        return replace(self, return_column_with_expressions=False)
+
+    def change_name(self, new_name: str):
+        return replace(self, name=new_name)
+
+    def add_prefix(self, prefix: str):
+        return replace(self, name=prefix + self.name) if prefix else self
+
+    def add_suffix(self, suffix: str):
+        return replace(self, name=self.name + suffix) if suffix else self
+
+    def add_table(self, table: str):
+        return replace(self, table=table) if table else self
+
+    def add_alias(self, alias: str) -> exp.Alias:
+        """Alias expects a SQLglot Identifier class or a str.
+
+        For safety, only pass strings to ensure we capture the entire
+        column reference, not just the identifier.
+
+        For example, col['lat'] is made up of both an identifier and bracket
+        index; the latter of which would be lost if passing identifiers.
+        """
+        # The identifier should be quoted or unquoted before being passed.
+        # This is to ensure we get the correct output.
+        alias = exp.Identifier(this=alias, quoted=self.quoted)
+        return self.build_column_tree().as_(alias)
+
+    def add_column_reference(self, index_name: str | int):
+        """
+        Manually add a column reference to your column - ['idx'], for example.
+
+        This is useful during the parsing process or when you try to combine
+        illegal name and bracket combinations such as 'SUR NAME['lat']',
+        without needing to add quotes to the column identifier.
+        """
+        is_str = type(index_name) == str
+        self.column_reference = exp.Literal(this=index_name, is_string=is_str)
+        return self
+
+    def build_column_tree(self):
+        # Create our column representation
+        column = sqlglot.column(col=self.name, table=self.table, quoted=self.quoted)
+        # Column is made up of the identifier + bracket index (if it exists)
+        if self.column_reference:
+            return exp.Bracket(this=column, expressions=[self.column_reference])
+        else:
+            return column
+
+    @classmethod
+    def from_sqlglot_column(
+        cls, column_tree: exp.Column, column_reference: exp.Identifier = None
+    ):
+        return cls(column_tree.name, column_reference=column_reference)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"name='{self.name}', quoted={self.quoted}, "
+            f"column_reference={self.column_reference.sql()}"
+        )
+
+
 class InputColumn:
     """
     Represents a SQL column or column reference
     Handles SQL dialect-specific issues such as identifier quoting.
 
-    The input should be the raw identifier, without SQL-specific identifier quotes.
-
-    For example, if a column is named 'first name' (with a space), the input should be
-    'first name', not '"first name"'.
+    The input can be either the raw identifier, or an identifier with
+    SQL-specific identifier quotes.
 
     Examples of valid inputs include:
     - 'first_name'
-    - 'first name'
+    - 'first[name'
+    - '"first name"'
     - 'coordinates['lat']'
+    - '"sur NAME"['lat']
     - 'coordinates[1]'
-
     """
 
     def __init__(
-        self, raw_column_name_or_column_reference, settings_obj=None, sql_dialect=None
+        self,
+        raw_column_name_or_column_reference: str,
+        settings_obj=None,
+        sql_dialect: str = None,
     ):
         # If settings_obj is None, then default values will be used
         # from the jsonschama
         self._settings_obj = settings_obj
 
-        if sql_dialect:
-            self._sql_dialect = sql_dialect
-        elif settings_obj:
-            self._sql_dialect = self._settings_obj._sql_dialect
-        else:
-            self._sql_dialect = None
+        self.register_dialect(sql_dialect)
 
-        self.input_name = self._quote_if_sql_keyword(
-            raw_column_name_or_column_reference
+        self.column_tree_builder: ColumnTreeBuilder = (
+            self._parse_input_name_to_column_tree_builder(
+                raw_column_name_or_column_reference
+            )
         )
 
-        self.input_name_as_tree = self.parse_input_name_to_sqlglot_tree()
+    def register_dialect(self, sql_dialect: str):
+        if not sql_dialect and self._settings_obj:
+            sql_dialect = self._settings_obj._sql_dialect
 
-        for identifier in self.input_name_as_tree.find_all(exp.Identifier):
-            identifier.args["quoted"] = True
+        self.sqlglot_name = sql_dialect
 
-    def quote(self) -> "InputColumn":
-        self_copy = deepcopy(self)
-        for identifier in self_copy.input_name_as_tree.find_all(exp.Identifier):
-            identifier.args["quoted"] = True
-        return self_copy
+    def from_settings_obj_else_default(self, key, schema_key=None):
+        # Covers the case where no settings obj is set on the comparison level
+        if self._settings_obj:
+            return getattr(self._settings_obj, key)
+        else:
+            if not schema_key:
+                schema_key = key
+            return default_value_from_schema(schema_key, "root")
 
-    def unquote(self) -> "InputColumn":
-        self_copy = deepcopy(self)
-        for identifier in self_copy.input_name_as_tree.find_all(exp.Identifier):
-            identifier.args["quoted"] = False
-        return self_copy
-
-    def parse_input_name_to_sqlglot_tree(self) -> Expression:
+    def _parse_input_name_to_column_tree_builder(self, name: str) -> ColumnTreeBuilder:
         """
         Parses the input name into a SQLglot expression tree.
 
@@ -118,89 +175,135 @@ class InputColumn:
         Note: We do not support inputs like 'SUR name[1]', in this case the user
         would have to quote e.g. `SUR name`[1]
         """
-
-        q_s, q_e = _get_dialect_quotes(self._sql_dialect)
+        q_s, q_e = _get_dialect_quotes(self.sqlglot_name)
 
         try:
-            tree = sqlglot.parse_one(self.input_name, read=self._sql_dialect)
-        except ParseError:
-            tree = sqlglot.parse_one(
-                f"{q_s}{self.input_name}{q_e}", read=self._sql_dialect
+            tree = sqlglot.parse_one(name, read=self.sqlglot_name)
+        except (ParseError, TokenError):
+            # The parse statement will error in cases such as: sur "name"['lat']
+            sqlglot.parse_one(f"{q_s}{name}{q_e}", read=self.sqlglot_name)
+            # index is None if nothing is set
+            identifier, index = self.manually_split_identifier_and_index(name)
+
+            # Construct the column manually if it can be parsed with quotes.
+            # This is useful for illegal columns such as test[ing, test'ing, test"ing
+            return ColumnTreeBuilder(name=identifier, column_reference=index)
+
+        return self._parse_sql_tree_to_column_tree_builder(name, tree)
+
+    def _parse_sql_tree_to_column_tree_builder(
+        self, name: str, tree: sqlglot.Expression
+    ) -> ColumnTreeBuilder:
+        # Columns which contains spaces will be registered as aliases.
+        # Check that no quotes have been applied to either end of the name:
+        # - "sur" name, sur "name" are both invalid column names
+        if tree.find(exp.Alias):
+            if any([identifier.quoted for identifier in tree.find_all(exp.Identifier)]):
+                raise ParseError(
+                    f"The supplied column name '{name}' contains quotes and cannot be "
+                    "parsed as a valid SQL identifier."
+                )
+
+        if tree.find(exp.Bracket):
+            # Pop the column, leaving the bracket as the remaining section of the tree
+            return ColumnTreeBuilder.from_sqlglot_column(
+                column_tree=tree.find(exp.Column),
+                column_reference=tree.find(exp.Literal),
             )
 
-        tree_signature = sqlglot_tree_signature(tree)
-        valid_signatures = ["column identifier", "bracket column literal identifier"]
+        # If the column has already been quoted, parse it
+        if tree.find(exp.Identifier).args.get("quoted"):
+            return ColumnTreeBuilder.from_sqlglot_column(column_tree=tree)
 
-        if tree_signature in valid_signatures:
-            return tree
-        else:
-            # e.g. SUR name parses to 'alias column identifier identifier'
-            # but we want "SUR name"
-            tree = sqlglot.parse_one(
-                f"{q_s}{self.input_name}{q_e}", read=self._sql_dialect
-            )
-            return tree
+        # If our column does not contain a quoted identifier, we can safely return
+        # the column builder
+        return ColumnTreeBuilder(name)
 
-    def from_settings_obj_else_default(self, key, schema_key=None):
-        # Covers the case where no settings obj is set on the comparison level
-        if self._settings_obj:
-            return getattr(self._settings_obj, key)
+    @staticmethod
+    def manually_split_identifier_and_index(identifier: str) -> [str, str]:
+        # Manually pull out the bracket index for an unparseable column.
+        # This ensures we correctly parse cases such as: sur name['lat']
+        if identifier.endswith("]") and "[" in identifier:
+            split_index = identifier.rfind("[")
+            before_bracket = identifier[:split_index].strip()
+            after_bracket = identifier[split_index:].strip("[]")
+            return before_bracket, after_bracket
         else:
-            if not schema_key:
-                schema_key = key
-            return default_value_from_schema(schema_key, "root")
+            return identifier, None
 
     @property
-    def gamma_prefix(self) -> str:
-        return self.from_settings_obj_else_default(
-            "_gamma_prefix", "comparison_vector_value_column_prefix"
-        )
-
-    @property
-    def bf_prefix(self) -> str:
+    def _bf_prefix(self):
         return self.from_settings_obj_else_default(
             "_bf_prefix", "bayes_factor_column_prefix"
         )
 
     @property
-    def tf_prefix(self) -> str:
+    def _tf_prefix(self):
         return self.from_settings_obj_else_default(
             "_tf_prefix", "term_frequency_adjustment_column_prefix"
         )
 
-    @property
-    def name(self) -> str:
-        return self.input_name_as_tree.sql(dialect=self._sql_dialect)
+    def _copy_with_new_column_builder(self, new_builder) -> InputColumn:
+        input_column_copy = deepcopy(self)
+        input_column_copy.column_tree_builder = new_builder
+        return input_column_copy
 
-    @property
-    def name_l(self) -> str:
-        return add_suffix(self.input_name_as_tree, suffix="_l").sql(
-            dialect=self._sql_dialect
+    def change_input_column_name(self, new_name: str):
+        return self._copy_with_new_column_builder(
+            self.column_tree_builder.change_name(new_name)
         )
 
-    @property
-    def name_r(self) -> str:
-        return add_suffix(self.input_name_as_tree, suffix="_r").sql(
-            dialect=self._sql_dialect
-        )
+    def unquote(self) -> InputColumn:
+        return self._copy_with_new_column_builder(self.column_tree_builder.unquote())
 
     @property
-    def names_l_r(self) -> list[str]:
+    def as_base_dialect(self) -> InputColumn:
+        input_column_copy = deepcopy(self)
+        input_column_copy.sqlglot_name = None
+        return input_column_copy
+
+    def column_tree_to_sql(self, column_tree: ColumnTreeBuilder) -> str:
+        return column_tree.build_column_tree().sql(self.sqlglot_name)
+
+    def _table_name_as(self, table: str, prefix: str = "", suffix: str = "") -> str:
+        # Remove quotes, if applied. This prevents
+        # the accidental addition of quotes to the alias.
+        # See: exp.Identifier(this='`test`', quoted=True).sql("spark")
+        column_builder = self.column_tree_builder.unquote()
+        # Add both the prefix and suffix arguments to the column
+        alias_tree = column_builder.add_prefix(prefix).add_suffix(suffix)
+        alias_string = self.column_tree_to_sql(alias_tree)
+
+        column_with_table = self.column_tree_builder.add_table(table).add_prefix(prefix)
+        tree = column_with_table.add_alias(alias_string)
+        return tree.sql(self.sqlglot_name)
+
+    @property
+    def name(self):
+        tree = self.column_tree_builder
+        return self.column_tree_to_sql(tree)
+
+    @property
+    def name_l(self):
+        tree = self.column_tree_builder.add_suffix("_l")
+        return self.column_tree_to_sql(tree)
+
+    @property
+    def name_r(self):
+        tree = self.column_tree_builder.add_suffix("_r")
+        return self.column_tree_to_sql(tree)
+
+    @property
+    def names_l_r(self):
         return [self.name_l, self.name_r]
 
     @property
     def l_name_as_l(self) -> str:
-        name_with_l_table = add_table(self.input_name_as_tree, "l").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{name_with_l_table} as {self.name_l}"
+        return self._table_name_as(table="l", suffix="_l")
 
     @property
     def r_name_as_r(self) -> str:
-        name_with_r_table = add_table(self.input_name_as_tree, "r").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{name_with_r_table} as {self.name_r}"
+        return self._table_name_as(table="r", suffix="_r")
 
     @property
     def l_r_names_as_l_r(self) -> list[str]:
@@ -208,25 +311,23 @@ class InputColumn:
 
     @property
     def bf_name(self) -> str:
-        return add_prefix(self.input_name_as_tree, prefix=self.bf_prefix).sql(
-            dialect=self._sql_dialect
-        )
+        tree = self.column_tree_builder.add_prefix(self._bf_prefix)
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name(self) -> str:
-        return add_prefix(self.input_name_as_tree, prefix=self.tf_prefix).sql(
-            dialect=self._sql_dialect
-        )
+        tree = self.column_tree_builder.add_prefix(self._tf_prefix)
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name_l(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        return add_suffix(tree, suffix="_l").sql(dialect=self._sql_dialect)
+        tree = self.column_tree_builder.add_prefix(self._tf_prefix).add_suffix("_l")
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name_r(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        return add_suffix(tree, suffix="_r").sql(dialect=self._sql_dialect)
+        tree = self.column_tree_builder.add_prefix(self._tf_prefix).add_suffix("_r")
+        return self.column_tree_to_sql(tree)
 
     @property
     def tf_name_l_r(self) -> list[str]:
@@ -234,29 +335,22 @@ class InputColumn:
 
     @property
     def l_tf_name_as_l(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        tf_name_with_l_table = add_table(tree, tablename="l").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{tf_name_with_l_table} as {self.tf_name_l}"
+        return self._table_name_as(table="l", prefix=self._tf_prefix, suffix="_l")
 
     @property
     def r_tf_name_as_r(self) -> str:
-        tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
-        tf_name_with_r_table = add_table(tree, tablename="r").sql(
-            dialect=self._sql_dialect
-        )
-        return f"{tf_name_with_r_table} as {self.tf_name_r}"
+        return self._table_name_as(table="r", prefix=self._tf_prefix, suffix="_r")
 
     @property
     def l_r_tf_names_as_l_r(self) -> list[str]:
         return [self.l_tf_name_as_l, self.r_tf_name_as_r]
 
-    def _quote_if_sql_keyword(self, name: str) -> str:
-        if name not in {"group", "index"}:
-            return name
-        start, end = _get_dialect_quotes(self._sql_dialect)
-        return start + name + end
+    def __repr__(self):
+        return (
+            "InputColumn(\n     "
+            f"{self.column_tree_builder.__repr__()}),\n     "
+            f"sql_dialect={self.sqlglot_name}\n)"
+        )
 
 
 def _get_dialect_quotes(dialect):

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 
 import sqlglot
 import sqlglot.expressions as exp

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -200,13 +200,13 @@ class InputColumn:
 
     def unquote(self) -> InputColumn:
         self_copy = deepcopy(self)
-        b = replace(self.col_builder, quoted=False)
+        b = replace(self_copy.col_builder, quoted=False)
         self_copy.col_builder = b
         return self_copy
 
     def quote(self) -> InputColumn:
         self_copy = deepcopy(self)
-        b = replace(self.col_builder, quoted=True)
+        b = replace(self_copy.col_builder, quoted=True)
         self_copy.col_builder = b
         return self_copy
 

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -21,8 +21,8 @@ class SqlglotColumnTreeBuilder:
 
     For instance, to add a `_l` to column_name, you can do:
 
-        new_column_name = self.col_builder.column_name + "_l"
-        replace(self.col_builder, column_name=new_column_name).sql
+        new_column_name = col_builder.column_name + "_l"
+        replace(col_builder, column_name=new_column_name).sql
 
 
     The `sql` property returns the sql string corresopnding to the tree
@@ -119,6 +119,7 @@ class SqlglotColumnTreeBuilder:
         # properly escaped using identifier quotes so e.g. if there is a space in the
         # input_str, it will be incorrectly parsed.
         # Possible cases are: first name, lat long[1] or lat long['lat']
+        # The space could also be any arbitrary character e.g. first[name
         q_s, q_e = _get_dialect_quotes(sqlglot_dialect)
         input_str = add_quotes_to_column_name(input_str, q_s, q_e)
         try:

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -273,13 +273,13 @@ class InputColumn:
 
     @property
     def l_tf_name_as_l(self) -> str:
-        alias = self._tf_prefix + self.col_builder.column_name + "_l"
+        alias = self._tf_prefix + self.unquote().name_l
         name = self._tf_prefix + self.col_builder.column_name
         return replace(self.col_builder, table="l", column_name=name, alias=alias).sql
 
     @property
     def r_tf_name_as_r(self) -> str:
-        alias = self._tf_prefix + self.col_builder.column_name + "_r"
+        alias = self._tf_prefix + self.unquote().name_r
         name = self._tf_prefix + self.col_builder.column_name
         return replace(self.col_builder, table="l", column_name=name, alias=alias).sql
 

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -206,7 +206,7 @@ class InputColumn:
 
         # Generate a ColumnTreeBuilder from the input column
         tree_builder = ColumnTreeBuilder.from_raw_column_name_or_column_reference(
-            name=raw_column_name_or_column_reference, sqlglot_name=sql_dialect
+            name=raw_column_name_or_column_reference, sqlglot_name=self.sqlglot_name
         )
         self.base_column_tree: ColumnTreeBuilder = tree_builder
 
@@ -250,9 +250,6 @@ class InputColumn:
         input_column_copy = deepcopy(self)
         input_column_copy.sqlglot_name = None
         return input_column_copy
-
-    def column_tree_to_sql(self, column_tree: ColumnTreeBuilder) -> str:
-        return column_tree.as_sqlglot_expression_tree().sql(self.sqlglot_name)
 
     def _table_name_as(self, table: str, prefix: str = "", suffix: str = "") -> str:
         # Remove quotes, if applied. This prevents

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2007,7 +2007,7 @@ class Linker:
         uid_r = _composite_unique_id_from_edges_sql(uid_cols, None, "r")
 
         self._settings_obj._blocking_rules_to_generate_predictions = [
-            BlockingRule(f"{uid_l} = {uid_r}")
+            BlockingRule(f"{uid_l} = {uid_r}", sqlglot_dialect=self._sql_dialect)
         ]
 
         nodes_with_tf = self._initialise_df_concat_with_tf()

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -13,7 +13,7 @@ from statistics import median
 
 import sqlglot
 
-from splink.input_column import InputColumn, remove_quotes_from_identifiers
+from splink.input_column import InputColumn
 from splink.settings_validation.column_lookups import InvalidColumnsLogger
 from splink.settings_validation.valid_types import (
     InvalidTypesAndValuesLogger,
@@ -1299,7 +1299,7 @@ class Linker:
         tf_tablename = colname_to_tf_tablename(input_col)
         cache = self._intermediate_table_cache
         concat_tf_tables = [
-            remove_quotes_from_identifiers(tf_col.input_name_as_tree).sql()
+            tf_col.unquote().name
             for tf_col in self._settings_obj._term_frequency_columns
         ]
 

--- a/splink/parse_sql.py
+++ b/splink/parse_sql.py
@@ -2,7 +2,7 @@ import sqlglot
 import sqlglot.expressions as exp
 from sqlglot.expressions import Bracket, Column, Lambda
 
-from .input_column import remove_quotes_from_identifiers
+from .sql_transform import remove_quotes_from_identifiers
 
 
 def get_columns_used_from_sql(sql, dialect=None, retain_table_prefix=False):

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -8,8 +8,9 @@ from typing import List
 
 import sqlglot
 
-from ..input_column import InputColumn, remove_quotes_from_identifiers
+from ..input_column import InputColumn
 from ..misc import ensure_is_list
+from ..sql_transform import remove_quotes_from_identifiers
 
 logger = logging.getLogger(__name__)
 

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -101,7 +101,7 @@ class SettingsValidator:
 
         col_list = ensure_is_list(col_list)
         if as_tree:
-            col_list = [c.input_name_as_tree for c in col_list]
+            col_list = [c.column_tree_builder.build_column_tree() for c in col_list]
         return set(remove_quotes_from_identifiers(tree).sql() for tree in col_list)
 
     def remove_prefix_and_suffix_from_column(

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -101,7 +101,9 @@ class SettingsValidator:
 
         col_list = ensure_is_list(col_list)
         if as_tree:
-            col_list = [c.column_tree_builder.build_column_tree() for c in col_list]
+            col_list = [
+                c.base_column_tree.as_sqlglot_expression_tree() for c in col_list
+            ]
         return set(remove_quotes_from_identifiers(tree).sql() for tree in col_list)
 
     def remove_prefix_and_suffix_from_column(

--- a/splink/settings_validation/settings_validator.py
+++ b/splink/settings_validation/settings_validator.py
@@ -101,9 +101,7 @@ class SettingsValidator:
 
         col_list = ensure_is_list(col_list)
         if as_tree:
-            col_list = [
-                c.base_column_tree.as_sqlglot_expression_tree() for c in col_list
-            ]
+            col_list = [c.col_builder.as_sqlglot_tree for c in col_list]
         return set(remove_quotes_from_identifiers(tree).sql() for tree in col_list)
 
     def remove_prefix_and_suffix_from_column(

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -69,16 +69,30 @@ def add_quotes_and_table_prefix(syntax_tree, table_name):
     return tree
 
 
-def sqlglot_tree_signature(tree):
-    """
-    A short string representation of a SQLglot tree.
+def sqlglot_tree_signature(sqlglot_tree):
+    """A short string representation of a SQLglot tree.
 
-    Allows you to easily check that a tree contains certain nodes
+    Allows you to check the type and placement
+    of nodes in the AST are as expected.
 
-    For instance, the string "robin['hi']" becomes:
-    'bracket column literal identifier'
-    """
-    return " ".join(n[0].key for n in tree.walk())
+    e.g. lower(hello) -> Lower(Column(Identifier))"""
+
+    def _signature(sub_tree):
+        if not isinstance(sub_tree, dict) or "class" not in sub_tree:
+            return ""
+
+        child_signatures = [
+            _signature(child)
+            for child in sub_tree.get("args", {}).values()
+            if _signature(child)
+        ]
+
+        if child_signatures:
+            return f"{sub_tree['class']}({', '.join(child_signatures)})"
+        else:
+            return sub_tree["class"]
+
+    return _signature(sqlglot_tree.dump())
 
 
 def remove_quotes_from_identifiers(tree) -> exp.Expression:

--- a/splink/sql_transform.py
+++ b/splink/sql_transform.py
@@ -67,3 +67,22 @@ def add_quotes_and_table_prefix(syntax_tree, table_name):
         col.args["table"] = table_name
 
     return tree
+
+
+def sqlglot_tree_signature(tree):
+    """
+    A short string representation of a SQLglot tree.
+
+    Allows you to easily check that a tree contains certain nodes
+
+    For instance, the string "robin['hi']" becomes:
+    'bracket column literal identifier'
+    """
+    return " ".join(n[0].key for n in tree.walk())
+
+
+def remove_quotes_from_identifiers(tree) -> exp.Expression:
+    tree = tree.copy()
+    for identifier in tree.find_all(exp.Identifier):
+        identifier.args["quoted"] = False
+    return tree

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -21,11 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def colname_to_tf_tablename(input_column: InputColumn):
-    input_col_no_quotes = remove_quotes_from_identifiers(
-        input_column.input_name_as_tree
-    )
-
-    input_column = input_col_no_quotes.sql().replace(" ", "_")
+    input_column = input_column.unquote().name.replace(" ", "_")
     return f"__splink__df_tf_{input_column}"
 
 

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -11,7 +11,6 @@ from pandas import concat, cut
 
 from .charts import altair_or_json, load_chart_definition
 from .input_column import InputColumn
-from .sql_transform import remove_quotes_from_identifiers
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:

--- a/splink/term_frequencies.py
+++ b/splink/term_frequencies.py
@@ -10,7 +10,8 @@ from numpy import arange, ceil, floor, log2
 from pandas import concat, cut
 
 from .charts import altair_or_json, load_chart_definition
-from .input_column import InputColumn, remove_quotes_from_identifiers
+from .input_column import InputColumn
+from .sql_transform import remove_quotes_from_identifiers
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -68,7 +68,7 @@ def test_splink_converges_to_known_params():
     # CREATE TABLE __splink__df_comparison_vectors_abc123
     # and modify the following line to include the value of the hash (abc123 above)
 
-    cvv_hashed_tablename = "__splink__df_comparison_vectors_ee08ffa85"
+    cvv_hashed_tablename = "__splink__df_comparison_vectors_f9bd31158"
     linker.register_table(df, cvv_hashed_tablename)
 
     em_training_session = EMTrainingSession(

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -1,35 +1,199 @@
-from splink.input_column import InputColumn
+from dataclasses import dataclass
+from functools import partial
+
+import pytest
+from sqlglot.errors import ParseError, TokenError
+
+from splink.input_column import InputColumn, _get_dialect_quotes
+
+
+@dataclass
+class ColumnTestCase:
+    """A simple helper class to more easily faciliate a range of
+    tests on expected outputs from our array of InputColumn methods.
+
+    - input_column: name of your initial column
+    - name_out: The expected name, with placeholders
+    - alias: the alias in an `AS ...` statement
+    - sql_dialect: The dialect to use.
+    """
+
+    input_column: str
+    name_out: str
+    alias: str
+    sql_dialect: str  # Assuming sql_dialect is passed as an argument
+
+    def __post_init__(self):
+        # Retrieve dialect quotes
+        dialect_quotes, q = _get_dialect_quotes(self.sql_dialect)
+
+        # Format strings with dialect quotes
+        self.name_out = self.name_out.format(q=dialect_quotes)
+        self.name_with_table = q + "{table}" + q + "." + self.name_out
+        self.alias = self.alias.format(q=dialect_quotes, prefix="", suffix="")
+
+        # Format input_column with the formatted name
+        name = self.input_column.format(q=dialect_quotes)
+        self.input_column = InputColumn(name, sql_dialect=self.sql_dialect)
+
+    def expected_name(self, prefix: str, suffix: str):
+        return self.name_out.format(prefix=prefix, suffix=suffix)
+
+    def expected_table_and_alias(self, table: str, prefix: str, suffix: str):
+        table = self.name_with_table.format(table=table, prefix=prefix, suffix="")
+        alias = self.alias.format(prefix=prefix, suffix=suffix)
+        return f"{table} AS {alias}"
 
 
 def test_input_column():
     c = InputColumn("my_col")
     assert c.name == '"my_col"'
+    # Check we only unquote for a given column building instance
     assert c.unquote().name == "my_col"
-
+    # Quotes should now return...
     assert c.name_l == '"my_col_l"'
     assert c.tf_name_l == '"tf_my_col_l"'
-    assert c.unquote().quote().l_tf_name_as_l == '"l"."tf_my_col" as "tf_my_col_l"'
-    assert c.unquote().l_tf_name_as_l == '"l".tf_my_col as tf_my_col_l'
+    assert c.l_tf_name_as_l == '"l"."tf_my_col" AS "tf_my_col_l"'
+    # Removes quotes for table name, column name and the alias
+    assert c.unquote().l_tf_name_as_l == "l.tf_my_col AS tf_my_col_l"
 
     c = InputColumn("SUR name")
     assert c.name == '"SUR name"'
     assert c.name_r == '"SUR name_r"'
-    assert c.r_name_as_r == '"r"."SUR name" as "SUR name_r"'
+    assert c.r_name_as_r == '"r"."SUR name" AS "SUR name_r"'
 
     c = InputColumn("col['lat']")
 
-    name = """
+    identifier = """
     "col"['lat']
     """.strip()
-    assert c.name == name
+    assert c.name == identifier
 
     l_tf_name_as_l = """
-    "l"."tf_col"['lat'] as "tf_col_l"['lat']
+    "l"."tf_col"['lat'] AS "tf_col_l['lat']"
     """.strip()
     assert c.l_tf_name_as_l == l_tf_name_as_l
 
     assert c.unquote().name == "col['lat']"
-    assert c.unquote().quote().name == name
 
     c = InputColumn("first name", sql_dialect="spark")
     assert c.name == "`first name`"
+
+
+@pytest.mark.parametrize("dialect", ["spark", "duckdb"])
+def test_input_column_without_expressions(dialect):
+    ColumnTester = partial(ColumnTestCase, sql_dialect=dialect)
+
+    # dir indicates the direction to be used for replacement
+    test_cases = (
+        ColumnTester(
+            # With raw identifier
+            input_column="test",
+            name_out="{q}{{prefix}}test{{suffix}}{q}",
+            alias="{q}{{prefix}}test{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # With a str bracket index
+            input_column="test['lat']",
+            name_out="{q}{{prefix}}test{{suffix}}{q}['lat']",
+            alias="{q}{{prefix}}test{{suffix}}['lat']{q}",
+        ),
+        ColumnTester(
+            # With spacey name + str bracket index
+            input_column="full name['surname']",
+            name_out="{q}{{prefix}}full name{{suffix}}{q}['surname']",
+            alias="{q}{{prefix}}full name{{suffix}}['surname']{q}",
+        ),
+        ColumnTester(
+            # With an int bracket index
+            input_column="test[0]",
+            name_out="{q}{{prefix}}test{{suffix}}{q}[0]",
+            alias="{q}{{prefix}}test{{suffix}}[0]{q}",
+        ),
+        ColumnTester(
+            # With spacey identifier
+            input_column="sur name",
+            name_out="{q}{{prefix}}sur name{{suffix}}{q}",
+            alias="{q}{{prefix}}sur name{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # Spacey identifier + quotes
+            input_column="{q}sur name{q}",
+            name_out="{q}{{prefix}}sur name{{suffix}}{q}",
+            alias="{q}{{prefix}}sur name{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # Illegal name in sqlglot
+            input_column="first]name",
+            name_out="{q}{{prefix}}first]name{{suffix}}{q}",
+            alias="{q}{{prefix}}first]name{{suffix}}{q}",
+        ),
+        ColumnTester(
+            # SQL key argument
+            input_column="group",
+            name_out="{q}{{prefix}}group{{suffix}}{q}",
+            alias="{q}{{prefix}}group{{suffix}}{q}",
+        ),
+    )
+
+    # The following variation matrix only works because our `InputColumn` method
+    # names match the expected outputs,
+    # For example - Property name:`col.name_l` -> Expected output:`{col}_l`.
+    # If we change our method names, we will need to tweak how this operates.
+    table_prefix_suffix_variations = (
+        # table, prefix, suffix
+        ("l", "", "_l"),
+        ("r", "", "_r"),
+        ("l", "tf_", "_l"),  # tf
+        ("r", "tf_", "_r"),  # tf
+    )
+
+    for column in test_cases:
+        for table, prefix, suffix in table_prefix_suffix_variations:
+            # Input Column
+            input_column = column.input_column
+            # Return values
+            expected_name_l_r = column.expected_name(prefix, suffix)
+            expected_name_with_table_alias = column.expected_table_and_alias(
+                table, prefix, suffix
+            )
+            # Property names
+            column_prefix_suffix_method = f"{prefix}name{suffix}"
+            column_table_prefix_suffix_method = f"{table}_{prefix}name_as{suffix}"
+
+            # Check every combination is as we expect
+            assert (
+                getattr(input_column, column_prefix_suffix_method) == expected_name_l_r
+            )
+            assert (
+                getattr(input_column, column_table_prefix_suffix_method)
+                == expected_name_with_table_alias
+            )
+
+
+def test_illegal_names_error():
+    # Check some odd, but legal names all run without issue
+    odd_but_legal_names = (
+        "sur[test",
+        "sur#test",
+        "sur 'name'",
+        "sur[test['lat']",
+        "sur'name",
+        "sur,name",
+        "sur  name",
+        "my test column",
+    )
+    for name in odd_but_legal_names:
+        InputColumn(name).name_l
+
+    # Check some illegal names we want to raise ParserErrors
+    illegal_names = ('sur "name"', '"sur" name', '"sur" name[0]', "sur \"name\"['lat']")
+    for name in illegal_names:
+        with pytest.raises(ParseError):
+            InputColumn(name)
+
+    # TokenError
+    token_errors = ('"sur" name"', 'sur"name')
+    for name in token_errors:
+        with pytest.raises(TokenError):
+            InputColumn(name)

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -189,7 +189,7 @@ def test_illegal_names_error():
     # Check some illegal names we want to raise ParserErrors
     illegal_names = ('sur "name"', '"sur" name', '"sur" name[0]', "sur \"name\"['lat']")
     for name in illegal_names:
-        with pytest.raises(ParseError):
+        with pytest.raises((ValueError, ParseError)):
             InputColumn(name)
 
     # TokenError

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from functools import partial
 
 import pytest
-from sqlglot.errors import ParseError, TokenError
 
 from splink.input_column import InputColumn, _get_dialect_quotes
 

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -189,11 +189,11 @@ def test_illegal_names_error():
     # Check some illegal names we want to raise ParserErrors
     illegal_names = ('sur "name"', '"sur" name', '"sur" name[0]', "sur \"name\"['lat']")
     for name in illegal_names:
-        with pytest.raises((ValueError, ParseError)):
+        with pytest.raises((ValueError)):
             InputColumn(name)
 
     # TokenError
     token_errors = ('"sur" name"', 'sur"name')
     for name in token_errors:
-        with pytest.raises(TokenError):
+        with pytest.raises(ValueError):
             InputColumn(name)

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -51,60 +51,60 @@ def test_move_l_r_table_prefix_to_column_suffix():
 
 def test_cast_concat_as_varchar():
     output = """
-        select cast(l.source_dataset as varchar) || '-__-' ||
-        cast(l.unique_id as varchar) as concat_id
+        select cast(l.source_dataset AS varchar) || '-__-' ||
+        cast(l.unique_id AS varchar) AS concat_id
     """
     output = sqlglot.parse_one(output).sql()
 
-    sql = "select l.source_dataset || '-__-' || l.unique_id as concat_id"
+    sql = "select l.source_dataset || '-__-' || l.unique_id AS concat_id"
     transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output
 
     sql = """
-        select cast(l.source_dataset as varchar) || '-__-' ||
-        l.unique_id as concat_id
+        select cast(l.source_dataset AS varchar) || '-__-' ||
+        l.unique_id AS concat_id
     """
     transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output
 
     sql = """
-        select cast(l.source_dataset as varchar) || '-__-' ||
-        cast(l.unique_id as varchar) as concat_id
+        select cast(l.source_dataset AS varchar) || '-__-' ||
+        cast(l.unique_id AS varchar) AS concat_id
     """
     transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output
 
-    sql = "select source_dataset || '-__-' || unique_id as concat_id"
+    sql = "select source_dataset || '-__-' || unique_id AS concat_id"
     transformed_sql = sql = sqlglot_transform_sql(sql, cast_concat_as_varchar)
     assert transformed_sql == output.replace("l.", "")
 
 
 def test_set_numeric_as_double():
-    sql = "select cast('a' as float8), cast(0.12345 as float8)"
+    sql = "select cast('a' AS float8), cast(0.12345 AS float8)"
     transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
     assert transformed_sql == "SELECT aD, 0.12345D"
 
-    sql = "select cast('a' as string), cast(0.12345 as float8)"
+    sql = "select cast('a' AS string), cast(0.12345 AS float8)"
     transformed_sql = sqlglot.transpile(sql, write="customspark")[0]
     assert transformed_sql == "SELECT CAST('a' AS STRING), 0.12345D"
 
 
 def test_add_pref_and_suffix():
     dull = InputColumn("dull")
-    dull_l_r = ['"l"."dull" as "dull_l"', '"r"."dull" as "dull_r"']
+    dull_l_r = ['"l"."dull" AS "dull_l"', '"r"."dull" AS "dull_r"']
     assert dull.l_r_names_as_l_r == dull_l_r
 
     assert dull.bf_name == '"bf_dull"'
     assert dull.tf_name_l == '"tf_dull_l"'
-    tf_dull_l_r = ['"l"."tf_dull" as "tf_dull_l"', '"r"."tf_dull" as "tf_dull_r"']
+    tf_dull_l_r = ['"l"."tf_dull" AS "tf_dull_l"', '"r"."tf_dull" AS "tf_dull_r"']
     assert dull.l_r_tf_names_as_l_r == tf_dull_l_r
 
     ll = InputColumn("lat['long']")
     assert ll.name_l == "\"lat_l\"['long']"
 
     ll_tf_l_r = [
-        '"l"."tf_lat"[\'long\'] as "tf_lat_l"[\'long\']',
-        '"r"."tf_lat"[\'long\'] as "tf_lat_r"[\'long\']',
+        '"l"."tf_lat"[\'long\'] AS "tf_lat_l[\'long\']"',
+        '"r"."tf_lat"[\'long\'] AS "tf_lat_r[\'long\']"',
     ]
 
     assert ll.l_r_tf_names_as_l_r == ll_tf_l_r
@@ -112,12 +112,12 @@ def test_add_pref_and_suffix():
     group = InputColumn("cluster")
     assert group.name_l == '"cluster_l"'
     assert group.bf_name == '"bf_cluster"'
-    group_l_r_names = ['"l"."cluster" as "cluster_l"', '"r"."cluster" as "cluster_r"']
+    group_l_r_names = ['"l"."cluster" AS "cluster_l"', '"r"."cluster" AS "cluster_r"']
     assert group.l_r_names_as_l_r == group_l_r_names
 
     group_tf_l_r = [
-        '"l"."tf_cluster" as "tf_cluster_l"',
-        '"r"."tf_cluster" as "tf_cluster_r"',
+        '"l"."tf_cluster" AS "tf_cluster_l"',
+        '"r"."tf_cluster" AS "tf_cluster_r"',
     ]
     assert group.l_r_tf_names_as_l_r == group_tf_l_r
 


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
A slimmed down version of the InputColumn expression extension - https://github.com/moj-analytical-services/splink/pull/1750.

The plan is to:
1. Implement these changes in Splink3.
2. Discuss how we wish to deal with expression chaining in Splink4, before beginning implementation.

<hr>

### Brief Description of the Provided Solution
Refer to the notes in my original PR for a comprehensive breakdown of the changes implemented in this update.

In summary, this PR:

- **Introduces the `ColumnTreeBuilder` (CTB) Class**:
    - This class essentially acts as a blueprint for constructing a SQLglot column.
    - The blueprint facilitates the construction of the Abstract Syntax Tree (AST) by invoking `build_column_tree()`.
    - The primary goal of this class is to simplify and make more intuitive the manipulation and construction of our columns.

- **Comparison of Old and New Syntax**:

  **Old Syntax:** 
  ```py
  tree = add_prefix(self.input_name_as_tree, prefix=self.tf_prefix)
  return add_suffix(tree, suffix="_l").sql(...)
  ```

  **New Syntax:** 
  ```py
  col.add_prefix(self.tf_prefix).add_suffix("_l").sql(...)
  ```

- **Changes to Parsing Base Columns**:
    - While the logic remains similar to the original signature methodology, the new approach includes a formal scanning for "brackets" (column references) and quoted identifiers.
    - This process precedes the delegation of the blueprint for object reconstruction to the CTB.

- **Modification in Handling Quotes**:
    - Quotes are now handled with temporary toggling instead of the previous method of permanent on and off toggling.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


