### PR TITLE
Migrate tests - ctl

### DIFF
--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -350,7 +350,7 @@ def test_forename_surname_comparison_levels(dialect, test_helpers):
             )
 
 
-# postcode_comparison
+# PostcodeComparison
 
 
 @mark_with_dialects_excluding("postgres", "sqlite")
@@ -409,7 +409,7 @@ def test_postcode_comparison_levels(dialect, test_helpers, test_gamma_assert):
     settings = {
         "link_type": "dedupe_only",
         "comparisons": [
-            ctl.postcode_comparison(
+            ctl.PostcodeComparison(
                 col_name=col_name,
                 lat_col="lat",
                 long_col="long",

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -84,7 +84,9 @@ def test_datediff_levels(dialect, test_helpers, test_gamma_assert):
         "comparisons": [
             ctl.DateComparison(
                 # TODO: revert to default damerau_levenshtein metric
-                ColumnExpression("dob").try_parse_date(), fuzzy_metric="levenshtein", fuzzy_thresholds=[2]
+                ColumnExpression("dob").try_parse_date(),
+                fuzzy_metric="levenshtein",
+                fuzzy_thresholds=[2],
             )
         ],
     }
@@ -216,29 +218,24 @@ def test_name_comparison_levels(dialect, test_helpers):
     linker_output = linker.predict().as_pandas_dataframe()
 
     # # Dict key: {gamma_level value: size}
-    size_gamma_lookup = {0: 6, 1: 4, 2: 0, 3: 2, 4: 2, 5: 1}
-    # 5: exact_match
-    # 4: dmetaphone exact match
-    # 3: damerau_levenshtein <= 1
+    size_gamma_lookup = {0: 6, 1: 6, 2: 0, 3: 2, 4: 1}
+    # 4: exact_match
+    # 3: dmetaphone exact match
     # 2: jaro_winkler > 0.9
     # 1: jaro_winkler > 0.8
     # 0: else
 
     # Check gamma sizes are as expected
     for gamma, expected_size in size_gamma_lookup.items():
-        assert (
-            sum(linker_output["gamma_custom_first_name_first_name_metaphone"] == gamma)
-            == expected_size
-        )
+        assert sum(linker_output["gamma_first_name"] == gamma) == expected_size
 
     # Check individual IDs are assigned to the correct gamma values
     # Dict key: {gamma_value: tuple of ID pairs}
     size_gamma_lookup = {
-        5: [[1, 6]],
-        4: [(2, 3), (4, 5)],
-        3: [(4, 6)],
+        4: [[1, 6]],
+        3: [(2, 3), (4, 5)],
         2: [],
-        1: [(1, 2), (2, 6)],
+        1: [(1, 2), (2, 6), (4, 6)],
         0: [(2, 4), (5, 6)],
     }
 
@@ -248,7 +245,7 @@ def test_name_comparison_levels(dialect, test_helpers):
                 linker_output.loc[
                     (linker_output.unique_id_l == left)
                     & (linker_output.unique_id_r == right)
-                ]["gamma_custom_first_name_first_name_metaphone"].values[0]
+                ]["gamma_first_name"].values[0]
                 == gamma
             )
 

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -322,7 +322,7 @@ def test_forename_surname_comparison_levels(dialect, test_helpers):
 
     # Check gamma sizes are as expected
     for gamma, expected_size in size_gamma_lookup.items():
-        gamma_matches = linker_output.filter(like="gamma_custom") == gamma
+        gamma_matches = linker_output.filter(like="gamma_forename_surname") == gamma
         gamma_matches_size = gamma_matches.sum().values[0]
         assert gamma_matches_size == expected_size
 
@@ -344,7 +344,7 @@ def test_forename_surname_comparison_levels(dialect, test_helpers):
                     (linker_output.unique_id_l == left)
                     & (linker_output.unique_id_r == right)
                 ]
-                .filter(like="gamma_custom")
+                .filter(like="gamma_forename_surname")
                 .values[0][0]
                 == gamma
             )


### PR DESCRIPTION
Some small adjustments to tests for compatibility with new `comparison_template_library` functions.

Once #1856 is merged, changes from that can be incorporated into #1714 and this can also be merged in.