### PR TITLE
Add SQlite to db api

### DIFF
--- a/splink/database_api.py
+++ b/splink/database_api.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import re
+import sqlite3
 from abc import ABC, abstractmethod
 from itertools import compress
 from tempfile import TemporaryDirectory
@@ -16,7 +17,7 @@ from pyspark.sql.utils import AnalysisException
 
 from .cache_dict_with_logging import CacheDictWithLogging
 from .databricks.enable_splink import enable_splink
-from .dialects import DuckDBDialect, SparkDialect, SplinkDialect
+from .dialects import DuckDBDialect, SparkDialect, SplinkDialect, SqliteDialect
 from .duckdb.duckdb_helpers.duckdb_helpers import (
     create_temporary_duckdb_connection,
     duckdb_load_from_file,
@@ -29,6 +30,7 @@ from .misc import major_minor_version_greater_equal_than
 from .spark.jar_location import get_scala_udfs
 from .spark.linker import SparkDataFrame
 from .splink_dataframe import SplinkDataFrame
+from .sqlite.linker import SQLiteDataFrame
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +208,7 @@ class DatabaseAPI(ABC, Generic[TablishType]):
 
 # alias for brevity:
 ddb_con = duckdb.DuckDBPyConnection
+sql_con = sqlite3.Connection
 
 
 class DuckDBAPI(DatabaseAPI):
@@ -643,3 +646,97 @@ class SparkAPI(DatabaseAPI):
         # specified.
         elif not self.break_lineage_method:
             self.break_lineage_method = "parquet"
+
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+
+class SQLiteAPI(DatabaseAPI):
+    sql_dialect = SqliteDialect()
+
+    @staticmethod
+    def dict_factory(cursor, row):
+        d = {}
+        for idx, col in enumerate(cursor.description):
+            d[col[0]] = row[idx]
+        return d
+
+    def _register_udfs(self, register_udfs: bool):
+        self.con.create_function("log2", 1, math.log2)
+        self.con.create_function("pow", 2, pow)
+        self.con.create_function("power", 2, pow)
+
+        if register_udfs:
+            try:
+                from rapidfuzz.distance.DamerauLevenshtein import distance as dam_lev
+                from rapidfuzz.distance.Jaro import distance as jaro
+                from rapidfuzz.distance.JaroWinkler import distance as jaro_winkler
+                from rapidfuzz.distance.Levenshtein import distance as levenshtein
+            except ModuleNotFoundError as e:
+                raise SplinkException(
+                    "To use fuzzy string-matching udfs in SQLite you must install "
+                    "the python package 'rapidfuzz'.  "
+                    "If you do not wish to do so, and do not need to use any "
+                    "fuzzy string-matching comparisons, you can use the linker argument "
+                    "`register_udfs=False`.\n"
+                    "See https://moj-analytical-services.github.io/splink/"
+                    "topic_guides/backends.html#sqlite for more information"
+                ) from e
+
+        def wrap_func_with_str(func):
+            def wrapped_func(str_l, str_r):
+                return func(str(str_l), str(str_r))
+
+            return wrapped_func
+
+        funcs_to_register = {
+            "levenshtein": levenshtein,
+            "damerau_levenshtein": dam_lev,
+            "jaro_winkler": jaro_winkler,
+            "jaro": jaro,
+        }
+
+        for sql_name, func in funcs_to_register.items():
+            self.con.create_function(sql_name, 2, wrap_func_with_str(func))
+
+    def __init__(
+        self, connection: Union[str, sql_con] = ":memory:", register_udfs=True
+    ):
+        if isinstance(connection, str):
+            connection = sqlite3.connect(connection)
+        self.con = connection
+        self.con.row_factory = self.dict_factory
+        self._register_udfs(register_udfs)
+
+    def _table_registration(self, input, table_name):
+        if isinstance(input, dict):
+            input = pd.DataFrame(input)
+        elif isinstance(input, list):
+            input = pd.DataFrame.from_records(input)
+
+        # Will error if an invalid data type is passed
+        input.to_sql(
+            table_name,
+            self.con,
+            index=False,
+            if_exists="replace",
+        )
+
+    def _table_to_splink_dataframe(self, templated_name, physical_name):
+        return SQLiteDataFrame(templated_name, physical_name, self)
+
+    def _table_exists_in_database(self, table_name):
+        sql = f"PRAGMA table_info('{table_name}');"
+
+        rec = self.con.execute(sql).fetchone()
+        if not rec:
+            return False
+        else:
+            return True
+
+    def _run_sql_execution(self, final_sql: str) -> sqlite3.Cursor:
+        return self.con.sql(final_sql)

--- a/splink/database_api.py
+++ b/splink/database_api.py
@@ -735,4 +735,3 @@ class SQLiteAPI(DatabaseAPI):
 
     def _run_sql_execution(self, final_sql: str) -> sqlite3.Cursor:
         return self.con.execute(final_sql)
-

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -89,6 +89,13 @@ class SplinkDialect(ABC):
             f"Backend '{self.name}' does not have a 'Jaccard' function"
         )
 
