### PR TITLE
(WIP) Faster duckdb with em salting

### DIFF
--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -369,7 +369,6 @@ def block_using_rules_sqls(linker: Linker):
     if linker._sql_dialect == "duckdb" and not linker._train_u_using_random_sample_mode:
         unioned_sql = f"""
         {unioned_sql}
-        order by 1
         """
 
     sqls.append({"sql": unioned_sql, "output_table_name": "__splink__df_blocked"})

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -239,8 +239,8 @@ class SaltedBlockingRule(BlockingRule):
 
             sqls.append(sql)
 
-        print("union")
-        return " UNION  ".join(sqls)
+        print("union all")
+        return " UNION ALL   ".join(sqls)
 
 
 def _sql_gen_where_condition(link_type, unique_id_cols):

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -239,7 +239,8 @@ class SaltedBlockingRule(BlockingRule):
 
             sqls.append(sql)
 
-        return " UNION ALL ".join(sqls)
+        print("union")
+        return " UNION  ".join(sqls)
 
 
 def _sql_gen_where_condition(link_type, unique_id_cols):

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -34,7 +34,7 @@ class EMTrainingSession:
     def __init__(
         self,
         linker: Linker,
-        blocking_rule_for_training: str,
+        blocking_rule_for_training: BlockingRule,
         fix_u_probabilities: bool = False,
         fix_m_probabilities: bool = False,
         fix_probability_two_random_records_match: bool = False,
@@ -54,10 +54,10 @@ class EMTrainingSession:
         self._settings_obj._training_mode = True
 
         if not isinstance(blocking_rule_for_training, BlockingRule):
-            blocking_rule = BlockingRule(blocking_rule_for_training)
+            blocking_rule_for_training = BlockingRule(blocking_rule_for_training)
 
-        self._settings_obj._blocking_rule_for_training = blocking_rule
-        self._blocking_rule_for_training = blocking_rule
+        self._settings_obj._blocking_rule_for_training = blocking_rule_for_training
+        self._blocking_rule_for_training = blocking_rule_for_training
         self._settings_obj._estimate_without_term_frequencies = (
             estimate_without_term_frequencies
         )
@@ -68,7 +68,7 @@ class EMTrainingSession:
             )
         else:
             self._comparison_levels_to_reverse_blocking_rule = self._original_settings_obj._get_comparison_levels_corresponding_to_training_blocking_rule(  # noqa
-                blocking_rule_for_training
+                blocking_rule_for_training.blocking_rule_sql
             )
 
         self._settings_obj._probability_two_random_records_match = (
@@ -87,7 +87,8 @@ class EMTrainingSession:
         if not comparisons_to_deactivate:
             comparisons_to_deactivate = []
             br_cols = get_columns_used_from_sql(
-                blocking_rule_for_training, self._settings_obj._sql_dialect
+                blocking_rule_for_training.blocking_rule_sql,
+                self._settings_obj._sql_dialect,
             )
             for cc in self._settings_obj.comparisons:
                 cc_cols = cc._input_columns_used_by_case_statement

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -55,7 +55,7 @@ def _proportion_sample_size_link_only(
 def _get_duckdb_salting(max_pairs):
     logged = math.log(max_pairs, 10)
     logged = max(logged - 4, 0)
-    return math.ceil(2.5**logged)
+    return math.ceil(2.5**logged) * 2
 
 
 def estimate_u_values(linker: Linker, max_pairs, seed=None):

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1652,7 +1652,7 @@ class Linker:
         self._initialise_df_concat_with_tf()
 
         # Extract the blocking rule
-        blocking_rule = blocking_rule_to_obj(blocking_rule).blocking_rule_sql
+        blocking_rule = blocking_rule_to_obj(blocking_rule)
 
         if comparisons_to_deactivate:
             # If user provided a string, convert to Comparison object

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -29,6 +29,7 @@ def predict_from_comparison_vectors_sqls(
     sql = f"""
     select {select_cols_expr} {clerical_match_score}
     from __splink__df_comparison_vectors
+    order by 1
     """
 
     sql = {

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -29,7 +29,6 @@ def predict_from_comparison_vectors_sqls(
     sql = f"""
     select {select_cols_expr} {clerical_match_score}
     from __splink__df_comparison_vectors
-    order by 1
     """
 
     sql = {
@@ -66,6 +65,7 @@ def predict_from_comparison_vectors_sqls(
     else:
         threshold_expr = ""
 
+    print("order by 1")
     sql = f"""
     select
     log2({bayes_factor_expr}) as match_weight,
@@ -73,6 +73,7 @@ def predict_from_comparison_vectors_sqls(
     {select_cols_expr} {clerical_match_score}
     from __splink__df_match_weight_parts
     {threshold_expr}
+    order by 1
     """
 
     sql = {

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -65,7 +65,6 @@ def predict_from_comparison_vectors_sqls(
     else:
         threshold_expr = ""
 
-    print("order by 1")
     sql = f"""
     select
     log2({bayes_factor_expr}) as match_weight,
@@ -73,7 +72,6 @@ def predict_from_comparison_vectors_sqls(
     {select_cols_expr} {clerical_match_score}
     from __splink__df_match_weight_parts
     {threshold_expr}
-    order by 1
     """
 
     sql = {
@@ -141,6 +139,7 @@ def predict_from_agreement_pattern_counts_sqls(
         "output_table_name": "__splink__df_predict",
     }
     sqls.append(sql)
+    return sqls
 
     return sqls
 

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -65,6 +65,7 @@ def predict_from_comparison_vectors_sqls(
     else:
         threshold_expr = ""
 
+    print("final order by")
     sql = f"""
     select
     log2({bayes_factor_expr}) as match_weight,
@@ -72,6 +73,7 @@ def predict_from_comparison_vectors_sqls(
     {select_cols_expr} {clerical_match_score}
     from __splink__df_match_weight_parts
     {threshold_expr}
+    order by 1
     """
 
     sql = {


### PR DESCRIPTION
See if we can get fully parallelised EM training in DuckDB

<details>
<summary>
test code
</summary>

```python
from IPython.display import display

from splink.datasets import splink_datasets
from splink.duckdb.blocking_rule_library import block_on
from splink.duckdb.comparison_library import (
    exact_match,
    levenshtein_at_thresholds,
)
from splink.duckdb.linker import DuckDBLinker

df = splink_datasets.historical_50k
df.head()

settings = {
    "probability_two_random_records_match": 0.01,
    "link_type": "dedupe_only",
    "blocking_rules_to_generate_predictions": [
        block_on(["first_name"]),
        block_on(["surname"]),
    ],
    "comparisons": [
        levenshtein_at_thresholds("first_name", 2),
        exact_match("surname"),
        exact_match("dob"),
        exact_match("birth_place"),
        exact_match("postcode_fake"),
    ],
    "retain_intermediate_calculation_columns": True,
    "max_iterations": 10,
    "em_convergence": 0.01,
}


linker = DuckDBLinker(df, settings)

br = block_on("first_name", salting_partitions=10)

linker.estimate_parameters_using_expectation_maximisation(br)
linker.parameter_estimate_comparisons_chart()

linker = DuckDBLinker(df, settings)

br = block_on("first_name", salting_partitions=10)

linker.estimate_parameters_using_expectation_maximisation(br)
display(linker.parameter_estimate_comparisons_chart())

linker = DuckDBLinker(df, settings)

br = block_on("first_name", salting_partitions=5)

linker.estimate_parameters_using_expectation_maximisation(br)
display(linker.parameter_estimate_comparisons_chart())


linker = DuckDBLinker(df, settings)

br = block_on("first_name")

linker.estimate_parameters_using_expectation_maximisation(br)
display(linker.parameter_estimate_comparisons_chart())
```

</details>