### PR TITLE
Splink4 - comparison template library

### DIFF
--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -181,8 +181,8 @@ class ExactMatchLevel(ComparisonLevelCreator):
                 )
             # leave tf_minimum_u_value as None
             # Since we know that it's a pure column reference it's fine to assign the
-            #  raw unescaped value to the dict - it will be processed via `InputColumn` when
-            # the dict is read
+            # raw unescaped value to the dict - it will be processed via `InputColumn`
+            # when the dict is read
 
             self.configure(
                 tf_adjustment_column=self.col_expression.raw_sql_expression,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -277,7 +277,7 @@ class DamerauLevenshteinLevel(ComparisonLevelCreator):
         dm_lev_fn = sql_dialect.damerau_levenshtein_function_name
         return f"{dm_lev_fn}({col.name_l}, {col.name_r}) <= {self.distance_threshold}"
 
-    def create_label_for_charts(self, sql_dialect: SplinkDialect) -> str:
+    def create_label_for_charts(self) -> str:
         return (
             f"Damerau-Levenshtein distance of {self.col_expression.label} "
             f"<= {self.distance_threshold}"

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -247,18 +247,19 @@ comparison_email_ctl = ctl.EmailComparison(
     fuzzy_thresholds=[1, 3],
 )
 comparison_name_ctl = ctl.NameComparison(
-    "forename",
+    "first_name",
     include_exact_match_level=False,
     phonetic_col_name="surname",  # ignore the fact this is nonsense
     fuzzy_metric="levenshtein",
     fuzzy_thresholds=[1, 2]
 )
 comparison_dob_ctl = ctl.DateComparison(
-    "dob",
+    ColumnExpression("dob").try_parse_date(),
     invalid_dates_as_null=True,
+    fuzzy_metric="levenshtein",
 )
 comparison_forenamesurname_ctl = ctl.ForenameSurnameComparison(
-    "forename", "surname",
+    "first_name", "surname",
     fuzzy_metric="levenshtein", fuzzy_thresholds=[2]
 )
 ctl_settings = cl_settings

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -246,15 +246,30 @@ comparison_email_ctl = ctl.EmailComparison(
     fuzzy_metric="levenshtein",
     fuzzy_thresholds=[1, 3],
 )
+comparison_name_ctl = ctl.NameComparison(
+    "forename",
+    include_exact_match_level=False,
+    phonetic_col_name="surname",  # ignore the fact this is nonsense
+    fuzzy_metric="levenshtein",
+    fuzzy_thresholds=[1, 2]
+)
+comparison_dob_ctl = ctl.DateComparison(
+    "dob",
+    invalid_dates_as_null=True,
+)
+comparison_forenamesurname_ctl = ctl.ForenameSurnameComparison(
+    "forename", "surname",
+    fuzzy_metric="levenshtein", fuzzy_thresholds=[2]
+)
 ctl_settings = cl_settings
 ctl_settings = {
     "link_type": "dedupe_only",
     "comparisons": [
-        # TODO: replace cl only with ctl
-        comparison_name,
-        comparison_city,
+        comparison_name_ctl,
+        # obviously not realistic:
+        comparison_forenamesurname_ctl,
         comparison_email_ctl,
-        comparison_dob,
+        comparison_dob_ctl,
     ],
     "blocking_rules_to_generate_predictions": [
         "l.dob = r.dob",

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -251,7 +251,7 @@ comparison_name_ctl = ctl.NameComparison(
     include_exact_match_level=False,
     phonetic_col_name="surname",  # ignore the fact this is nonsense
     fuzzy_metric="levenshtein",
-    fuzzy_thresholds=[1, 2]
+    fuzzy_thresholds=[1, 2],
 )
 comparison_dob_ctl = ctl.DateComparison(
     ColumnExpression("dob").try_parse_date(),
@@ -259,8 +259,7 @@ comparison_dob_ctl = ctl.DateComparison(
     fuzzy_metric="levenshtein",
 )
 comparison_forenamesurname_ctl = ctl.ForenameSurnameComparison(
-    "first_name", "surname",
-    fuzzy_metric="levenshtein", fuzzy_thresholds=[2]
+    "first_name", "surname", fuzzy_metric="levenshtein", fuzzy_thresholds=[2]
 )
 ctl_settings = cl_settings
 ctl_settings = {

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -5,9 +5,8 @@ import pytest
 
 import splink.comparison_level_library as cll
 import splink.comparison_library as cl
-from splink.column_expression import ColumnExpression
 import splink.comparison_template_library as ctl
-
+from splink.column_expression import ColumnExpression
 
 from .decorator import mark_with_dialects_excluding
 

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -244,7 +244,7 @@ comparison_email_ctl = ctl.EmailComparison(
     invalid_emails_as_null=True,
     include_domain_match_level=True,
     fuzzy_metric="levenshtein",
-    thresholds=[1, 3],
+    fuzzy_thresholds=[1, 3],
 )
 ctl_settings = cl_settings
 ctl_settings = {


### PR DESCRIPTION
Following on from #1840 this implements the remaining `comparison_template_library` functions to Splink 4. Namely:
* `DateComparison`
* `NameComparison`
* `ForenameSurnameComparison`
* `PostcodeComparison`

I have adjusted the interface + method of doing things to align with how it is done with `EmailComparison`. Again, this is not set in stone, but wanted to keep things fairly consistent, and get a reasonable working version before adjusting the logic significantly (and potentially simplifying functionality further).

A couple of output differences:
* `NameComparison` has no `damerau_levenshtein` in defaults, similarly to #1840.
* No tf adjustment on full name in `ForenameSurnameComparison` - implementing this would need a bit of thought to avoid it being inconsistent with remaining codebase
* Different `output_column_name`s

I haven't put loads of thought into this - I imagine we will want to take a proper pass over this module before release, but just to get a working version with more-or-less similar functionality to Splink 3 in.

NB: have realised the `DateComparison` 1st Jan option doesn't work - this will probably require a dedicated `ExactMatchWithLiteralLevel` (or an option for this in `ExactMatchLevel` - either way will fix up in a separate PR)