+    def random_sample_sql(
+        self, proportion, sample_size, seed=None, table=None, unique_id=None
+    ):
+        raise NotImplementedError(
+            f"Backend '{self.name}' needs a random_sample_sql added to its dialect"
+        )
+
     @staticmethod
     def _wrap_in_nullif(func):
         def nullif_wrapped_function(*args, **kwargs):
@@ -334,6 +341,23 @@ class SqliteDialect(SplinkDialect):
     @property
     def jaro_winkler_function_name(self):
         return "jaro_winkler"
+
+    def random_sample_sql(
+        self, proportion, sample_size, seed=None, table=None, unique_id=None
+    ):
+        if proportion == 1.0:
+            return ""
+        if seed:
+            raise NotImplementedError(
+                "SQLite does not support seeds in random ",
+                "samples. Please remove the `seed` parameter.",
+            )
+
+        sample_size = int(sample_size)
+
+        return f"""ORDER BY RANDOM()
+            LIMIT {sample_size}
+            """
 
 
 class PostgresDialect(SplinkDialect):

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -342,6 +342,10 @@ class SqliteDialect(SplinkDialect):
     def jaro_winkler_function_name(self):
         return "jaro_winkler"
 
+    @property
+    def infinity_expression(self):
+        return "'infinity'"
+
     def random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None
     ):

--- a/splink/sqlite/linker.py
+++ b/splink/sqlite/linker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from math import log2, pow
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
@@ -14,6 +15,8 @@ from ..splink_dataframe import SplinkDataFrame
 from ..unique_id_concat import _composite_unique_id_from_nodes_sql
 
 logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from ..database_api import SQLiteAPI
 
 
 def dict_factory(cursor, row):
@@ -24,14 +27,14 @@ def dict_factory(cursor, row):
 
 
 class SQLiteDataFrame(SplinkDataFrame):
-    linker: SQLiteLinker
+    db_api: SQLiteAPI
 
     @property
     def columns(self) -> list[InputColumn]:
         sql = f"""
         PRAGMA table_info({self.physical_name});
         """
-        pragma_result = self.linker.con.execute(sql).fetchall()
+        pragma_result = self.db_api.con.execute(sql).fetchall()
         cols = [r["name"] for r in pragma_result]
 
         return [InputColumn(c, sql_dialect="sqlite") for c in cols]
