### PR TITLE
(Splink 4) ArrayIntersectAtSizes

### DIFF
--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -331,7 +331,7 @@ class ArrayIntersectAtSizes(ComparisonCreator):
 
         Args:
             col_name (str): The name of the column to compare.
-            size_threshold_or_thresholds (Union[int, list], optional): The
+            size_threshold_or_thresholds (Union[int, list[int]], optional): The
                 size threshold(s) for the intersection levels.
                 Defaults to [1].
         """

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -309,3 +309,56 @@ class JaroWinklerAtThresholds(ComparisonCreator):
 
     def create_output_column_name(self) -> str:
         return self.col_name
+
+
+class ArrayIntersectAtSizes(ComparisonCreator):
+    def __init__(
+        self,
+        col_name: str,
+        size_threshold_or_thresholds: Union[Iterable[int], int] = [1],
+    ):
+        """
+        Represents a comparison of the data in `col_name` with multiple levels based on
+        the intersection sizes of array elements:
+            - Intersection at specified size thresholds
+            - ...
+            - Anything else
+
+        For example, with size_threshold_or_thresholds = [3, 1], the levels are:
+            - Intersection of arrays in `col_name` has at least 3 elements
+            - Intersection of arrays in `col_name` has at least 1 element
+            - Anything else (e.g., empty intersection)
+
+        Args:
+            col_name (str): The name of the column to compare.
+            size_threshold_or_thresholds (Union[int, list], optional): The
+                size threshold(s) for the intersection levels.
+                Defaults to [1].
+        """
+
+        thresholds_as_iterable = ensure_is_iterable(size_threshold_or_thresholds)
+        self.thresholds = [*thresholds_as_iterable]
+        super().__init__(col_name)
+
+    def create_comparison_levels(
+        self, sql_dialect: SplinkDialect
+    ) -> List[ComparisonLevelCreator]:
+        return [
+            cll.NullLevel(self.col_name),
+            *[
+                cll.ArrayIntersectLevel(self.col_name, min_intersection=threshold)
+                for threshold in self.thresholds
+            ],
+            cll.ElseLevel(),
+        ]
+
+    def create_description(self) -> str:
+        comma_separated_thresholds_string = ", ".join(map(str, self.thresholds))
+        plural = "s" if len(self.thresholds) > 1 else ""
+        return (
+            f"Array intersection at minimum size{plural} {comma_separated_thresholds_string} vs. "
+            "anything else"
+        )
+
+    def create_output_column_name(self) -> str:
+        return self.col_name

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -356,8 +356,8 @@ class ArrayIntersectAtSizes(ComparisonCreator):
         comma_separated_thresholds_string = ", ".join(map(str, self.thresholds))
         plural = "s" if len(self.thresholds) > 1 else ""
         return (
-            f"Array intersection at minimum size{plural} {comma_separated_thresholds_string} vs. "
-            "anything else"
+            f"Array intersection at minimum size{plural} "
+            f"{comma_separated_thresholds_string} vs. anything else"
         )
 
     def create_output_column_name(self) -> str:


### PR DESCRIPTION
Implement `ArrayIntersectAtSizes`

<details>
<summary>
test script
</summary>

```python
from splink.datasets import splink_datasets
from splink.duckdb.blocking_rule_library import block_on
from splink.comparison_library import (
    DamerauLevenshteinAtThresholds,
    JaccardAtThresholds,
    JaroAtThresholds,
    JaroWinklerAtThresholds,
    ExactMatch,
    ArrayIntersectAtSizes
)

from splink.duckdb.linker import DuckDBLinker

JaroWinklerAtThresholds("first_name", 0.7).create_comparison_dict("spark")
df = splink_datasets.fake_1000

df['email'] = df['email'].apply(lambda x: [x])

settings = {
    "probability_two_random_records_match": 0.01,
    "link_type": "dedupe_only",
    "blocking_rules_to_generate_predictions": [
        block_on("first_name"),
        block_on("surname"),
    ],
    "comparisons": [
        DamerauLevenshteinAtThresholds("first_name", 2),
        ArrayIntersectAtSizes("email", 1),
    ],
    "retain_intermediate_calculation_columns": True,
    "additional_columns_to_retain": ["cluster"],
    "max_iterations": 10,
    "em_convergence": 0.01,
}


linker = DuckDBLinker(df, settings)

linker.estimate_u_using_random_sampling(target_rows=1e5)
display(linker.match_weights_chart())
linker.save_model_to_json()

```

</details>

