### PR TITLE
Pass SQL dialect information to `ComparisonLevel` object

### DIFF
--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -19,7 +19,11 @@ class ComparisonLevelCreator(ABC):
     def get_comparison_level(self, sql_dialect_str: str) -> ComparisonLevel:
         """sql_dialect_str is a string to make this method easier to use
         for the end user - otherwise they'd need to import a SplinkDialect"""
-        return ComparisonLevel(self.create_level_dict(sql_dialect_str))
+        sql_dialect = SplinkDialect.from_string(sql_dialect_str)
+        return ComparisonLevel(
+            self.create_level_dict(sql_dialect_str),
+            sql_dialect=sql_dialect.sqlglot_name,
+        )
 
     @final
     def create_level_dict(self, sql_dialect_str: str) -> dict:


### PR DESCRIPTION
When we use a `ComparisonLevelCreator` to create a `ComparisonLevel` we should also pass along SQL dialect information, so that it is available on the `ComparisonLevel` object. This is useful, for instance, in our current implementation of `Settings` validation (as currently in Splink4 any mismatched dialect issues are not picked up).

Currently this translates from our user-facing 'Splink' dialect name to the `sqlglot` version. We might want to have a think about how we deal with all this a bit more closely, but for now this should restore existing functionality.