### PR TITLE
Check for ColumnExpression in TF adjustment column

### DIFF
--- a/splink/column_expression.py
+++ b/splink/column_expression.py
@@ -222,3 +222,7 @@ class ColumnExpression:
             return "transformed " + self.raw_sql_expression
         else:
             return self.raw_sql_expression
+
+    def __repr__(self):
+        # TODO: need to include transform info, but guard for case of no dialect
+        return f"ColumnExpression(sql_expression='{self.raw_sql_expression}')"

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -14,6 +14,7 @@ from sqlglot.optimizer.simplify import simplify
 
 from .constants import LEVEL_NOT_OBSERVED_TEXT
 from .default_from_jsonschema import default_value_from_schema
+from .exceptions import SplinkException
 from .input_column import InputColumn
 from .misc import (
     dedupe_preserving_order,
@@ -196,7 +197,21 @@ class ComparisonLevel:
     def _tf_adjustment_input_column(self):
         val = self._level_dict_val_else_default("tf_adjustment_column")
         if val:
-            return InputColumn(val, sql_dialect=self.sql_dialect)
+            # if we have a string, as happens when we are coming from .as_dict(),
+            # then we do not need to worry
+            if isinstance(val, str):
+                val_str = val
+            # otherwise we have a ColumnExpression. Make sure there are no transforms
+            # on it, otherwise a no-no as a tf column
+            elif not val.is_pure_column_or_column_reference:
+                raise SplinkException(
+                    "`tf_adjustment_column` must have a pure column or "
+                    "column reference, but found ColumnExpression: "
+                    f"{val}."
+                )
+            else:
+                val_str = val.name
+            return InputColumn(val_str, sql_dialect=self.sql_dialect)
         else:
             return None
 


### PR DESCRIPTION
`ComparisonLevel._tf_adjustment_input_column` fetches the value `tf_adjustment_column` from the level dict, if it exists.

With the changes of #1782 this will _usually_ be a `ColumnExpression`, but will be a string if for instance we have gone via `.as_dict()`.

As we are feeding into an `InputColumn` we coerce to a string to construct that, but throw an error if we are using a transformed column (as they are not allowed for tf columns).

This is not necessarily the best way to do this, but these are the (cherry-picked) changes I have implemented for now in testing branch #1714 -  if there is a more sensible flow then happy to ditch that and merge whatever that is into tests branch instead.
I imagine at some point we will be revising some of the logic in `ComparisonLevel` anyhow.