### PR TITLE
Reinstate import change

### DIFF
--- a/splink/cluster_metrics.py
+++ b/splink/cluster_metrics.py
@@ -1,7 +1,4 @@
-from splink.unique_id_concat import (
-    _composite_unique_id_from_edges_sql,
-    _composite_unique_id_from_nodes_sql,
-)
+from splink.splink_dataframe import SplinkDataFrame
 
 
 def _size_density_sql(


### PR DESCRIPTION
The merge of #1787 accidentally undid a change from #1763 - this reinstates it.

See [current file on `master`](https://github.com/moj-analytical-services/splink/blob/master/splink/cluster_metrics.py#L1-L4).