### PR TITLE
Custom Postgres date-casting

### DIFF
--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -97,7 +97,6 @@ class SplinkDialect(ABC):
 
         return nullif_wrapped_function
 
-    @final
     def try_parse_date(self, name: str, date_format: str = None):
         return self._wrap_in_nullif(self._try_parse_date_raw)(name, date_format)
 
@@ -311,10 +310,10 @@ class PostgresDialect(SplinkDialect):
     def default_date_format(self):
         return "YYYY-MM-DD"
 
-    def _try_parse_date_raw(self, name: str, date_format: str = None):
+    def try_parse_date(self, name: str, date_format: str = None):
         if date_format is None:
             date_format = self.default_date_format
-        return f"""to_date({name}, '{date_format}')"""
+        return f"""try_cast_date({name}, '{date_format}')"""
 
     def array_intersect(self, clc: "ComparisonLevelCreator"):
         clc.col_expression.sql_dialect = self


### PR DESCRIPTION
Existing postgres date-casting is not compatible with `nullif`, and gives an error if it fails which means we can't use it as flexibly in comparison levels as would be ideal.

This PR:
* implements a custom postgres udf casting function that returns `NULL` instead of error in case of failure to parse
* uses this in `PostgresDialect.try_parse_date` without `nullif` wrapper