### PR TITLE
Fix linting workflows

### DIFF
--- a/.github/workflows/auto_update_script_contents.yml
+++ b/.github/workflows/auto_update_script_contents.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -1,5 +1,9 @@
 name: autoblack
 on: [pull_request]
+
+env:
+  PYTHON_VERSION: "3.12.1"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,10 +13,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Load cached Poetry installation
         uses: actions/cache@v2
@@ -22,6 +26,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,20 +1,19 @@
 name: Lint
 on: [pull_request]
 
+env:
+  PYTHON_VERSION: "3.12.1"
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Load cached Poetry installation
         uses: actions/cache@v2
@@ -24,6 +23,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/pytest_benchmark_comment.yml
+++ b/.github/workflows/pytest_benchmark_comment.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/pytest_benchmark_commit.yml
+++ b/.github/workflows/pytest_benchmark_commit.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/run_demos_examples.yml
+++ b/.github/workflows/run_demos_examples.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/run_demos_tutorials.yml
+++ b/.github/workflows/run_demos_tutorials.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: '1.7.0'
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
The `autoblack` and `linting` workflows have recently stopped working (see e.g. [this job run](https://github.com/moj-analytical-services/splink/actions/runs/7492588050/job/20396421367)) with error `/home/runner/.local/venv/bin/python: error while loading shared libraries: libpython3.9.so.1.0: cannot open shared object file: No such file or directory`, which is some sort of virtual env error.

I don't know what change triggered this error (as neither poetry nor the install-poetry action have had any new releases), but it seems going from latest poetry (1.7.1), the default, to 1.7.0 fixes things, so have pinned that version for all workflows without a version pinned.