### PR TITLE
Custom comparison level and comparison

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -27,6 +27,14 @@ def unsupported_splink_dialects(unsupported_dialects: List[str]):
     return decorator
 
 
+def _translate_sql_string(
+    sqlglot_base_dialect_sql: str, to_sqlglot_dialect: str
+) -> str:
+    tree = parse_one(sqlglot_base_dialect_sql)
+
+    return tree.sql(dialect=to_sqlglot_dialect)
+
+
 def validate_distance_threshold(
     lower_bound: Union[int, float],
     upper_bound: Union[int, float],
@@ -325,9 +333,7 @@ class DatediffLevel(ComparisonLevelCreator):
             f"<= {self.date_threshold}"
         )
 
-        tree = parse_one(sqlglot_base_dialect_sql)
-
-        return tree.sql(dialect=sqlglot_dialect_name)
+        return _translate_sql_string(sqlglot_base_dialect_sql, sqlglot_dialect_name)
 
     def create_label_for_charts(self) -> str:
         return (
@@ -418,9 +424,7 @@ class ArrayIntersectLevel(ComparisonLevelCreator):
             ARRAY_SIZE(ARRAY_INTERSECT({col.name_l}, {col.name_r}))
                 >= {self.min_intersection}
                 """
-        tree = parse_one(sqlglot_base_dialect_sql)
-
-        return tree.sql(dialect=sqlglot_dialect_name)
+        return _translate_sql_string(sqlglot_base_dialect_sql, sqlglot_dialect_name)
 
     def create_label_for_charts(self) -> str:
         return f"Array intersection size >= {self.min_intersection}"

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -103,20 +103,23 @@ class CustomLevel(ComparisonLevelCreator):
         sql_condition = self.sql_condition
         if self.base_dialect_str is not None:
             base_dialect = SplinkDialect.from_string(self.base_dialect_str)
-            base_dialect_sqlglot_name = base_dialect.sqlglot_name
-        else:
-            base_dialect_sqlglot_name = None
+            # if we are told it is one dialect, but try to create comparison level
+            # of another, try to translate with sqlglot
+            if sql_dialect != base_dialect:
+                base_dialect_sqlglot_name = base_dialect.sqlglot_name
 
-        # as default, translate condition into our dialect
-        try:
-            sql_condition = _translate_sql_string(
-                sql_condition, sql_dialect.sqlglot_name, base_dialect_sqlglot_name
-            )
-        # if we hit a sqlglot error, assume users knows what they are doing,
-        # e.g. it is something custom / unknown to sqlglot
-        # error will just appear when they try to use it
-        except TokenError:
-            pass
+                # as default, translate condition into our dialect
+                try:
+                    sql_condition = _translate_sql_string(
+                        sql_condition,
+                        sql_dialect.sqlglot_name,
+                        base_dialect_sqlglot_name,
+                    )
+                # if we hit a sqlglot error, assume users knows what they are doing,
+                # e.g. it is something custom / unknown to sqlglot
+                # error will just appear when they try to use it
+                except TokenError:
+                    pass
         return sql_condition
 
     def create_label_for_charts(self) -> str:

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -81,6 +81,20 @@ class CustomLevel(ComparisonLevelCreator):
         label_for_charts: str = None,
         base_dialect_str: str = None,
     ):
+        """Represents a comparison level with a custom sql expression
+
+        Must be in a form suitable for use in a SQL CASE WHEN expression
+        e.g. "substr(name_l, 1, 1) = substr(name_r, 1, 1)"
+
+        Args:
+            sql_condition (str): SQL condition to assess similarity
+            label_for_charts (str, optional): A label for this level to be used in
+                charts. Default None, so that `sql_condition` is used
+            base_dialect_str (str, optional): If specified, the SQL dialect that
+                this expression will parsed as when attempting to translate to
+                other backends
+
+        """
         self.sql_condition = sql_condition
         self.label_for_charts = label_for_charts
         self.base_dialect_str = base_dialect_str

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -64,6 +64,22 @@ class ElseLevel(ComparisonLevelCreator):
         return "All other comparisons"
 
 
+class CustomLevel(ComparisonLevelCreator):
+    def __init__(self, sql_condition: str, label_for_charts: str = None):
+        self.sql_condition = sql_condition
+        self.label_for_charts = label_for_charts
+
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        return self.sql_condition
+
+    def create_label_for_charts(self) -> str:
+        return (
+            self.label_for_charts
+            if self.label_for_charts is not None
+            else self.sql_condition
+        )
+
+
 class ExactMatchLevel(ComparisonLevelCreator):
     def __init__(self, col_name: str, term_frequency_adjustments: bool = False):
         """Represents a comparison level where there is an exact match

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -12,15 +12,27 @@ class CustomComparison(ComparisonCreator):
     def __init__(
         self,
         output_column_name: str,
-        comparison_levels: list[ComparisonLevelCreator],
+        comparison_levels: list[Union[ComparisonLevelCreator, dict]],
         description: str = None,
     ):
+        """
+        Represents a comparison of the data with custom supplied levels.
+
+        Args:
+            output_col_name (str): The column name to use to refer to this comparison
+            comparison_levels (list): A list of some combination of
+                `ComparisonLevelCreator` objects, or dicts. These represent the
+                similarity levels assessed by the comparison, in order of decreasing
+                specificity
+            description (str, optional): An optional description of the comparison
+        """
+
         self._output_column_name = output_column_name
         self._comparison_levels = comparison_levels
         self._description = description
 
     @staticmethod
-    def _convert_to_creator(cl: Union[dict, ComparisonLevelCreator]):
+    def _convert_to_creator(cl: Union[ComparisonLevelCreator, dict]):
         if isinstance(cl, ComparisonLevelCreator):
             return cl
         if isinstance(cl, dict):

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -4,7 +4,6 @@ from . import comparison_level_library as cll
 from .comparison_creator import ComparisonCreator
 from .comparison_level_creator import ComparisonLevelCreator
 from .comparison_level_library import CustomLevel
-from .dialects import SplinkDialect
 from .misc import ensure_is_iterable
 
 
@@ -43,9 +42,7 @@ class CustomComparison(ComparisonCreator):
             f"but found type {type(cl)} for entry {cl}"
         )
 
