### PR TITLE
Comparison level creator composition

### DIFF
--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -5,7 +5,6 @@ from typing import Iterable, Union, final
 from .blocking import BlockingRule
 from .comparison_creator import ComparisonLevelCreator
 from .comparison_level import ComparisonLevel
-from .comparison_level_library import CustomLevel
 from .dialects import SplinkDialect
 
 
@@ -13,8 +12,10 @@ def _ensure_is_comparison_level_creator(
     cl: Union[ComparisonLevelCreator, dict]
 ) -> ComparisonLevelCreator:
     if isinstance(cl, dict):
+        from .comparison_level_library import CustomLevel
+
         # TODO: proper dict => level method
-        return CustomLevel(**dict)
+        return CustomLevel(**cl)
     if isinstance(cl, ComparisonLevelCreator):
         return cl
     raise TypeError(
@@ -30,8 +31,7 @@ class _Merge(ComparisonLevelCreator):
         if num_levels == 0:
             raise ValueError(f"Must provide at least one level to {type(self)}()")
         self.comparison_levels = [
-            _ensure_is_comparison_level_creator(cl)
-            for cl in comparison_levels
+            _ensure_is_comparison_level_creator(cl) for cl in comparison_levels
         ]
         self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
 

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -33,7 +33,7 @@ class _Merge(ComparisonLevelCreator):
         self.comparison_levels = [
             _ensure_is_comparison_level_creator(cl) for cl in comparison_levels
         ]
-        self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
+        self.is_null_level = all(cl.is_null_level for cl in self.comparison_levels)
 
     @final
     def create_sql(self, sql_dialect: SplinkDialect) -> str:

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -59,6 +59,7 @@ class And(_Merge):
         *comparison_levels (ComparisonLevelCreator | dict): These represent the
             comparison levels you wish to combine via 'AND'
     """
+
     _clause = "AND"
 
 
@@ -73,6 +74,7 @@ class Or(_Merge):
         *comparison_levels (ComparisonLevelCreator | dict): These represent the
             comparison levels you wish to combine via 'OR'
     """
+
     _clause = "OR"
 
 
@@ -87,6 +89,7 @@ class Not(ComparisonLevelCreator):
         *comparison_level (ComparisonLevelCreator | dict): This represents the
             comparison level you wish to negate with 'NOT'
     """
+
     def __init__(self, comparison_level: Union[ComparisonLevelCreator, dict]):
         self.comparison_level = _ensure_is_comparison_level_creator(comparison_level)
         # turn null levels into non-null levels, otherwise do nothing

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -60,7 +60,7 @@ class Not(ComparisonLevelCreator):
     def __init__(self, comparison_level: Union[ComparisonLevelCreator, dict]):
         self.comparison_level = _ensure_is_comparison_level_creator(comparison_level)
         # turn null levels into non-null levels, otherwise do nothing
-        if comparison_level.is_null_level:
+        if self.comparison_level.is_null_level:
             self.is_null_level = False
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -1,420 +1,67 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Union
 
 from .blocking import BlockingRule
+from .comparison_creator import ComparisonLevelCreator
 from .comparison_level import ComparisonLevel
+from .dialects import SplinkDialect
 
 
-def and_(
-    *clls: ComparisonLevel | dict,
-    label_for_charts=None,
-    m_probability=None,
-    is_null_level=None,
-) -> ComparisonLevel:
-    """Merge ComparisonLevels using logical "AND".
+class And(ComparisonLevelCreator):
+    def __init__(self, *comparison_levels: Union[ComparisonLevelCreator, dict]):
+        num_levels = len(comparison_levels)
+        if num_levels == 0:
+            raise ValueError("Must provide at least one level to And()")
+        self.comparison_levels = comparison_levels
+        self.is_null_level = all(
+            getattr(cl, "is_null_level", False) for cl in comparison_levels
+        )
 
-    Merge multiple ComparisonLevels into a single ComparisonLevel by
-    merging their SQL conditions using a logical "AND".
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        return " AND ".join(
+            map(lambda cl: cl.create_sql(sql_dialect), self.comparison_levels)
+        )
 
-    By default, we generate a new `label_for_charts` for the new ComparisonLevel.
-    You can override this, and any other ComparisonLevel attributes, by passing
-    them as keyword arguments.
-
-    Args:
-        *clls (ComparisonLevel | dict): ComparisonLevels or comparison
-            level dictionaries to merge
-        label_for_charts (str, optional): A label for this comparson level,
-            which will appear on charts as a reminder of what the level represents.
-            Defaults to a composition of - `label_1 AND label_2`
-        m_probability (float, optional): Starting value for m probability.
-            Defaults to None.
-        is_null_level (bool, optional): If true, m and u values will not be
-            estimated and instead the match weight will be zero for this column.
-            Defaults to None.
-
-    Examples:
-        === ":simple-duckdb: DuckDB"
-            Simple null level composition with an `AND` clause
-            ``` python
-            import splink.duckdb.comparison_level_library as cll
-            cll.and_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-            Composing a levenshtein level with a custom `contains` level
-            ``` python
-            import splink.duckdb.comparison_level_library as cll
-            misspelling = cll.levenshtein_level("name", 1)
-            contains = {
-                "sql_condition": "(contains(name_l, name_r) OR " \
-                "contains(name_r, name_l))"
-            }
-            merged = cll.and_(misspelling, contains, label_for_charts="Spelling error")
-            ```
-            ```python
-            merged.as_dict()
-            ```
-            >{
-            > 'sql_condition': '(levenshtein("name_l", "name_r") <= 1) ' \
-            >  'AND ((contains(name_l, name_r) OR contains(name_r, name_l)))',
-            >  'label_for_charts': 'Spelling error'
-            >}
-        === ":simple-apachespark: Spark"
-            Simple null level composition with an `AND` clause
-            ``` python
-            import splink.spark.comparison_level_library as cll
-            cll.and_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-            Composing a levenshtein level with a custom `contains` level
-            ``` python
-            import splink.spark.comparison_level_library as cll
-            misspelling = cll.levenshtein_level("name", 1)
-            contains = {
-                "sql_condition": "(contains(name_l, name_r) OR " \
-                "contains(name_r, name_l))"
-            }
-            merged = cll.and_(misspelling, contains, label_for_charts="Spelling error")
-            ```
-            ```python
-            merged.as_dict()
-            ```
-            >{
-            > 'sql_condition': '(levenshtein("name_l", "name_r") <= 1) ' \
-            >  'AND ((contains(name_l, name_r) OR contains(name_r, name_l)))',
-            >  'label_for_charts': 'Spelling error'
-            >}
-        === ":simple-amazonaws: Athena"
-            Simple null level composition with an `AND` clause
-            ``` python
-            import splink.athena.comparison_level_library as cll
-            cll.and_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-            Composing a levenshtein level with a custom `contains` level
-            ``` python
-            import splink.athena.comparison_level_library as cll
-            misspelling = cll.levenshtein_level("name", 1)
-            contains = {
-                "sql_condition": "(contains(name_l, name_r) OR " \
-                "contains(name_r, name_l))"
-            }
-            merged = cll.and_(misspelling, contains, label_for_charts="Spelling error")
-            ```
-            ```python
-            merged.as_dict()
-            ```
-            >{
-            > 'sql_condition': '(levenshtein("name_l", "name_r") <= 1) ' \
-            >  'AND ((contains(name_l, name_r) OR contains(name_r, name_l)))',
-            >  'label_for_charts': 'Spelling error'
-            >}
-        === ":simple-sqlite: SQLite"
-            Simple null level composition with an `AND` clause
-            ``` python
-            import splink.sqlite.comparison_level_library as cll
-            cll.and_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-
-    Returns:
-        ComparisonLevel: A new ComparisonLevel with the merged
-            SQL condition
-    """
-    return _cl_merge(
-        *clls,
-        clause="AND",
-        label_for_charts=label_for_charts,
-        m_probability=m_probability,
-        is_null_level=is_null_level,
-    )
+    def create_label_for_charts(self) -> str:
+        return " AND ".join(
+            map(lambda cl: cl.create_label_for_charts(), self.comparison_levels)
+        )
 
 
-def or_(
-    *clls: ComparisonLevel | dict,
-    label_for_charts: str | None = None,
-    m_probability: float | None = None,
-    is_null_level: bool | None = None,
-) -> ComparisonLevel:
-    """Merge ComparisonLevels using logical "OR".
+class Or(ComparisonLevelCreator):
+    def __init__(self, *comparison_levels: Union[ComparisonLevelCreator, dict]):
+        num_levels = len(comparison_levels)
+        if num_levels == 0:
+            raise ValueError("Must provide at least one level to Or()")
+        self.comparison_levels = comparison_levels
+        self.is_null_level = all(
+            getattr(cl, "is_null_level", False) for cl in comparison_levels
+        )
 
-    Merge multiple ComparisonLevels into a single ComparisonLevel by
-    merging their SQL conditions using a logical "OR".
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        return " OR ".join(
+            map(lambda cl: cl.create_sql(sql_dialect), self.comparison_levels)
+        )
 
-    By default, we generate a new `label_for_charts` for the new ComparisonLevel.
-    You can override this, and any other ComparisonLevel attributes, by passing
-    them as keyword arguments.
-
-    Args:
-        *clls (ComparisonLevel | dict): ComparisonLevels or comparison
-            level dictionaries to merge
-        label_for_charts (str, optional): A label for this comparson level,
-            which will appear on charts as a reminder of what the level represents.
-            Defaults to a composition of - `label_1 OR label_2`
-        m_probability (float, optional): Starting value for m probability.
-            Defaults to None.
-        is_null_level (bool, optional): If true, m and u values will not be
-            estimated and instead the match weight will be zero for this column.
-            Defaults to None.
-
-    Examples:
-        === ":simple-duckdb: DuckDB"
-            Simple null level composition with an `OR` clause
-            ``` python
-            import splink.duckdb.comparison_level_library as cll
-            cll.or_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-            Composing a levenshtein level with a custom `contains` level
-            ``` python
-            import splink.duckdb.comparison_level_library as cll
-            misspelling = cll.levenshtein_level("name", 1)
-            contains = {
-                "sql_condition": "(contains(name_l, name_r) OR " \
-                "contains(name_r, name_l))"
-            }
-            merged = cll.or_(misspelling, contains, label_for_charts="Spelling error")
-            ```
-            ```python
-            merged.as_dict()
-            ```
-            >{
-            > sql_condition': '(levenshtein("name_l", "name_r") <= 1) ' \
-            >  'OR ((contains(name_l, name_r) OR contains(name_r, name_l)))',
-            >  'label_for_charts': 'Spelling error'
-            >}
-        === ":simple-apachespark: Spark"
-            Simple null level composition with an `OR` clause
-            ``` python
-            import splink.spark.comparison_level_library as cll
-            cll.or_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-            Composing a levenshtein level with a custom `contains` level
-            ``` python
-            import splink.spark.comparison_level_library as cll
-            misspelling = cll.levenshtein_level("name", 1)
-            contains = {
-                "sql_condition": "(contains(name_l, name_r) OR " \
-                "contains(name_r, name_l))"
-            }
-            merged = cll.or_(misspelling, contains, label_for_charts="Spelling error")
-            ```
-            ```python
-            merged.as_dict()
-            ```
-            >{
-            > sql_condition': '(levenshtein("name_l", "name_r") <= 1) ' \
-            >  'OR ((contains(name_l, name_r) OR contains(name_r, name_l)))',
-            >  'label_for_charts': 'Spelling error'
-            >}
-        === ":simple-amazonaws: Athena"
-            Simple null level composition with an `OR` clause
-            ``` python
-            import splink.athena.comparison_level_library as cll
-            cll.or_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-            Composing a levenshtein level with a custom `contains` level
-            ``` python
-            import splink.athena.comparison_level_library as cll
-            misspelling = cll.levenshtein_level("name", 1)
-            contains = {
-                "sql_condition": "(contains(name_l, name_r) OR " \
-                "contains(name_r, name_l))"
-            }
-            merged = cll.or_(misspelling, contains, label_for_charts="Spelling error")
-            ```
-            ```python
-            merged.as_dict()
-            ```
-            >{
-            > sql_condition': '(levenshtein("name_l", "name_r") <= 1) ' \
-            >  'OR ((contains(name_l, name_r) OR contains(name_r, name_l)))',
-            >  'label_for_charts': 'Spelling error'
-            >}
-        === ":simple-sqlite: SQLite"
-            Simple null level composition with an `OR` clause
-            ``` python
-            import splink.sqlite.comparison_level_library as cll
-            cll.or_(cll.null_level("first_name"), cll.null_level("surname"))
-            ```
-
-    Returns:
-        ComparisonLevel: A new ComparisonLevel with the merged
-            SQL condition
-    """
-
-    return _cl_merge(
-        *clls,
-        clause="OR",
-        label_for_charts=label_for_charts,
-        m_probability=m_probability,
-        is_null_level=is_null_level,
-    )
+    def create_label_for_charts(self) -> str:
+        return " OR ".join(
+            map(lambda cl: cl.create_label_for_charts(), self.comparison_levels)
+        )
 
 
-def not_(
-    cll: ComparisonLevel | dict,
-    label_for_charts: str | None = None,
-    m_probability: float | None = None,
-) -> ComparisonLevel:
-    """Negate a ComparisonLevel.
+class Not(ComparisonLevelCreator):
+    def __init__(self, comparison_level: Union[ComparisonLevelCreator, dict]):
+        self.comparison_level = comparison_level
+        # turn null levels into non-null levels, otherwise do nothing
+        if comparison_level.is_null_level:
+            self.is_null_level = False
 
-    Returns a ComparisonLevel with the same SQL condition as the input,
-    but prefixed with "NOT".
+    def create_sql(self, sql_dialect: SplinkDialect) -> str:
+        return f"NOT ({self.comparison_level.create_sql(sql_dialect)})"
 
-    By default, we generate a new `label_for_charts` for the new ComparisonLevel.
-    You can override this, and any other ComparisonLevel attributes, by passing
-    them as keyword arguments.
-
-    Args:
-        cll (ComparisonLevel | dict): ComparisonLevel or comparison
-            level dictionary
-        label_for_charts (str, optional): A label for this comparson level,
-            which will appear on charts as a reminder of what the level represents.
-        m_probability (float, optional): Starting value for m probability.
-            Defaults to None.
-
-    Examples:
-        === ":simple-duckdb: DuckDB"
-            *Not* an exact match on first name
-            ``` python
-            import splink.duckdb.comparison_level_library as cll
-            cll.not_(cll.exact_match("first_name"))
-            ```
-            Find all exact matches *not* on the first of January
-            ``` python
-            import splink.duckdb.comparison_level_library as cll
-            dob_first_jan =  {
-               "sql_condition": "SUBSTR(dob_std_l, -5) = '01-01'",
-               "label_for_charts": "Date is 1st Jan",
-            }
-            exact_match_not_first_jan = cll.and_(
-                cll.exact_match_level("dob"),
-                cll.not_(dob_first_jan),
-                label_for_charts = "Exact match and not the 1st Jan"
-            )
-            ```
-        === ":simple-apachespark: Spark"
-            *Not* an exact match on first name
-            ``` python
-            import splink.spark.comparison_level_library as cll
-            cll.not_(cll.exact_match("first_name"))
-            ```
-            Find all exact matches *not* on the first of January
-            ``` python
-            import splink.spark.comparison_level_library as cll
-            dob_first_jan =  {
-               "sql_condition": "SUBSTR(dob_std_l, -5) = '01-01'",
-               "label_for_charts": "Date is 1st Jan",
-            }
-            exact_match_not_first_jan = cll.and_(
-                cll.exact_match_level("dob"),
-                cll.not_(dob_first_jan),
-                label_for_charts = "Exact match and not the 1st Jan"
-            )
-            ```
-        === ":simple-amazonaws: Athena"
-            *Not* an exact match on first name
-            ``` python
-            import splink.athena.comparison_level_library as cll
-            cll.not_(cll.exact_match("first_name"))
-            ```
-            Find all exact matches *not* on the first of January
-            ``` python
-            import splink.athena.comparison_level_library as cll
-            dob_first_jan =  {
-               "sql_condition": "SUBSTR(dob_std_l, -5) = '01-01'",
-               "label_for_charts": "Date is 1st Jan",
-            }
-            exact_match_not_first_jan = cll.and_(
-                cll.exact_match_level("dob"),
-                cll.not_(dob_first_jan),
-                label_for_charts = "Exact match and not the 1st Jan"
-            )
-            ```
-        === ":simple-sqlite: SQLite"
-            *Not* an exact match on first name
-            ``` python
-            import splink.sqlite.comparison_level_library as cll
-            cll.not_(cll.exact_match("first_name"))
-            ```
-            Find all exact matches *not* on the first of January
-            ``` python
-            import splink.sqlite.comparison_level_library as cll
-            dob_first_jan =  {
-               "sql_condition": "SUBSTR(dob_std_l, -5) = '01-01'",
-               "label_for_charts": "Date is 1st Jan",
-            }
-            exact_match_not_first_jan = cll.and_(
-                cll.exact_match_level("dob"),
-                cll.not_(dob_first_jan),
-                label_for_charts = "Exact match and not the 1st Jan"
-            )
-            ```
-
-    Returns:
-        ComparisonLevel
-            A new ComparisonLevel with the negated SQL condition and label_for_charts
-    """
-    cls, sql_dialect = _parse_comparison_levels(cll)
-    cl = cls[0]
-    result = {}
-    result["sql_condition"] = f"NOT ({cl.sql_condition})"
-
-    # Invert if is_null_level.
-    # If NOT is_null_level, then we don't know if the inverted level is null or not
-    if not cl.is_null_level:
-        result["is_null_level"] = False
-
-    result["label_for_charts"] = (
-        label_for_charts if label_for_charts else f"NOT ({cl.label_for_charts})"
-    )
-
-    if m_probability:
-        result["m_probability"] = m_probability
-
-    return ComparisonLevel(result, sql_dialect=sql_dialect)
-
-
-def _cl_merge(
-    *clls: ComparisonLevel | dict,
-    clause: str,
-    label_for_charts: str | None = None,
-    m_probability: float | None = None,
-    is_null_level: bool | None = None,
-) -> ComparisonLevel:
-    if len(clls) == 0:
-        raise ValueError("Must provide at least one ComparisonLevel")
-
-    cls, sql_dialect = _parse_comparison_levels(*clls)
-    result = {}
-    conditions = ("(" + cl.sql_condition + ")" for cl in cls)
-    result["sql_condition"] = f" {clause} ".join(conditions)
-
-    # Set to null level if all supplied levels are "null levels"
-    if is_null_level or (is_null_level is None and all(d.is_null_level for d in cls)):
-        result["is_null_level"] = True
-
-    if label_for_charts:
-        result["label_for_charts"] = label_for_charts
-    else:
-        labels = ("(" + cl.label_for_charts + ")" for cl in cls)
-        result["label_for_charts"] = f" {clause} ".join(labels)
-
-    if m_probability:
-        result["m_probability"] = m_probability
-
-    return ComparisonLevel(result, sql_dialect=sql_dialect)
-
-
-def _parse_comparison_levels(
-    *cls: ComparisonLevel | dict,
-) -> tuple[list[ComparisonLevel], str | None]:
-    cls = [_to_comparison_level(cl) for cl in cls]
-    sql_dialect = _unify_sql_dialects(cls)
-    return cls, sql_dialect
-
-
-def _to_comparison_level(cl: ComparisonLevel | dict) -> ComparisonLevel:
-    if isinstance(cl, ComparisonLevel):
-        return cl
-    else:
-        return ComparisonLevel(cl)
+    def create_label_for_charts(self) -> str:
+        return f"NOT ({self.comparison_level.create_label_for_charts()})"
 
 
 def _unify_sql_dialects(cls: Iterable[ComparisonLevel | BlockingRule]) -> str | None:

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Union
+from typing import Iterable, Union, final
 
 from .blocking import BlockingRule
 from .comparison_creator import ComparisonLevelCreator
@@ -8,42 +8,34 @@ from .comparison_level import ComparisonLevel
 from .dialects import SplinkDialect
 
 
-class And(ComparisonLevelCreator):
+class _Merge(ComparisonLevelCreator):
+    @final
     def __init__(self, *comparison_levels: Union[ComparisonLevelCreator, dict]):
         num_levels = len(comparison_levels)
         if num_levels == 0:
-            raise ValueError("Must provide at least one level to And()")
+            raise ValueError(f"Must provide at least one level to {type(self)}()")
         self.comparison_levels = comparison_levels
         self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
 
+    @final
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        return " AND ".join(
+        return f" {self._clause} ".join(
             map(lambda cl: f"({cl.create_sql(sql_dialect)})", self.comparison_levels)
         )
 
+    @final
     def create_label_for_charts(self) -> str:
-        return " AND ".join(
+        return f" {self._clause} ".join(
             map(lambda cl: f"({cl.create_label_for_charts()})", self.comparison_levels)
         )
 
 
-class Or(ComparisonLevelCreator):
-    def __init__(self, *comparison_levels: Union[ComparisonLevelCreator, dict]):
-        num_levels = len(comparison_levels)
-        if num_levels == 0:
-            raise ValueError("Must provide at least one level to Or()")
-        self.comparison_levels = comparison_levels
-        self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
+class And(_Merge):
+    _clause = "AND"
 
-    def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        return " OR ".join(
-            map(lambda cl: f"({cl.create_sql(sql_dialect)})", self.comparison_levels)
-        )
 
-    def create_label_for_charts(self) -> str:
-        return " OR ".join(
-            map(lambda cl: f"({cl.create_label_for_charts()})", self.comparison_levels)
-        )
+class Or(_Merge):
+    _clause = "OR"
 
 
 class Not(ComparisonLevelCreator):

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -18,12 +18,12 @@ class And(ComparisonLevelCreator):
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         return " AND ".join(
-            map(lambda cl: cl.create_sql(sql_dialect), self.comparison_levels)
+            map(lambda cl: f"({cl.create_sql(sql_dialect)})", self.comparison_levels)
         )
 
     def create_label_for_charts(self) -> str:
         return " AND ".join(
-            map(lambda cl: cl.create_label_for_charts(), self.comparison_levels)
+            map(lambda cl: f"({cl.create_label_for_charts()})", self.comparison_levels)
         )
 
 
@@ -37,12 +37,12 @@ class Or(ComparisonLevelCreator):
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         return " OR ".join(
-            map(lambda cl: cl.create_sql(sql_dialect), self.comparison_levels)
+            map(lambda cl: f"({cl.create_sql(sql_dialect)})", self.comparison_levels)
         )
 
     def create_label_for_charts(self) -> str:
         return " OR ".join(
-            map(lambda cl: cl.create_label_for_charts(), self.comparison_levels)
+            map(lambda cl: f"({cl.create_label_for_charts()})", self.comparison_levels)
         )
 
 

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -49,14 +49,44 @@ class _Merge(ComparisonLevelCreator):
 
 
 class And(_Merge):
+    """
+    Represents a comparison level that is an 'AND' of other comparison levels
+
+    Merge multiple ComparisonLevelCreators into a single ComparisonLevelCreator by
+    merging their SQL conditions using a logical "AND".
+
+    Args:
+        *comparison_levels (ComparisonLevelCreator | dict): These represent the
+            comparison levels you wish to combine via 'AND'
+    """
     _clause = "AND"
 
 
 class Or(_Merge):
+    """
+    Represents a comparison level that is an 'OR' of other comparison levels
+
+    Merge multiple ComparisonLevelCreators into a single ComparisonLevelCreator by
+    merging their SQL conditions using a logical "OR".
+
+    Args:
+        *comparison_levels (ComparisonLevelCreator | dict): These represent the
+            comparison levels you wish to combine via 'OR'
+    """
     _clause = "OR"
 
 
 class Not(ComparisonLevelCreator):
+    """
+    Represents a comparison level that is the negation of another comparison level
+
+    Resulting ComparisonLevelCreator is equivalent to the passed ComparisonLevelCreator
+    but with SQL conditions negated with logical "NOY".
+
+    Args:
+        *comparison_level (ComparisonLevelCreator | dict): This represents the
+            comparison level you wish to negate with 'NOT'
+    """
     def __init__(self, comparison_level: Union[ComparisonLevelCreator, dict]):
         self.comparison_level = _ensure_is_comparison_level_creator(comparison_level)
         # turn null levels into non-null levels, otherwise do nothing

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -14,9 +14,7 @@ class And(ComparisonLevelCreator):
         if num_levels == 0:
             raise ValueError("Must provide at least one level to And()")
         self.comparison_levels = comparison_levels
-        self.is_null_level = all(
-            getattr(cl, "is_null_level", False) for cl in comparison_levels
-        )
+        self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         return " AND ".join(
@@ -35,9 +33,7 @@ class Or(ComparisonLevelCreator):
         if num_levels == 0:
             raise ValueError("Must provide at least one level to Or()")
         self.comparison_levels = comparison_levels
-        self.is_null_level = all(
-            getattr(cl, "is_null_level", False) for cl in comparison_levels
-        )
+        self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         return " OR ".join(

--- a/splink/comparison_level_composition.py
+++ b/splink/comparison_level_composition.py
@@ -5,7 +5,22 @@ from typing import Iterable, Union, final
 from .blocking import BlockingRule
 from .comparison_creator import ComparisonLevelCreator
 from .comparison_level import ComparisonLevel
+from .comparison_level_library import CustomLevel
 from .dialects import SplinkDialect
+
+
+def _ensure_is_comparison_level_creator(
+    cl: Union[ComparisonLevelCreator, dict]
+) -> ComparisonLevelCreator:
+    if isinstance(cl, dict):
+        # TODO: proper dict => level method
+        return CustomLevel(**dict)
+    if isinstance(cl, ComparisonLevelCreator):
+        return cl
+    raise TypeError(
+        f"parameter 'cl' must be a `ComparisonLevelCreator` or `dict`, "
+        f"but is of type {type(cl)} [{cl}]"
+    )
 
 
 class _Merge(ComparisonLevelCreator):
@@ -14,7 +29,10 @@ class _Merge(ComparisonLevelCreator):
         num_levels = len(comparison_levels)
         if num_levels == 0:
             raise ValueError(f"Must provide at least one level to {type(self)}()")
-        self.comparison_levels = comparison_levels
+        self.comparison_levels = [
+            _ensure_is_comparison_level_creator(cl)
+            for cl in comparison_levels
+        ]
         self.is_null_level = all(cl.is_null_level for cl in comparison_levels)
 
     @final
@@ -40,7 +58,7 @@ class Or(_Merge):
 
 class Not(ComparisonLevelCreator):
     def __init__(self, comparison_level: Union[ComparisonLevelCreator, dict]):
-        self.comparison_level = comparison_level
+        self.comparison_level = _ensure_is_comparison_level_creator(comparison_level)
         # turn null levels into non-null levels, otherwise do nothing
         if comparison_level.is_null_level:
             self.is_null_level = False

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 from sqlglot import parse_one
 
-from .comparison_level_composition import And, Not, Or
+from .comparison_level_composition import And, Not, Or  # NOQA: F401
 from .comparison_level_creator import ComparisonLevelCreator
 from .comparison_level_sql import great_circle_distance_km_sql
 from .dialects import SplinkDialect

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -2,6 +2,7 @@ from typing import List, Union
 
 from sqlglot import TokenError, parse_one
 
+# import composition functions for export
 from .comparison_level_composition import And, Not, Or  # NOQA: F401
 from .comparison_level_creator import ComparisonLevelCreator
 from .comparison_level_sql import great_circle_distance_km_sql

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -2,6 +2,7 @@ from typing import List, Union
 
 from sqlglot import parse_one
 
+from .comparison_level_composition import And, Not, Or
 from .comparison_level_creator import ComparisonLevelCreator
 from .comparison_level_sql import great_circle_distance_km_sql
 from .dialects import SplinkDialect


### PR DESCRIPTION
And, Or, Not for `ComparisonLevelCreator`s for Splink 4.

Implemented using subclasses much like in `comparison_level_library` as that felt like a natural fit, and requires very little code. Have renamed accordingly to `And`, `Or`, and `Not`.

Still to do:
- [x] handle `dict`-based comparison levels - will build on #1768 
- [x] restore revised docstrings

Any feedback in meantime welcome