### PR TITLE
Comparison configure

### DIFF
--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -110,8 +110,14 @@ class ComparisonCreator(ABC):
     @m_probabilities.setter
     def m_probabilities(self, m_probabilities: list[float]):
         if m_probabilities:
-            if len(m_probabilities) != self.num_non_null_levels:
-                raise ValueError("nope")
+            num_probs_supplied = len(m_probabilities)
+            num_non_null_levels = self.num_non_null_levels
+            if num_probs_supplied != self.num_non_null_levels:
+                raise ValueError(
+                    f"Comparison has {num_non_null_levels} non-null levels, "
+                    f"but received {num_probs_supplied} values for m_probabilities. "
+                    "These numbers must be the same."
+                )
             self._m_probabilities = m_probabilities
 
     @final
@@ -123,8 +129,14 @@ class ComparisonCreator(ABC):
     @u_probabilities.setter
     def u_probabilities(self, u_probabilities: list[float]):
         if u_probabilities:
-            if len(u_probabilities) != self.num_non_null_levels:
-                raise ValueError("nope")
+            num_probs_supplied = len(u_probabilities)
+            num_non_null_levels = self.num_non_null_levels
+            if num_probs_supplied != self.num_non_null_levels:
+                raise ValueError(
+                    f"Comparison has {num_non_null_levels} non-null levels, "
+                    f"but received {num_probs_supplied} values for u_probabilities. "
+                    "These numbers must be the same."
+                )
             self._u_probabilities = u_probabilities
 
     def __repr__(self) -> str:

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -18,9 +18,6 @@ class ComparisonCreator(ABC):
         """
         self.col_name = col_name
 
-        self._levels_m_probabilities = None
-        self._levels_u_probabilities = None
-
     # TODO: property?
     @abstractmethod
     def create_comparison_levels(self) -> List[ComparisonLevelCreator]:

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -19,9 +19,7 @@ class ComparisonCreator(ABC):
         self.col_name = col_name
 
     @abstractmethod
-    def create_comparison_levels(
-        self, sql_dialect: SplinkDialect
-    ) -> List[ComparisonLevelCreator]:
+    def create_comparison_levels(self) -> List[ComparisonLevelCreator]:
         pass
 
     @abstractmethod
@@ -40,13 +38,12 @@ class ComparisonCreator(ABC):
 
     @final
     def create_comparison_dict(self, sql_dialect_str: str) -> dict:
-        sql_dialect = SplinkDialect.from_string(sql_dialect_str)
         level_dict = {
             "comparison_description": self.create_description(),
             "output_column_name": self.create_output_column_name(),
             "comparison_levels": [
                 cl.get_comparison_level(sql_dialect_str)
-                for cl in self.create_comparison_levels(sql_dialect)
+                for cl in self.create_comparison_levels()
             ],
         }
 

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -87,6 +87,16 @@ class ComparisonLevelCreator(ABC):
 
         return self
 
+    @final
+    @property
+    def is_null_level(self) -> bool:
+        return getattr(self, "_is_null_level", False)
+
+    @final
+    @is_null_level.setter
+    def is_null_level(self, is_null_level: bool):
+        self._is_null_level = is_null_level
+
     def __repr__(self) -> str:
         return (
             f"Comparison level generator for {self.create_label_for_charts()}. "

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -3,7 +3,6 @@ from typing import Iterable, List, Union
 from . import comparison_level_library as cll
 from .comparison_creator import ComparisonCreator
 from .comparison_level_creator import ComparisonLevelCreator
-from .dialects import SplinkDialect
 from .misc import ensure_is_iterable
 
 
@@ -17,9 +16,7 @@ class ExactMatch(ComparisonCreator):
         col_name (str): The name of the column to compare
     """
 
-    def create_comparison_levels(
-        self, sql_dialect: SplinkDialect
-    ) -> List[ComparisonLevelCreator]:
+    def create_comparison_levels(self) -> List[ComparisonLevelCreator]:
         return [
             cll.NullLevel(self.col_name),
             cll.ExactMatchLevel(self.col_name),
@@ -64,9 +61,7 @@ class LevenshteinAtThresholds(ComparisonCreator):
         self.thresholds = [*thresholds_as_iterable]
         super().__init__(col_name)
 
-    def create_comparison_levels(
-        self, sql_dialect: SplinkDialect
-    ) -> List[ComparisonLevelCreator]:
+    def create_comparison_levels(self) -> List[ComparisonLevelCreator]:
         return [
             cll.NullLevel(self.col_name),
             cll.ExactMatchLevel(self.col_name),

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -1,3 +1,5 @@
+import pytest
+
 import splink.comparison_level_library as cll
 import splink.comparison_library as cl
 
@@ -57,8 +59,10 @@ def test_cll_creators_instantiate_levels(dialect):
 
 comparison_first_name = cl.LevenshteinAtThresholds("first_name", [2, 3])
 comparison_surname = cl.LevenshteinAtThresholds("surname", [3])
-comparison_city = cl.ExactMatch("city")
-comparison_email = cl.LevenshteinAtThresholds("email", 3)
+comparison_city = cl.ExactMatch("city").configure(u_probabilities=[0.6, 0.4])
+comparison_email = cl.LevenshteinAtThresholds("email", 3).configure(
+    m_probabilities=[0.8, 0.1, 0.1]
+)
 
 cl_settings = {
     "link_type": "dedupe_only",
@@ -78,3 +82,17 @@ def test_cl_creators_run_predict(dialect, test_helpers):
 
     linker = helper.Linker(df, cl_settings, **helper.extra_linker_args())
     linker.predict()
+
+
+def test_cl_configure():
+    cl.LevenshteinAtThresholds("col", [1, 2, 3]).configure(
+        m_probabilities=[0.4, 0.1, 0.1, 0.3, 0.1]
+    )
+
+    with pytest.raises(ValueError):
+        # too many probabilities
+        cl.ExactMatch("col").configure(m_probabilities=[0.5, 0.3, 0.2])
+
+    with pytest.raises(ValueError):
+        # too few probabilities
+        cl.LevenshteinAtThresholds("col").configure(u_probabilities=[0.5, 0.5])

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -85,6 +85,7 @@ def test_cl_creators_run_predict(dialect, test_helpers):
 
 
 def test_cl_configure():
+    # this is fine:
     cl.LevenshteinAtThresholds("col", [1, 2, 3]).configure(
         m_probabilities=[0.4, 0.1, 0.1, 0.3, 0.1]
     )
@@ -95,4 +96,4 @@ def test_cl_configure():
 
     with pytest.raises(ValueError):
         # too few probabilities
-        cl.LevenshteinAtThresholds("col").configure(u_probabilities=[0.5, 0.5])
+        cl.LevenshteinAtThresholds("col", [1, 2]).configure(u_probabilities=[0.5, 0.5])


### PR DESCRIPTION
This adds a `.configure()` method to `ComparisonCreator`, which can be used to pass `m` and `u` probabilities to the underlying levels.

I have also stuck `ComparisonCreator.is_null_level` behind a property/setter, so that we can give it a 'default' value (when unset) without having to add a base-class constructor back in. I have also repeated this pattern on `ComparisonCreator` for `m_probabilities` and `u_probabilities`, which while less necessary here I think separates out the logic a bit more.

A couple of other things:
* some helper methods
* `ComparisonCreator` doesn't need to know about dialects (we can add back if needed, but thinking about it, I think that should be able to entirely be deferred to the levels themselves)