### PR TITLE
Fix brl comp test

### DIFF
--- a/splink/blocking_rule_composition.py
+++ b/splink/blocking_rule_composition.py
@@ -283,7 +283,7 @@ def not_(*brls: BlockingRule | dict | str, salting_partitions: int = 1) -> Block
             SQL condition
     """
     if len(brls) == 0:
-        raise ValueError("You must provide at least one BlockingRule")
+        raise TypeError("You must provide at least one BlockingRule")
     elif len(brls) > 1:
         warnings.warning(
             "More than one BlockingRule entered for `NOT` composition. "

--- a/tests/test_blocking_rule_composition.py
+++ b/tests/test_blocking_rule_composition.py
@@ -62,10 +62,10 @@ def test_binary_composition_internals_AND(test_helpers, dialect):
 
 
 def test_not():
-    import splink.duckdb.duckdb_comparison_level_library as brl
+    import splink.duckdb.blocking_rule_library as brl
 
-    # Integration test for a simple dictionary cl
-    dob_jan_first = {"sql_condition": "SUBSTR(dob_std_l, -5) = '01-01'"}
+    # Integration test for a simple dictionary blocking rule
+    dob_jan_first = {"blocking_rule": "SUBSTR(dob_std_l, -5) = '01-01'"}
     brl.not_(dob_jan_first)
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Blocking rule test was using comparison levels instead of blocking rules.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
Fixed test to use blocking rule in place of comparison level.

Also changed the error type given when `brl.not_` has no arguments - `TypeError` is usually what we have when an incorrect number of arguments is passed.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


