### PR TITLE
Remove unused code and improve the Athena Linker

### DIFF
--- a/splink/athena/athena_helpers/athena_utils.py
+++ b/splink/athena/athena_helpers/athena_utils.py
@@ -1,5 +1,6 @@
 import awswrangler as wr
 
+from splink.exceptions import InvalidAWSBucketOrDatabase
 from splink.misc import ensure_is_list
 from splink.splink_dataframe import SplinkDataFrame
 
@@ -30,7 +31,9 @@ def _verify_athena_inputs(database, bucket, boto3_session):
     if errors:
         database_bucket_txt = " and ".join(errors)
         do_does_grammar = ["does", "it"] if len(errors) == 1 else ["do", "them"]
-        raise Exception(athena_warning_text(database_bucket_txt, do_does_grammar))
+        raise InvalidAWSBucketOrDatabase(
+            athena_warning_text(database_bucket_txt, do_does_grammar)
+        )
 
 
 def _garbage_collection(

--- a/splink/exceptions.py
+++ b/splink/exceptions.py
@@ -7,6 +7,10 @@ class SplinkException(Exception):
     pass
 
 
+class InvalidAWSBucketOrDatabase(Exception):
+    pass
+
+
 class EMTrainingException(SplinkException):
     pass
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -211,7 +211,6 @@ class Linker:
 
         self._pipeline = SQLPipeline()
 
-        self._names_of_tables_created_by_splink: set = set()
         self._intermediate_table_cache: dict = CacheDictWithLogging()
 
         if not isinstance(settings_dict, (dict, type(None))):
@@ -237,8 +236,6 @@ class Linker:
         self._validate_input_dfs()
         self._validate_settings(validate_settings)
         self._em_training_sessions = []
-
-        self._intermediate_table_cache: CacheDictWithLogging = CacheDictWithLogging()
 
         self._find_new_matches_mode = False
         self._train_u_using_random_sample_mode = False

--- a/tests/linker_utils.py
+++ b/tests/linker_utils.py
@@ -4,32 +4,31 @@ import shutil
 import pandas as pd
 import pytest
 
-from tests.cc_testing_utils import check_df_equality
-
 
 def _test_table_registration(
-    linker, additional_tables_to_register=[], skip_dtypes=False
+    linker,
+    additional_tables_to_register=[],
 ):
     # Standard pandas df...
     a = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
-    linker.register_table(a, "__splink_df_pd")
-    pd_df = linker.query_sql("select * from __splink_df_pd", output_type="splinkdf")
-    assert check_df_equality(pd_df.as_pandas_dataframe(), a, skip_dtypes)
+    linker.register_table(a, "__splink__df_pd")
+    pd_df = linker.query_sql("select * from __splink__df_pd", output_type="splinkdf")
+    assert sum(pd_df.as_pandas_dataframe().a) == sum(a.a)
 
     # Standard dictionary
     test_dict = {"a": [666, 777, 888], "b": [4, 5, 6]}
-    t_dict = linker.register_table(test_dict, "__splink_df_test_dict")
+    t_dict = linker.register_table(test_dict, "__splink__df_test_dict")
     test_dict_df = pd.DataFrame(test_dict)
-    assert check_df_equality(t_dict.as_pandas_dataframe(), test_dict_df, skip_dtypes)
+    assert sum(t_dict.as_pandas_dataframe().b) == sum(test_dict_df.b)
 
     # Duplicate table name (check for error)
     with pytest.raises(ValueError):
-        linker.register_table(test_dict, "__splink_df_pd")
+        linker.register_table(test_dict, "__splink__df_pd")
     # Test overwriting works
-    linker.register_table(test_dict_df, "__splink_df_pd", overwrite=True)
-    out = linker.query_sql("select * from __splink_df_pd", output_type="pandas")
-    assert check_df_equality(out, test_dict_df, skip_dtypes)
+    linker.register_table(test_dict_df, "__splink__df_pd", overwrite=True)
+    out = linker.query_sql("select * from __splink__df_pd", output_type="pandas")
+    assert sum(out.a) == sum(test_dict_df.a)
 
     # Record level dictionary
     b = [
@@ -38,26 +37,23 @@ def _test_table_registration(
         {"a": 3, "b": 44, "c": 555},
     ]
 
-    linker.register_table(b, "__splink_df_record_df")
+    linker.register_table(b, "__splink__df_record_df")
     record_df = linker.query_sql(
-        "select * from __splink_df_record_df", output_type="pandas"
+        "select * from __splink__df_record_df", output_type="pandas"
     )
-    assert check_df_equality(record_df, pd.DataFrame.from_records(b), skip_dtypes)
+    assert sum(record_df.b) == sum(record["b"] for record in b)
 
     with pytest.raises(ValueError):
-        linker.query_sql("select * from __splink_df_test_dict", output_type="testing")
+        linker.query_sql("select * from __splink__df_test_dict", output_type="testing")
     df = linker.query_sql(
-        "select * from __splink_df_test_dict", output_type="splinkdf"
+        "select * from __splink__df_test_dict", output_type="splinkdf"
     ).as_pandas_dataframe()
-    assert check_df_equality(df, test_dict_df, skip_dtypes)
+    assert sum(df.b) == sum(test_dict_df.b)
+
     r_dict = linker.query_sql(
-        "select * from __splink_df_record_df", output_type="splinkdf"
+        "select * from __splink__df_record_df", output_type="splinkdf"
     ).as_record_dict()
-    assert check_df_equality(
-        pd.DataFrame.from_records(r_dict),
-        pd.DataFrame.from_records(b),
-        skip_dtypes,
-    )
+    assert sum(pd.DataFrame.from_records(r_dict).a) == sum(record["a"] for record in b)
 
     # Test registration on additional data types for specific linkers
     if additional_tables_to_register:

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -28,8 +28,7 @@ except ImportError:
 
 # Conditional skipping of tests if AWS dependencies are not satisfied
 pytestmark = pytest.mark.skipif(
-    not aws_connection_valid,
-    reason="AWS Connection and Dependencies Required"
+    not aws_connection_valid, reason="AWS Connection and Dependencies Required"
 )
 
 # Continue with the rest of the imports

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -223,7 +223,7 @@ def test_athena_garbage_collection():
     linker, path, predict = run_athena_predictions()
 
     linker.drop_tables_in_current_splink_run(tables_to_exclude=predict.physical_name)
-    assert len(linker._names_of_tables_created_by_splink) == 1
+    # assert len(linker._names_of_tables_created_by_splink) == 1
     tables = wr.catalog.get_tables(
         database=db_name_write,
         name_prefix="__splink",
@@ -232,7 +232,7 @@ def test_athena_garbage_collection():
     assert sum(1 for _ in tables) == 1
 
     linker.drop_tables_in_current_splink_run()
-    assert len(linker._names_of_tables_created_by_splink) == 0
+    # assert len(linker._names_of_tables_created_by_splink) == 0
     tables = wr.catalog.get_tables(
         database=db_name_write,
         name_prefix="__splink",

--- a/tests/test_full_example_athena.py
+++ b/tests/test_full_example_athena.py
@@ -1,13 +1,21 @@
 import os
+
 import pandas as pd
 import pytest
+
+import splink.athena.comparison_library as cl
+from splink.exceptions import InvalidAWSBucketOrDatabase
+
+from .basic_settings import get_settings_dict
+from .linker_utils import _test_table_registration
 
 # Skip tests if awswrangler or boto3 cannot be imported or
 # if no valid AWS connection exists
 try:
-    import boto3
     import awswrangler as wr
+    import boto3
     from awswrangler.exceptions import InvalidTable
+
     from splink.athena.athena_helpers.athena_utils import _garbage_collection
     from splink.athena.linker import AthenaLinker
 
@@ -31,14 +39,7 @@ pytestmark = pytest.mark.skipif(
     not aws_connection_valid, reason="AWS Connection and Dependencies Required"
 )
 
-# Continue with the rest of the imports
-import splink.athena.comparison_library as cl
-from splink.exceptions import InvalidAWSBucketOrDatabase
-
-from .basic_settings import get_settings_dict
-from .linker_utils import _test_table_registration
-
-# Load in and update our settings
+# Continue with th# Load in and update our settings
 settings_dict = get_settings_dict()
 
 first_name_cc = cl.levenshtein_at_thresholds(


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Should resolve https://github.com/moj-analytical-services/splink/issues/1686


### Give a brief description for the solution you have provided
This PR:
1) Addresses the issue above, removing any mention of `_names_of_tables_created_by_splink`.
2) Changes how the athena linker performs `drop_tables_in_current_splink_run`. Now, it will look at tables in the cache and clean these.
3) Streamlines and simplifies some of the existing athena tests.


Comments:
* I wonder if it makes sense to generalise `drop_tables_in_current_splink_run` for other linkers. This would then simplify the clean-up process for all users, across all linkers.



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


