### PR TITLE
Remove `ColumnExpression`s from final `level_dict`

### DIFF
--- a/splink/comparison_level_creator.py
+++ b/splink/comparison_level_creator.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from inspect import signature
 from typing import final
 
+from .column_expression import ColumnExpression
 from .comparison_level import ComparisonLevel
 from .dialects import SplinkDialect
 
@@ -38,6 +39,9 @@ class ComparisonLevelCreator(ABC):
 
         for attr in allowed_attrs:
             if (value := getattr(self, attr, None)) is not None:
+                if isinstance(value, ColumnExpression):
+                    value.sql_dialect = sql_dialect
+                    value = value.name
                 level_dict[attr] = value
 
         return level_dict


### PR DESCRIPTION
The changes in #1782 had the unintended side-effect of breaking some of the term-frequency stuff, as the `tf_adjustment_column` could end up as a `ColumnExpression`.

This PR implements the suggestion in [this comment](https://github.com/moj-analytical-services/splink/pull/1810#issuecomment-1867447595) to convert any `ColumnExpression` into strings as we construct the `level_dict` in `ComparisonLevelCreator` (which is what is passed to the key method `get_comparison_level`), ensuring that `ComparisonLevel` only deals with fully-constructed SQL strings rather than our construction-aiding objects.