### PR TITLE
Fixes #1872 Update deduplicate_1k_synthetic.ipynb to fix spark error

### DIFF
--- a/docs/demos/examples/spark/deduplicate_1k_synthetic.ipynb
+++ b/docs/demos/examples/spark/deduplicate_1k_synthetic.ipynb
@@ -124,7 +124,7 @@
    ],
    "source": [
     "from splink.spark.linker import SparkLinker\n",
-    "linker = SparkLinker(df, settings)\n",
+    "linker = SparkLinker(df, settings, spark=spark)\n",
     "deterministic_rules = [\n",
     "    \"l.first_name = r.first_name and levenshtein(r.dob, l.dob) <= 1\",\n",
     "    \"l.surname = r.surname and levenshtein(r.dob, l.dob) <= 1\",\n",


### PR DESCRIPTION
Quick fix to error on spark  "AttributeError: 'NoneType' object has no attribute 'sparkContext'"

### Type of PR

- [ x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
closes #1872


### Give a brief description for the solution you have provided
Original error is caused by the linker spark context to be none.  I changed the example to pass the spark context as a parameter.



### PR Checklist

- [ ] Added documentation for changes
- [ x] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


