### PR TITLE
Fix distance in km bug

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -471,9 +471,6 @@ class DistanceInKMLevel(ComparisonLevelCreator):
         self.not_null = not_null
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
-        ColumnExpression.instantiate_if_str(self.lat_col, splink_dialect=sql_dialect)
-        ColumnExpression.instantiate_if_str(self.long_col, splink_dialect=sql_dialect)
-
         self.lat_col_expression.sql_dialect = sql_dialect
         lat_col = self.lat_col_expression
 


### PR DESCRIPTION
Fixes a bug with some code that doesn't seem to do anything

<details>
<summary>
Reprex
</summary>

```python
import logging

import splink.comparison_level_library as cll
import splink.comparison_library as cl
from splink.column_expression import ColumnExpression
from splink.datasets import splink_datasets
from splink.duckdb.linker import DuckDBLinker

ce = ColumnExpression("first_name").regex_extract(r"^[ABCDabcd].{1}", 1)
comparison_first_name = cl.ExactMatch(ce)
comparison_surname = cl.ExactMatch("surname")
comparison_dist = cl.DistanceInKMAtThresholds("lat", "lng", [1.0])

comparison_dist.col_expressions['latitude_column']

cl_settings = {
    "link_type": "dedupe_only",
    "comparisons": [comparison_first_name, comparison_surname, comparison_dist],
    "retain_matching_columns": True,
    "retain_intermediate_calculation_columns": True,
}


df = splink_datasets.fake_1000
df["lat"] = 34
df["lng"] = 34


linker = DuckDBLinker(df, cl_settings)

logging.getLogger("splink").setLevel(1)

linker.predict().as_pandas_dataframe()

```

</details>

results in
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[~/Documents/data_linking/splink_311/try_sandbox.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/try_sandbox.py) in <cell line: 0>()
     [20](file:///Users/robinlinacre/Documents/data_linking/splink_311/try_sandbox.py?line=19) df["lat"] = 34
     [21](file:///Users/robinlinacre/Documents/data_linking/splink_311/try_sandbox.py?line=20) df["lng"] = 34
---> [22](file:///Users/robinlinacre/Documents/data_linking/splink_311/try_sandbox.py?line=21) linker = DuckDBLinker(df, cl_settings)
     [23](file:///Users/robinlinacre/Documents/data_linking/splink_311/try_sandbox.py?line=22) logging.getLogger("splink").setLevel(1)
     [24](file:///Users/robinlinacre/Documents/data_linking/splink_311/try_sandbox.py?line=23) linker.predict().as_pandas_dataframe()

[~/Documents/data_linking/splink_311/splink/duckdb/linker.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/duckdb/linker.py) in __init__(self, input_table_or_tables, settings_dict, connection, set_up_basic_logging, output_schema, input_table_aliases, validate_settings)
    178             pass
    179 
--> 180         super().__init__(
    181             input_tables,
    182             settings_dict,

[~/Documents/data_linking/splink_311/splink/linker.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/linker.py) in __init__(self, input_table_or_tables, settings_dict, accepted_df_dtypes, set_up_basic_logging, input_table_aliases, validate_settings)
    233             # for now we instantiate all the correct types before the validator sees it
    234             settings_dict = deepcopy(settings_dict)
--> 235             self._instantiate_comparison_levels(settings_dict)
    236             self._validate_settings_components(settings_dict)
    237             self._setup_settings_objs(settings_dict)

[~/Documents/data_linking/splink_311/splink/linker.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/linker.py) in _instantiate_comparison_levels(self, settings_dict)
    559                         comparison_levels[idx_cl] = level.get_comparison_level(dialect)
    560             elif isinstance(comparison, ComparisonCreator):
--> 561                 comparisons[idx_c] = comparison.get_comparison(dialect)
    562 
    563     def _initialise_df_concat(self, materialise=False):

[~/Documents/data_linking/splink_311/splink/comparison_creator.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/comparison_creator.py) in get_comparison(self, sql_dialect_str)
    110         """sql_dialect_str is a string to make this method easier to use
    111         for the end user - otherwise they'd need to import a SplinkDialect"""
--> 112         return Comparison(self.create_comparison_dict(sql_dialect_str))
    113 
    114     @final

[~/Documents/data_linking/splink_311/splink/comparison_creator.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/comparison_creator.py) in create_comparison_dict(self, sql_dialect_str)
    117             "comparison_description": self.create_description(),
    118             "output_column_name": self.create_output_column_name(),
--> 119             "comparison_levels": [
    120                 cl.get_comparison_level(sql_dialect_str)
    121                 for cl in self.get_configured_comparison_levels()

[~/Documents/data_linking/splink_311/splink/comparison_creator.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/comparison_creator.py) in <listcomp>(.0)
    118             "output_column_name": self.create_output_column_name(),
    119             "comparison_levels": [
--> 120                 cl.get_comparison_level(sql_dialect_str)
    121                 for cl in self.get_configured_comparison_levels()
    122             ],

[~/Documents/data_linking/splink_311/splink/comparison_level_creator.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/comparison_level_creator.py) in get_comparison_level(self, sql_dialect_str)
     23         sql_dialect = SplinkDialect.from_string(sql_dialect_str)
     24         return ComparisonLevel(
---> 25             self.create_level_dict(sql_dialect_str),
     26             sql_dialect=sql_dialect.sqlglot_name,
     27         )

[~/Documents/data_linking/splink_311/splink/comparison_level_creator.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/comparison_level_creator.py) in create_level_dict(self, sql_dialect_str)
     31         sql_dialect = SplinkDialect.from_string(sql_dialect_str)
     32         level_dict = {
---> 33             "sql_condition": self.create_sql(sql_dialect),
     34             "label_for_charts": self.create_label_for_charts(),
     35         }

[~/Documents/data_linking/splink_311/splink/comparison_level_library.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_311/~/Documents/data_linking/splink_311/splink/comparison_level_library.py) in create_sql(self, sql_dialect)
    472 
    473     def create_sql(self, sql_dialect: SplinkDialect) -> str:
--> 474         ColumnExpression.instantiate_if_str(self.lat_col, splink_dialect=sql_dialect)
    475         ColumnExpression.instantiate_if_str(self.long_col, splink_dialect=sql_dialect)
    476 

AttributeError: 'DistanceInKMLevel' object has no attribute 'lat_col'
```
