### PR TITLE
Comparison tf adjustments

### DIFF
--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -27,6 +27,11 @@ class ComparisonCreator(ABC):
         # furnish comparison levels with m and u probabilities as needed
         comparison_levels = self.create_comparison_levels()
 
+        if self.term_frequency_adjustments:
+            for cl in comparison_levels:
+                if cl.is_exact_match_level:
+                    cl.term_frequency_adjustments = True
+
         if self.m_probabilities:
             m_values = self.m_probabilities.copy()
             comparison_levels = [
@@ -88,6 +93,7 @@ class ComparisonCreator(ABC):
     def configure(
         self,
         *,
+        term_frequency_adjustments: bool = False,
         m_probabilities: list[float] = None,
         u_probabilities: list[float] = None,
     ) -> "ComparisonCreator":
@@ -107,12 +113,25 @@ class ComparisonCreator(ABC):
                 # in that order
             )
         Args:
+            term_frequency_adjustments (bool, optional): Whether term frequency
+                adjustments are switched on for this comparison. Only applied
+                to exact match levels. Default: False
             m_probabilities (list, optional): List of m probabilities
             u_probabilities (list, optional): List of u probabilities
         """
+        self.term_frequency_adjustments = term_frequency_adjustments
         self.m_probabilities = m_probabilities
         self.u_probabilities = u_probabilities
         return self
+
+    @property
+    def term_frequency_adjustments(self):
+        return getattr(self, "_term_frequency_adjustments", False)
+
+    @final
+    @term_frequency_adjustments.setter
+    def term_frequency_adjustments(self, term_frequency_adjustments: bool):
+        self._term_frequency_adjustments = term_frequency_adjustments
 
     @final
     @property

--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -105,6 +105,16 @@ class ComparisonLevelCreator(ABC):
     def is_null_level(self, is_null_level: bool):
         self._is_null_level = is_null_level
 
+    @final
+    @property
+    def is_exact_match_level(self) -> bool:
+        return getattr(self, "_is_exact_match_level", False)
+
+    @final
+    @is_exact_match_level.setter
+    def is_exact_match_level(self, is_exact_match_level: bool):
+        self._is_exact_match_level = is_exact_match_level
+
     def __repr__(self) -> str:
         return (
             f"Comparison level generator for {self.create_label_for_charts()}. "

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -149,10 +149,16 @@ class ExactMatchLevel(ComparisonLevelCreator):
                 adjustments to the exact match level. Defaults to False.
 
         """
-        config = {}
-
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
+        self.term_frequency_adjustments = term_frequency_adjustments
         self.is_exact_match_level = True
+
+    @property
+    def term_frequency_adjustments(self):
+        return self.tf_adjustment_column is not None
+
+    @term_frequency_adjustments.setter
+    def term_frequency_adjustments(self, term_frequency_adjustments: bool):
 
         if term_frequency_adjustments:
             if not self.col_expression.is_pure_column_or_column_reference:
@@ -162,12 +168,13 @@ class ExactMatchLevel(ComparisonLevelCreator):
                     "transforms applied to it such as lower(), "
                     "substr() etc."
                 )
-
-            config["tf_adjustment_column"] = col_name
-            config["tf_adjustment_weight"] = 1.0
             # leave tf_minimum_u_value as None
+            self.configure(
+                tf_adjustment_column=self.col_expression,
+                tf_adjustment_weight=1.0,
+            )
 
-        self.configure(**config)
+        # TODO: how to 'turn off'?? configure doesn't currently allow
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         self.col_expression.sql_dialect = sql_dialect

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -170,7 +170,7 @@ class ExactMatchLevel(ComparisonLevelCreator):
                 )
             # leave tf_minimum_u_value as None
             self.configure(
-                tf_adjustment_column=self.col_expression,
+                tf_adjustment_column=self.col_expression.raw_sql_expression,
                 tf_adjustment_weight=1.0,
             )
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -152,6 +152,7 @@ class ExactMatchLevel(ComparisonLevelCreator):
         config = {}
 
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
+        self.is_exact_match_level = True
 
         if term_frequency_adjustments:
             if not self.col_expression.is_pure_column_or_column_reference:

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -172,7 +172,7 @@ class ExactMatchLevel(ComparisonLevelCreator):
             # Since we know that it's a pure column reference it's fine to assign the
             #  raw unescaped value to the dict - it will be processed via `InputColumn` when
             # the dict is read
-            
+
             self.configure(
                 tf_adjustment_column=self.col_expression.raw_sql_expression,
                 tf_adjustment_weight=1.0,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -169,6 +169,10 @@ class ExactMatchLevel(ComparisonLevelCreator):
                     "substr() etc."
                 )
             # leave tf_minimum_u_value as None
+            # Since we know that it's a pure column reference it's fine to assign the
+            #  raw unescaped value to the dict - it will be processed via `InputColumn` when
+            # the dict is read
+            
             self.configure(
                 tf_adjustment_column=self.col_expression.raw_sql_expression,
                 tf_adjustment_weight=1.0,

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -73,18 +73,13 @@ class ExactMatch(ComparisonCreator):
     def __init__(
         self,
         col_name: str,
-        term_frequency_adjustments=False,
     ):
-        self.term_frequency_adjustments = term_frequency_adjustments
         super().__init__(col_name)
 
     def create_comparison_levels(self) -> List[ComparisonLevelCreator]:
         return [
             cll.NullLevel(self.col_expression),
-            cll.ExactMatchLevel(
-                self.col_expression,
-                term_frequency_adjustments=self.term_frequency_adjustments,
-            ),
+            cll.ExactMatchLevel(self.col_expression),
             cll.ElseLevel(),
         ]
 


### PR DESCRIPTION
Term frequency adjustments now available to all `ComparisonCreator`s, via `.configure()`. Correspondingly have removed direct access for `ExactMatch` for consistency.

For a `ComparisonLevelCreator` we can now turn term frequencies on via setting a property (so not just set in the constructor), but currently there is not a (direct) way to turn them off (without manually adjusting the relevant properties one-by-one). We could add a shortcut to this of some kind (either directly changing properties, or refactoring configure), but it is probably a fairly niche need so low priority. Have left a note though, as it could be the kind of thing that crops up again in the future.

Term frequency adjustments are set for any level which has the `is_exact_match_level` property `True`. It uses this, rather than `isinstance(lev, ExactMatchLevel)` to allow this to potentially apply to `CustomLevel` or `And`, where that would be relevant, although for this PR that is not implemented.