### PR TITLE
Comparison validation

### DIFF
--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -32,6 +32,7 @@ class ComparisonCreator(ABC):
             name_reference: ColumnExpression.instantiate_if_str(column)
             for name_reference, column in cols.items()
         }
+        self._validate()
 
     # many ComparisonCreators have a single column expression, so provide a
     # convenience property for this case. Error if there are none or many
@@ -56,6 +57,10 @@ class ComparisonCreator(ABC):
                 f"`.col_expressions` has non-default single entry: {type(self)}"
             ) from None
         return col_expression
+
+    def _validate(self) -> None:
+        # create levels - let them raise errors if there are issues
+        self.create_comparison_levels()
 
     # TODO: property?
     @abstractmethod

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -57,6 +57,7 @@ def validate_numeric_parameter(
             f"{lower_bound} and {upper_bound} for {level_name}"
         )
 
+
 def validate_categorical_parameter(
     allowed_values: List[str],
     parameter_value: str,
@@ -69,8 +70,7 @@ def validate_categorical_parameter(
     else:
         comma_quote_separated_options = "', '".join(allowed_values)
         raise ValueError(
-            f"'{parameter_name}' must be one of: "
-            f"'{comma_quote_separated_options}'"
+            f"'{parameter_name}' must be one of: " f"'{comma_quote_separated_options}'"
         )
 
 
@@ -436,7 +436,7 @@ class DatediffLevel(ComparisonLevelCreator):
             upper_bound=float("inf"),
             parameter_value=date_threshold,
             level_name=self.__class__.__name__,
-            parameter_name="date_threshold"
+            parameter_name="date_threshold",
         )
         self.date_metric = validate_categorical_parameter(
             allowed_values=["day", "month", "year"],

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -36,18 +36,19 @@ def _translate_sql_string(
     return tree.sql(dialect=to_sqlglot_dialect)
 
 
-def validate_distance_threshold(
+def validate_numeric_parameter(
     lower_bound: Union[int, float],
     upper_bound: Union[int, float],
-    distance_threshold: Union[int, float],
+    parameter_value: Union[int, float],
     level_name: str,
+    parameter_name: str = "distance_threshold",
 ) -> Union[int, float]:
     """Check if a distance threshold falls between two bounds."""
-    if lower_bound <= distance_threshold <= upper_bound:
-        return distance_threshold
+    if lower_bound <= parameter_value <= upper_bound:
+        return parameter_value
     else:
         raise ValueError(
-            "'distance_threshold' must be between "
+            f"'{parameter_name}' must be between "
             f"{lower_bound} and {upper_bound} for {level_name}"
         )
 
@@ -301,10 +302,10 @@ class JaroWinklerLevel(ComparisonLevelCreator):
         """
 
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
-        self.distance_threshold = validate_distance_threshold(
+        self.distance_threshold = validate_numeric_parameter(
             lower_bound=0,
             upper_bound=1,
-            distance_threshold=distance_threshold,
+            parameter_value=distance_threshold,
             level_name=self.__class__.__name__,
         )
 
@@ -336,10 +337,10 @@ class JaroLevel(ComparisonLevelCreator):
         """
 
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
-        self.distance_threshold = validate_distance_threshold(
+        self.distance_threshold = validate_numeric_parameter(
             lower_bound=0,
             upper_bound=1,
-            distance_threshold=distance_threshold,
+            parameter_value=distance_threshold,
             level_name=self.__class__.__name__,
         )
 
@@ -371,10 +372,10 @@ class JaccardLevel(ComparisonLevelCreator):
         """
 
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
-        self.distance_threshold = validate_distance_threshold(
+        self.distance_threshold = validate_numeric_parameter(
             lower_bound=0,
             upper_bound=1,
-            distance_threshold=distance_threshold,
+            parameter_value=distance_threshold,
             level_name=self.__class__.__name__,
         )
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -52,6 +52,22 @@ def validate_numeric_parameter(
             f"{lower_bound} and {upper_bound} for {level_name}"
         )
 
+def validate_categorical_parameter(
+    allowed_values: List[str],
+    parameter_value: str,
+    level_name: str,
+    parameter_name: str,
+) -> Union[int, float]:
+    """Check if a distance threshold falls between two bounds."""
+    if parameter_value in allowed_values:
+        return parameter_value
+    else:
+        comma_quote_separated_options = "', '".join(allowed_values)
+        raise ValueError(
+            f"'{parameter_name}' must be one of: "
+            f"'{comma_quote_separated_options}'"
+        )
+
 
 class NullLevel(ComparisonLevelCreator):
     def __init__(
@@ -410,13 +426,18 @@ class DatediffLevel(ComparisonLevelCreator):
             date_format (str): The format of the date string
         """
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
-        self.date_metric = date_metric
         self.date_threshold = validate_numeric_parameter(
             lower_bound=0,
             upper_bound=float("inf"),
             parameter_value=date_threshold,
             level_name=self.__class__.__name__,
             parameter_name="date_threshold"
+        )
+        self.date_metric = validate_categorical_parameter(
+            allowed_values=["day", "month", "year"],
+            parameter_value=date_metric,
+            level_name=self.__class__.__name__,
+            parameter_name="date_metric",
         )
 
     @unsupported_splink_dialects(["sqlite"])

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -410,8 +410,14 @@ class DatediffLevel(ComparisonLevelCreator):
             date_format (str): The format of the date string
         """
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
-        self.date_threshold = date_threshold
         self.date_metric = date_metric
+        self.date_threshold = validate_numeric_parameter(
+            lower_bound=0,
+            upper_bound=float("inf"),
+            parameter_value=date_threshold,
+            level_name=self.__class__.__name__,
+            parameter_name="date_threshold"
+        )
 
     @unsupported_splink_dialects(["sqlite"])
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
@@ -523,7 +529,13 @@ class ArrayIntersectLevel(ComparisonLevelCreator):
         """
 
         self.col_expression = ColumnExpression.instantiate_if_str(col_name)
-        self.min_intersection = min_intersection
+        self.min_intersection = validate_numeric_parameter(
+            lower_bound=0,
+            upper_bound=float("inf"),
+            parameter_value=min_intersection,
+            level_name=self.__class__.__name__,
+            parameter_name="min_intersection",
+        )
 
     @unsupported_splink_dialects(["sqlite"])
     def create_sql(self, sql_dialect: SplinkDialect) -> str:

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -44,6 +44,11 @@ def validate_numeric_parameter(
     parameter_name: str = "distance_threshold",
 ) -> Union[int, float]:
     """Check if a distance threshold falls between two bounds."""
+    if not isinstance(parameter_value, (int, float)):
+        raise TypeError(
+            f"'{parameter_name}' must be numeric, but received type "
+            f"{type(parameter_value)}"
+        )
     if lower_bound <= parameter_value <= upper_bound:
         return parameter_value
     else:

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -383,6 +383,18 @@ class DatediffAtThresholds(ComparisonCreator):
         date_thresholds_as_iterable = ensure_is_iterable(date_thresholds)
         self.date_thresholds = [*date_thresholds_as_iterable]
 
+        num_metrics = len(self.date_metrics)
+        num_thresholds = len(self.date_thresholds)
+        if num_thresholds == 0:
+            raise ValueError("`date_thresholds` must have at least one entry")
+        if num_metrics == 0:
+            raise ValueError("`date_metrics` must have at least one entry")
+        if num_metrics != num_thresholds:
+            raise ValueError(
+                "`date_thresholds` and `date_metrics` must have "
+                "the same number of entries"
+            )
+
         self.cast_strings_to_dates = cast_strings_to_dates
         self.date_format = date_format
 

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -51,7 +51,18 @@ class DateComparison(ComparisonCreator):
         self.date_thresholds = [*date_thresholds_as_iterable]
         date_metrics_as_iterable = ensure_is_iterable(datediff_metrics)
         self.date_metrics = [*date_metrics_as_iterable]
-        # TODO: check lengths match!
+
+        num_metrics = len(self.date_metrics)
+        num_thresholds = len(self.date_thresholds)
+        if num_thresholds == 0:
+            raise ValueError("`date_thresholds` must have at least one entry")
+        if num_metrics == 0:
+            raise ValueError("`date_metrics` must have at least one entry")
+        if num_metrics != num_thresholds:
+            raise ValueError(
+                "`date_thresholds` and `date_metrics` must have "
+                "the same number of entries"
+            )
 
         self.date_format = date_format
         self.invalid_dates_as_null = invalid_dates_as_null


### PR DESCRIPTION
A few things here:

* previous `distance_threshold` validation generalised to numeric types - also checks type
  * used by `ArrayIntersectLevel` and `DatediffLevel`
* categorical validation - used to validate `date_metric` values
* generic basic validation in `ComparisonCreator.__init__` by instantiating levels so we can re-use level validation
  * don't store them, as there's no real cost. Possible argument for creating them once here (and maybe other attributes) rather than having it be a method, but don't need to decide that here
* higher-level validation in `DateComparison` and `DatediffAtThresholds`. Logic is identical, but felt like overkill to separate out for these two cases. If something more generic could be useful can pull out then.