### PR TITLE
Fix Spark Datediff

### DIFF
--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -163,6 +163,35 @@ class SparkDialect(SplinkDialect):
     def default_date_format(self):
         return "yyyy-MM-dd"
 
+    def date_diff(self, clc: "ComparisonLevelCreator"):
+        # need custom solution as sqlglot gets confused by 'metric', as in Spark
+        # datediff _only_ works in days
+        clc.col_expression.sql_dialect = self
+        col = clc.col_expression
+        datediff_args = f"{col.name_l}, {col.name_r}"
+
+        if clc.date_metric == "day":
+            date_f = f"""
+                abs(
+                    datediff(
+                        {datediff_args}
+                    )
+                )
+            """
+        elif clc.date_metric in ["month", "year"]:
+            date_f = f"""
+                floor(abs(
+                    months_between(
+                        {datediff_args}
+                    )"""
+            if clc.date_metric == "year":
+                date_f += " / 12))"
+            else:
+                date_f += "))"
+        return f"""
+            {date_f} <= {clc.date_threshold}
+        """
+
     def try_parse_date(self, name: str, date_format: str = None):
         if date_format is None:
             date_format = self.default_date_format


### PR DESCRIPTION
Spark SQL returns datediff only in days, so our sqlglot transpilation gets confused when we specify a metric, ending up with invalid expressions like: `ABS(DATEDIFF(day, to_date(`dob_r`, 'yyyy-MM-dd'), to_date(`dob_l`, 'yyyy-MM-dd'))) <= 30`.

This implements a custom datediff function in `SparkDialect` to be used by the `DatediffLevel`, so that we avoid the `sqlglot` issue.
The function uses the same logic as we currently have in Splink 3 - the only difference is I changed `ceil` to `floor` to be (more) consistent with the approach in postgres. Will possibly be changing approach anyhow (see #1838) so not too worried about the details here for the moment.