### PR TITLE
Improve speed of link only sample test

### DIFF
--- a/.github/workflows/pytest_postgres.yml
+++ b/.github/workflows/pytest_postgres.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - '**dev'
+      - "**dev"
     paths:
       - splink/**
       - tests/**
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ "3.8.16", "3.9.10" ]
+        python-version: ["3.8.16", "3.9.10"]
     services:
       pg_splink_ci:
         image: postgres
@@ -30,8 +30,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-            # map port so we can access
-            - 5432:5432
+          # map port so we can access
+          - 5432:5432
     name: Run tests with python verion ${{ matrix.python-version }}
     steps:
       #----------------------------------------------
@@ -50,8 +50,8 @@ jobs:
       - name: Load cached Poetry installation
         uses: actions/cache@v2
         with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-0  # increment to reset cache
+          path: ~/.local # the path depends on the OS
+          key: poetry-0 # increment to reset cache
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -89,5 +89,4 @@ jobs:
       - name: Run only postgres-marked tests
         run: |
           source .venv/bin/activate
-          pytest -v -m postgres_only tests/
-
+          pytest -v --durations=0 -m postgres_only tests/

--- a/.github/workflows/pytest_postgres.yml
+++ b/.github/workflows/pytest_postgres.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - "**dev"
+      - '**dev'
     paths:
       - splink/**
       - tests/**
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8.16", "3.9.10"]
+        python-version: [ "3.8.16", "3.9.10" ]
     services:
       pg_splink_ci:
         image: postgres
@@ -30,8 +30,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          # map port so we can access
-          - 5432:5432
+            # map port so we can access
+            - 5432:5432
     name: Run tests with python verion ${{ matrix.python-version }}
     steps:
       #----------------------------------------------
@@ -50,8 +50,8 @@ jobs:
       - name: Load cached Poetry installation
         uses: actions/cache@v2
         with:
-          path: ~/.local # the path depends on the OS
-          key: poetry-0 # increment to reset cache
+          path: ~/.local  # the path depends on the OS
+          key: poetry-0  # increment to reset cache
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -90,3 +90,4 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest -v --durations=0 -m postgres_only tests/
+

--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - "**dev"
+      - '**dev'
     paths:
       - splink/**
       - tests/**
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8.16", "3.9.10"]
+        python-version: [ "3.8.16", "3.9.10" ]
     name: Run tests with python verion ${{ matrix.python-version }}
     steps:
       #----------------------------------------------
@@ -33,8 +33,8 @@ jobs:
       - name: Load cached Poetry installation
         uses: actions/cache@v2
         with:
-          path: ~/.local # the path depends on the OS
-          key: poetry-0 # increment to reset cache
+          path: ~/.local  # the path depends on the OS
+          key: poetry-0  # increment to reset cache
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -73,3 +73,4 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest --durations=0 tests/
+

--- a/.github/workflows/pytest_run_tests_with_cache.yml
+++ b/.github/workflows/pytest_run_tests_with_cache.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - '**dev'
+      - "**dev"
     paths:
       - splink/**
       - tests/**
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ "3.8.16", "3.9.10" ]
+        python-version: ["3.8.16", "3.9.10"]
     name: Run tests with python verion ${{ matrix.python-version }}
     steps:
       #----------------------------------------------
@@ -33,8 +33,8 @@ jobs:
       - name: Load cached Poetry installation
         uses: actions/cache@v2
         with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-0  # increment to reset cache
+          path: ~/.local # the path depends on the OS
+          key: poetry-0 # increment to reset cache
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -72,5 +72,4 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest tests/
-
+          pytest --durations=0 tests/

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tests.decorator import mark_with_dialects_excluding
 from splink.estimate_u import _proportion_sample_size_link_only
+from tests.decorator import mark_with_dialects_excluding
 
 
 @mark_with_dialects_excluding()
@@ -26,7 +26,7 @@ def test_u_train(test_helpers, dialect):
     }
     df_linker = helper.convert_frame(df)
 
-    args = helper.extra_linker_args()
+    helper.extra_linker_args()
 
     linker = helper.Linker(df_linker, settings, **helper.extra_linker_args())
     linker.debug_mode = True

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -197,11 +197,11 @@ def test_u_train_link_only_sample_proportion():
         con.register("combined_df", combined_df)
 
         query = """
-            SELECT count(*)
-            FROM combined_df a
-            JOIN combined_df b
-            ON a.source_dataset_name != b.source_dataset_name
-            AND a.source_dataset_name || a.unique_id < b.source_dataset_name || b.unique_id
+        SELECT count(*)
+        FROM combined_df a
+        JOIN combined_df b
+        ON a.source_dataset_name != b.source_dataset_name
+        AND a.source_dataset_name || a.unique_id < b.source_dataset_name || b.unique_id
         """
 
         result = con.execute(query).fetchdf()

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -141,7 +141,7 @@ def test_u_train_link_only_sample(test_helpers, dialect):
     )
     linker.debug_mode = True
 
-    linker.estimate_u_using_random_sampling(max_pairs=max_pairs, seed=42)
+    linker.estimate_u_using_random_sampling(max_pairs=max_pairs)
 
     # count how many pairs we _actually_ generated in random sampling
     check_blocking_sql = """

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -27,8 +27,6 @@ def test_u_train(test_helpers, dialect):
     }
     df_linker = helper.convert_frame(df)
 
-    helper.extra_linker_args()
-
     linker = helper.Linker(df_linker, settings, **helper.extra_linker_args())
     linker.debug_mode = True
     linker.estimate_u_using_random_sampling(max_pairs=1e6)


### PR DESCRIPTION
Now we've fixed the analyse blocking test, this is now the [slowest test](https://github.com/moj-analytical-services/splink/issues/1707#issuecomment-1801671570)

Combining a `spark` test with `debug_mode=True` is very slow, because lots of intermediate tables are produced and output to parquet.  (I've also tried setting the checkpointing method to `persist` but that didn't help either)

In this PR, I've disabled the spark test, and included a new test for the underlying calculation
https://mojdt.slack.com/archives/C060KLFJXPX/p1699978472369589

Here's some previous notes coped from slack:

I have been experimenting with [this test](https://github.com/moj-analytical-services/splink/blob/b1db4a2e6a39f5263dbaa728539402314432f3e2/tests/test_u_train.py#L106) (the second slowest).

The problem is I can’t find an easy to to make it faster

- It would be possible to refactor the test to make it faster, but at a significant loss of clarity as to what the test is actually doing

- reducing size of data makes the test close to useless.  needs big sample because of the random element. 

- running debug_mode = True is really bad for Spark performance, but necessary to test the high-level API

- possibly there’s a solution with a seed, but not sure how robust, and only works in spark and duckdb

I wonder if the best solution is simply to disable Spark for this test.  On the basis that it’s really testing the random sample size is computed correctly - and if that’s right in Duckdb, then it should be right in Spark. (realise that isn’t completely watertight, but if it’s wrong other things should break too).
