### PR TITLE
Comparison Creator - col_expressions as dict

### DIFF
--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -13,7 +13,6 @@ class ComparisonCreator(ABC):
         self,
         col_name_or_names: Union[
             List[Union[str, ColumnExpression]], Union[str, ColumnExpression]
-        ] = None,
     ):
         """
         Class to author Comparisons

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -471,9 +471,6 @@ class DistanceInKMLevel(ComparisonLevelCreator):
         self.not_null = not_null
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        ColumnExpression.instantiate_if_str(self.lat_col, splink_dialect=sql_dialect)
-        ColumnExpression.instantiate_if_str(self.long_col, splink_dialect=sql_dialect)
-
         self.lat_col_expression.sql_dialect = sql_dialect
         lat_col = self.lat_col_expression
 

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -518,11 +518,16 @@ class DistanceInKMAtThresholds(ComparisonCreator):
 
         thresholds_as_iterable = ensure_is_iterable(km_thresholds)
         self.thresholds = [*thresholds_as_iterable]
-        super().__init__(col_name_or_names=[lat_col, long_col])
+        super().__init__(
+            col_name_or_names={
+                "latitude_column": lat_col,
+                "longitude_column": long_col,
+            }
+        )
 
     def create_comparison_levels(self) -> List[ComparisonLevelCreator]:
-        lat_col = self.col_expressions[0]
-        long_col = self.col_expressions[1]
+        lat_col = self.col_expressions["latitude_column"]
+        long_col = self.col_expressions["longitude_column"]
         return [
             cll.Or(cll.NullLevel(lat_col), cll.NullLevel(long_col)),
             *[
@@ -541,6 +546,6 @@ class DistanceInKMAtThresholds(ComparisonCreator):
         )
 
     def create_output_column_name(self) -> str:
-        lat_col = self.col_expressions[0]
-        long_col = self.col_expressions[1]
+        lat_col = self.col_expressions["latitude_column"]
+        long_col = self.col_expressions["longitude_column"]
         return f"{lat_col.output_column_name}_{long_col.output_column_name}"

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -29,6 +29,9 @@ class CustomComparison(ComparisonCreator):
         self._output_column_name = output_column_name
         self._comparison_levels = comparison_levels
         self._description = description
+        # we deliberately don't call super().__init__() - all that does is set up
+        # column expressions, which we do not need here as we are dealing with
+        # levels directly
 
     @staticmethod
     def _convert_to_creator(cl: Union[ComparisonLevelCreator, dict]):


### PR DESCRIPTION
As mentioned in [the PR that furnished ComparisonCreator with multiple column expressions](https://github.com/moj-analytical-services/splink/pull/1815) it is a bit nicer to have `ComparisonCreator.col_expressions` exist as a dict rather than a list, so that we can write:

```py
lat_col = self.col_expressions["latitude_column"]
long_col = self.col_expressions["longitude_column"]
```
instead of
```py
lat_col = self.col_expressions[0]
long_col = self.col_expressions[1]
```
which should make reliant code more readable.

I have also stopped `ComparisonCreator`'s `__init__` arg being optional - I think only `CustomComparison` made use of the `None` option (and is the only one that _should_), but can restore if there are other potential use-cases I've not envisaged.