### PR TITLE
DistanceInKMAtThresholds Comparison

### DIFF
--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -1,30 +1,31 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Union, final
+from typing import List, Union, final
 
 from .column_expression import ColumnExpression
 from .comparison import Comparison
 from .comparison_level_creator import ComparisonLevelCreator
 from .exceptions import SplinkException
-from .misc import ensure_is_iterable
+from .misc import ensure_is_list
 
 
 class ComparisonCreator(ABC):
     def __init__(
         self,
         col_name_or_names: Union[
-            Iterable[Union[str, ColumnExpression]], Union[str, ColumnExpression]
+            List[Union[str, ColumnExpression]], Union[str, ColumnExpression]
         ] = None,
     ):
         """
         Class to author Comparisons
         Args:
             col_name_or_names (str, ColumnExpression): Input column name(s).
-                Can be a single item or an Iterable.
+                Can be a single item or a list.
         """
         if col_name_or_names is None:
             cols = []
         else:
-            cols = ensure_is_iterable(col_name_or_names)
+            # use list rather than iterable so we don't decompose strings
+            cols = ensure_is_list(col_name_or_names)
         # TODO: would this be nicer as a dict?
         self.col_expressions = list(
             map(

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -25,7 +25,7 @@ class ComparisonCreator(ABC):
             cols = []
         else:
             cols = ensure_is_iterable(col_name_or_names)
-        # TODO: would this be nicer as a dict?
+        # TODO: would this be nicer as a dict?
         self.col_expressions = list(
             map(
                 ColumnExpression.instantiate_if_str,

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -25,6 +25,7 @@ class ComparisonCreator(ABC):
             cols = []
         else:
             cols = ensure_is_iterable(col_name_or_names)
+        # TODO: would this be nicer as a dict?
         self.col_expressions = list(
             map(
                 ColumnExpression.instantiate_if_str,

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -1,21 +1,53 @@
 from abc import ABC, abstractmethod
-from typing import List, Union, final
+from typing import Iterable, List, Union, final
 
 from .column_expression import ColumnExpression
 from .comparison import Comparison
 from .comparison_level_creator import ComparisonLevelCreator
+from .exceptions import SplinkException
+from .misc import ensure_is_iterable
 
 
 class ComparisonCreator(ABC):
-    # TODO: need to think about what this is used for - do we need multiple columns
-    # if we are sticking with storing a col_name ?
-    def __init__(self, col_name: Union[str, ColumnExpression] = None):
+    def __init__(
+        self,
+        col_name_or_names: Union[
+            Iterable[Union[str, ColumnExpression]], Union[str, ColumnExpression]
+        ] = None,
+    ):
         """
         Class to author Comparisons
         Args:
-            col_name (str): Input column name
+            col_name_or_names (str, ColumnExpression): Input column name(s).
+                Can be a single item or an Iterable.
         """
-        self.col_expression = ColumnExpression.instantiate_if_str(col_name)
+        if col_name_or_names is None:
+            cols = []
+        else:
+            cols = ensure_is_iterable(col_name_or_names)
+        self.col_expressions = list(
+            map(
+                ColumnExpression.instantiate_if_str,
+                cols,
+            )
+        )
+
+    # many ComparisonCreators have a single column expression, so provide a
+    # convenience property for this case. Error if there are none or many
+    @property
+    def col_expression(self) -> ColumnExpression:
+        num_cols = len(self.col_expressions)
+        if num_cols > 1:
+            raise SplinkException(
+                "Cannot get `ComparisonLevelCreator.col_expression` when "
+                f"`.col_expressions` has more than one element: {type(self)}"
+            )
+        if num_cols == 0:
+            raise SplinkException(
+                "Cannot get `ComparisonLevelCreator.col_expression` when "
+                f"`.col_expressions` has no elements: {type(self)}"
+            )
+        return self.col_expressions[0]
 
     # TODO: property?
     @abstractmethod

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -494,24 +494,23 @@ class DistanceInKMAtThresholds(ComparisonCreator):
         self,
         lat_col: str,
         long_col: str,
-        km_thresholds=[0.1, 1],
+        km_thresholds: Union[Iterable[float], float],
     ):
         """
         A comparison of the latitude, longitude coordinates defined in
         'lat_col' and 'long col' giving the great circle distance between them in km.
 
-        An example of the output with default arguments and km_thresholds = [1, 10]
-        would be
+        An example of the output with km_thresholds = [1, 10] would be:
 
         * The two coordinates are within 1 km of one another
         * The two coordinates are within 10 km of one another
-        * Anything else (i.e. the distance between coordinates lie outside this range)
+        * Anything else (i.e. the distance between coordinates are > 10km apart)
 
         Args:
             lat_col(str): The name of the latitude column to compare.
             long_col(str): The name of the longitude column to compare.
-            km_thresholds (list, optional): The km thresholds for the distance levels.
-                Defaults to [0.1, 1].
+            km_thresholds (iterable[float] | float): The km threshold(s) for the
+                distance levels.
         """
 
         thresholds_as_iterable = ensure_is_iterable(km_thresholds)


### PR DESCRIPTION
This implements a `ComparisonCreator` for `DistanceInKMAtThresholds`.

I have made some adjustments to the base class to allow for the fact that `DistanceInKMAtThresholds` has two associated columns (or column references) - this should also cover use-cases for several of the `comparison_template_library` functions, as well as potentially `CustomComparison` if we end up injecting this info into `Comparison`.

`ComparisonCreator` now has a list attribute `col_expression` which stores all associated `ColumnExpression`s. For ease of use, as single-column comparisons are a common case, the constructor still accepts a single column expression in such cases, and there is a property `.col_expression` that will return the (only) column expression in such cases, or throw an error if there are more than one (or none - currently `CustomComparison` though may make sense to let that do the SQL parsing).
This might be nicer (particularly when it comes to the `ctl` functions) as a dict, rather than a list to make it clearer which elements are being accessed, but as that adds a little layer of complexity on top of what there is already I thought I'd keep this more readable - happy to implement in this PR though if that seems more sensible.

Also implements a basic `DistanceInKMAtThresholds` - have left off `include_exact_match_level` for the time being while we decide about level of interface complexity etc.