### PR TITLE
Custom charts label for levels

### DIFF
--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -52,6 +52,7 @@ class ComparisonLevelCreator(ABC):
         tf_adjustment_weight: float = None,
         tf_minimum_u_value: float = None,
         is_null_level: bool = None,
+        label_for_charts: str = None,
     ) -> "ComparisonLevelCreator":
         """
         Configure the comparison level with options which are common to all
@@ -78,6 +79,9 @@ class ComparisonLevelCreator(ABC):
             is_null_level (bool, optional): If true, m and u values will not be
                 estimated and instead the match weight will be zero for this column.
                 Defaults to None, equivalent to False.
+            label_for_charts (str, optional): If provided, a custom label that will
+                be used for this level in any charts. Defaults to None, in which case
+                a default label will be provided.
 
         Returns:
             ComparisonLevelCreator: The instance of the ComparisonLevelCreator class

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -84,11 +84,7 @@ def test_cll_creators_instantiate_levels(dialect):
 
 @mark_with_dialects_excluding()
 def test_cll_creators_instantiate_levels_with_config(dialect):
-    lev_dict = (
-        cll.NullLevel("city")
-        .get_comparison_level(dialect)
-        .as_dict()
-    )
+    lev_dict = cll.NullLevel("city").get_comparison_level(dialect).as_dict()
     assert lev_dict["is_null_level"]
 
     lev_dict = (

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -19,7 +19,9 @@ comparison_surname = {
     "comparison_levels": [
         cll.NullLevel("surname"),
         cll.ExactMatchLevel("surname", term_frequency_adjustments=True),
-        cll.LevenshteinLevel("surname", 2),
+        cll.LevenshteinLevel("surname", 2).configure(
+            label_for_charts="surname Levenshtein under 2"
+        ),
         cll.ElseLevel().configure(m_probability=0.2, u_probability=0.85),
     ],
 }
@@ -78,6 +80,42 @@ def test_cll_creators_instantiate_levels(dialect):
     cll.ElseLevel().get_comparison_level(dialect)
     cll.ExactMatchLevel("city").get_comparison_level(dialect)
     cll.LevenshteinLevel("city", 5).get_comparison_level(dialect)
+
+
+@mark_with_dialects_excluding()
+def test_cll_creators_instantiate_levels_with_config(dialect):
+    lev_dict = (
+        cll.NullLevel("city")
+        .get_comparison_level(dialect)
+        .as_dict()
+    )
+    assert lev_dict["is_null_level"]
+
+    lev_dict = (
+        cll.ElseLevel()
+        .configure(m_probability=0.2, u_probability=0.7)
+        .get_comparison_level(dialect)
+        .as_dict()
+    )
+    assert lev_dict["m_probability"] == 0.2
+    assert lev_dict["u_probability"] == 0.7
+
+    lev_dict = (
+        cll.ExactMatchLevel("city")
+        .configure(tf_adjustment_column="city", tf_adjustment_weight=0.9)
+        .get_comparison_level(dialect)
+        .as_dict()
+    )
+    assert lev_dict["tf_adjustment_column"] == "city"
+    assert lev_dict["tf_adjustment_weight"] == 0.9
+
+    lev_dict = (
+        cll.LevenshteinLevel("city", 5)
+        .configure(label_for_charts="city loose fuzzy match")
+        .get_comparison_level(dialect)
+        .as_dict()
+    )
+    assert lev_dict["label_for_charts"] == "city loose fuzzy match"
 
 
 comparison_name = cl.CustomComparison(


### PR DESCRIPTION
Use `ComparisonLevelCreator.configure()` to allow the setting of custom charts labels for levels. Useful as an option for user, but also:

* to allow internal tidying when dealing with transformed columns (e.g. `lower(substr(col,1,2))` - see #1782)
* potential for features such as #1210

This is just the basic functionality - not dealt with how this is used by `ComparisonCreator` or any other places.

Also added more detail to our Splink4 tests on comparison levels