@@ -52,7 +55,7 @@ class SQLiteDataFrame(SplinkDataFrame):
         AND name='{self.physical_name}';
         """
 
-        res = self.linker.con.execute(sql).fetchall()
+        res = self.db_api.con.execute(sql).fetchall()
         if len(res) == 0:
             raise ValueError(
                 f"{self.physical_name} does not exist in the sqlite db provided.\n"
@@ -66,7 +69,7 @@ class SQLiteDataFrame(SplinkDataFrame):
 
         drop_sql = f"""
         DROP TABLE IF EXISTS {self.physical_name}"""
-        cur = self.linker.con.cursor()
+        cur = self.db_api.con.cursor()
         cur.execute(drop_sql)
 
     def as_record_dict(self, limit=None):
@@ -77,7 +80,7 @@ class SQLiteDataFrame(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
         sql += ";"
-        cur = self.linker.con.cursor()
+        cur = self.db_api.con.cursor()
         return cur.execute(sql).fetchall()
 
 
@@ -94,17 +97,6 @@ class SQLiteLinker(Linker):
     ):
         self._sql_dialect_ = "sqlite"
 
-        if isinstance(connection, str):
-            connection = sqlite3.connect(connection)
-        self.con = connection
-        self.con.row_factory = dict_factory
-        # maths functions not always available by default depending on system
-        self.con.create_function("log2", 1, log2)
-        self.con.create_function("pow", 2, pow)
-        self.con.create_function("power", 2, pow)
-        if register_udfs:
-            self._register_udfs()
-
         input_tables = ensure_is_list(input_table_or_tables)
         input_aliases = self._ensure_aliases_populated_and_is_list(
             input_table_or_tables, input_table_aliases
@@ -119,140 +111,3 @@ class SQLiteLinker(Linker):
             input_table_aliases=input_aliases,
             validate_settings=validate_settings,
         )
-
-    def _table_to_splink_dataframe(self, templated_name, physical_name):
-        return SQLiteDataFrame(templated_name, physical_name, self)
-
-    def _execute_sql_against_backend(self, sql, templated_name, physical_name):
-        # In the case of a table already existing in the database,
-        # execute sql is only reached if the user has explicitly turned off the cache
-        self._delete_table_from_database(physical_name)
-
-        sql = f"""
-        create table {physical_name}
-        as
-        {sql}
-        """
-        self._log_and_run_sql_execution(sql, templated_name, physical_name)
-
-        output_obj = self._table_to_splink_dataframe(templated_name, physical_name)
-        return output_obj
-
-    def _run_sql_execution(
-        self, final_sql: str, templated_name: str, physical_name: str
-    ) -> SplinkDataFrame:
-        return self.con.execute(final_sql)
-
-    def register_table(self, input, table_name, overwrite=False):
-        # If the user has provided a table name, return it as a SplinkDataframe
-        if isinstance(input, str):
-            return self._table_to_splink_dataframe(table_name, input)
-
-        # Check if table name is already in use
-        exists = self._table_exists_in_database(table_name)
-        if exists:
-            if not overwrite:
-                raise ValueError(
-                    f"Table '{table_name}' already exists in database. "
-                    "Please use the 'overwrite' argument if you wish to overwrite"
-                )
-            else:
-                self._delete_table_from_database(table_name)
-
-        self._table_registration(input, table_name)
-        return self._table_to_splink_dataframe(table_name, table_name)
-
-    def _table_registration(self, input, table_name):
-        if isinstance(input, dict):
-            input = pd.DataFrame(input)
-        elif isinstance(input, list):
-            input = pd.DataFrame.from_records(input)
-
-        # Will error if an invalid data type is passed
-        input.to_sql(
-            table_name,
-            self.con,
-            index=False,
-            if_exists="replace",
-        )
-
-    def _random_sample_sql(
-        self, proportion, sample_size, seed=None, table=None, unique_id=None
-    ):
-        if proportion == 1.0:
-            return ""
-        if seed:
-            raise NotImplementedError(
-                "SQLite does not support seeds in random ",
-                "samples. Please remove the `seed` parameter.",
-            )
-
-        sample_size = int(sample_size)
-
-        if unique_id is None:
-            # unique_id col, with source_dataset column if needed to disambiguate
-            unique_id_cols = self._settings_obj._unique_id_input_columns
-            unique_id = _composite_unique_id_from_nodes_sql(unique_id_cols)
-        if table is None:
-            table = "__splink__df_concat_with_tf"
-        return (
-            f"WHERE {unique_id} IN ("
-            f"    SELECT {unique_id} FROM {table}"
-            f"    ORDER BY RANDOM() LIMIT {sample_size}"
-            f")"
-        )
-
-    @property
-    def _infinity_expression(self):
-        return "'infinity'"
-
-    def _table_exists_in_database(self, table_name):
-        sql = f"PRAGMA table_info('{table_name}');"
-
-        rec = self.con.execute(sql).fetchone()
-        if not rec:
-            return False
-        else:
-            return True
-
-    def _delete_table_from_database(self, name):
-        drop_sql = f"""
-        DROP TABLE IF EXISTS {name}"""
-        self.con.execute(drop_sql)
-
-    def _register_udfs(self):
-        try:
-            from rapidfuzz.distance.DamerauLevenshtein import distance as dam_lev
-            from rapidfuzz.distance.Jaro import distance as jaro
-            from rapidfuzz.distance.JaroWinkler import distance as jaro_winkler
-            from rapidfuzz.distance.Levenshtein import distance as levenshtein
-        except ModuleNotFoundError as e:
-            raise SplinkException(
-                "To use fuzzy string-matching udfs in SQLite you must install "
-                "the python package 'rapidfuzz'.  "
-                "If you do not wish to do so, and do not need to use any "
-                "fuzzy string-matching comparisons, you can use the linker argument "
-                "`register_udfs=False`.\n"
-                "See https://moj-analytical-services.github.io/splink/"
-                "topic_guides/backends.html#sqlite for more information"
-            ) from e
-
-        def wrap_func_with_str(func):
-            def wrapped_func(str_l, str_r):
-                return func(str(str_l), str(str_r))
-
-            return wrapped_func
-
-        # name in SQL : python function
-        funcs_to_register = {
-            "levenshtein": levenshtein,
-            # alias for levenshtein. This is sqlglot recognised, but is in an extension,
-            # so not available natively
-            "editdist3": levenshtein,
-            "damerau_levenshtein": dam_lev,
-            "jaro_winkler": jaro_winkler,
-            "jaro": jaro,
-        }
-
-        for sql_name, func in funcs_to_register.items():
-            self.con.create_function(sql_name, 2, wrap_func_with_str(func))


### PR DESCRIPTION
This was all very straightforward and seems to work

<details>
<summary>
Testing script
</summary>

```python
import splink.comparison_library as cl
from splink.database_api import DuckDBAPI, SparkAPI, SQLiteAPI
from splink.datasets import splink_datasets
from splink.linker import Linker

df = splink_datasets.fake_1000
df.to_parquet("fake_1000.parquet")

settings = {
    "link_type": "dedupe_only",
    "comparisons": [
        cl.LevenshteinAtThresholds("first_name"),
        cl.LevenshteinAtThresholds("surname"),
        cl.ExactMatch("city"),
        cl.ExactMatch("email"),
    ],
}

backend = "sqlite"

if backend == "spark":
    from pyspark import SparkConf, SparkContext
    from pyspark.sql import SparkSession

    from splink.spark.jar_location import similarity_jar_location

    conf = SparkConf()

    conf.set("spark.driver.memory", "6g")
    conf.set("spark.sql.shuffle.partitions", "1")
    conf.set("spark.default.parallelism", "1")
    path = similarity_jar_location()
    conf.set("spark.jars", path)

    sc = SparkContext.getOrCreate(conf=conf)

    spark = SparkSession(sc)
    spark.sparkContext.setCheckpointDir("./tmp_checkpoints")

    from splink.spark.blocking_rule_library import block_on

    db_api = SparkAPI(spark=spark)
elif backend == "duckdb":
    from splink.duckdb.blocking_rule_library import block_on

    db_api = DuckDBAPI()

elif backend == "sqlite":
    from splink.sqlite.blocking_rule_library import block_on

    db_api = SQLiteAPI()

settings["blocking_rules_to_generate_predictions"] = [
    block_on("first_name"),
    block_on("surname"),
]

linker = Linker(df, settings, db_api)


linker.estimate_u_using_random_sampling(max_pairs=1e4)

blocking_rule_for_training = block_on(["first_name", "surname"])

linker.estimate_parameters_using_expectation_maximisation(
    blocking_rule_for_training, estimate_without_term_frequencies=True
)

blocking_rule_for_training = block_on("substr(dob, 1, 4)")  # block on year
linker.estimate_parameters_using_expectation_maximisation(
    blocking_rule_for_training, estimate_without_term_frequencies=True
)


pairwise_predictions = linker.predict()

clusters = linker.cluster_pairwise_predictions_at_threshold(pairwise_predictions, 0.95)
clusters.as_pandas_dataframe(limit=5)




```

</details>

I changed the random sample SQL code so that it no longer needs to know about the unique id column; I think as a result we may be able to drop the argument from the function signature in the dialect class

Apparently the new version is slightly less efficient but i don't think that really matters since the sqlite linker is not really meant for speed

Here's a check that (somewhat) verifies that's a valid approach to random sampling
```
import sqlite3
import pandas as pd

# Create a sample dataset of 100 rows
df = pd.DataFrame({'id': range(1, 101), 'value': range(101, 201)})

# Connect to a SQLite database in memory
conn = sqlite3.connect(':memory:')

# Write the data to a SQLite table
df.to_sql('sample_table', conn, index=False, if_exists='replace')

# Function to select 10 random rows
def select_random_sample(conn):
    query = "SELECT * FROM sample_table ORDER BY RANDOM() LIMIT 10"
    return pd.read_sql_query(query, conn)

# Select random samples twice to check for differences
sample1 = select_random_sample(conn)
sample2 = select_random_sample(conn)

sample1, sample2


```