-    def create_comparison_levels(
-        self, sql_dialect: SplinkDialect
-    ) -> List[ComparisonLevelCreator]:
+    def create_comparison_levels(self) -> List[ComparisonLevelCreator]:
         comparison_level_creators = [
             self._convert_to_creator(cl) for cl in self._comparison_levels
         ]

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractproperty
 from typing import TYPE_CHECKING
-from .input_column import InputColumn
 
 from .input_column import InputColumn
 

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -246,6 +246,9 @@ class SQLiteLinker(Linker):
         # name in SQL : python function
         funcs_to_register = {
             "levenshtein": levenshtein,
+            # alias for levenshtein. This is sqlglot recognised, but is in an extension,
+            # so not available natively
+            "editdist3": levenshtein,
             "damerau_levenshtein": dam_lev,
             "jaro_winkler": jaro_winkler,
             "jaro": jaro,

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -89,7 +89,7 @@ comparison_name = cl.CustomComparison(
             "sql_condition": (
                 "concat(first_name_l, surname_l) = concat(first_name_r, surname_r)"
             ),
-            "label_for_charts": "both names matching"
+            "label_for_charts": "both names matching",
         },
         cll.CustomLevel(
             (

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -31,10 +31,29 @@ comparison_city = {
         cll.ElseLevel(),
     ],
 }
+comparison_email = {
+    "output_column_name": "dob",
+    "comparison_levels": [
+        cll.NullLevel("dob"),
+        cll.ExactMatchLevel("dob"),
+        cll.CustomLevel("substr(dob_l, 1, 4) = substr(dob_r, 1, 4)", "year matches"),
+        {
+            "sql_condition": "substr(dob_l, 1, 2) = substr(dob_r, 1, 2)",
+            "label_for_charts": "century matches",
+        },
+        cll.LevenshteinLevel("dob", 3),
+        cll.ElseLevel(),
+    ],
+}
 
 cll_settings = {
     "link_type": "dedupe_only",
-    "comparisons": [comparison_first_name, comparison_surname, comparison_city],
+    "comparisons": [
+        comparison_first_name,
+        comparison_surname,
+        comparison_city,
+        comparison_email,
+    ],
 }
 
 

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -54,6 +54,10 @@ cll_settings = {
         comparison_city,
         comparison_email,
     ],
+    "blocking_rules_to_generate_predictions": [
+        "l.dob = r.dob",
+        "l.first_name = r.first_name",
+    ],
 }
 
 
@@ -102,6 +106,10 @@ cl_settings = {
         comparison_city,
         comparison_email,
         comparison_dob,
+    ],
+    "blocking_rules_to_generate_predictions": [
+        "l.dob = r.dob",
+        "l.first_name = r.first_name",
     ],
 }
 

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -78,6 +78,21 @@ comparison_first_name = cl.LevenshteinAtThresholds("first_name", [2, 3])
 comparison_surname = cl.LevenshteinAtThresholds("surname", [3])
 comparison_city = cl.ExactMatch("city")
 comparison_email = cl.LevenshteinAtThresholds("email", 3)
+comparison_dob = cl.CustomComparison(
+    "dob",
+    [
+        cll.NullLevel("dob"),
+        cll.ExactMatchLevel("dob"),
+        cll.CustomLevel("substr(dob_l, 1, 4) = substr(dob_r, 1, 4)", "year matches"),
+        {
+            "sql_condition": "substr(dob_l, 1, 2) = substr(dob_r, 1, 2)",
+            "label_for_charts": "century matches",
+        },
+        cll.LevenshteinLevel("dob", 3),
+        cll.ElseLevel(),
+    ],
+    "Date of birth comparison with exact, year, century and lev<=3 levels",
+)
 
 cl_settings = {
     "link_type": "dedupe_only",
@@ -86,6 +101,7 @@ cl_settings = {
         comparison_surname,
         comparison_city,
         comparison_email,
+        comparison_dob,
     ],
 }
 

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -111,6 +111,7 @@ comparison_city = cl.ExactMatch("city").configure(u_probabilities=[0.6, 0.4])
 comparison_email = cl.LevenshteinAtThresholds("email", 3).configure(
     m_probabilities=[0.8, 0.1, 0.1]
 )
+comparison_dob = cl.LevenshteinAtThresholds("dob", [1, 2])
 
 cl_settings = {
     "link_type": "dedupe_only",


### PR DESCRIPTION
Defines library `CustomLevel` and `CustomComparison`.

## `CustomLevel`

Provides a wrapper for supplying a `sql_condition`. It additionally allows automatic best-effort translation between dialects (powered by `sqlglot`), so that users don't need to worry so much about writing dialect-dependent SQL.

See test additions for examples of this working in practice.

Edit: altered, see below:
The way it works currently when we create a (dialected) level,:
* `sql_condition` is parsed by `sqlglot`, using an optional dialect the user can specify
*  try to translate to the specified dialect (even if it is the same as the 'initial' form)
* if this fails, just return the original `sql_condition` (which may be wanted if it is e.g. custom stuff, or new features `sqlglot` doesn't know about)

This does mean that SQL expressions can end up more complicated than that specified by user, so may be worth having some kind of flag to turn this transpilation off? That would also catch potential situations where sqlglot ends up spitting out an invalid expression (as was happening with `levenshtein` + `sqlite` initially due to extension-specific stuff, necessitating an alias in our linker) 

Edit: now we only translate if we have a specified dialect and it doesn't match that of the level requested to be made

## `CustomComparison`

A wrapper for supplying a comparison as a list of levels. Any levels which are defined as simple `dict`s will be coerced t `CustomLevel`s, so that:
* we have consistent types, which is useful for things like checking whether levels are null levels (see e.g. #1765)
* we automatically get the translation ☝️ capabilities of `CustomLevel`

That happens with a simple `**kwargs` but should probably be replaced with a proper deserialisation method once we set that up consistently.

Also included:
* blocking rules in new tests to speed them up (most of the time now is making `spark`, where applicable)

Not included:
* automatic coercion to `CustomComparison`, as not clear to me atm when that should happen (but would be useful so that we get the translation even if we define all our comparisons in dict form)

