### PR TITLE
SQLAlchemy 1.x and 2.x compatibility: Use explicit transactions, remove sqlalchemy version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Support `sqlalchemy >= 2.0.0` ([#1908](https://github.com/moj-analytical-services/splink/pull/1908))
+
 ## [3.9.11] - 2024-01-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ awswrangler = [
     {version=">=3.0.0,<4.0.0", python = "^3.8", optional=true}
 ]
 
-# sqlalchemy >= 2.0.0 not working well with older pandas
-sqlalchemy = {version=">=1.4.0,<2.0.0", optional=true}
 psycopg2-binary = {version=">=2.8.0", optional=true}
 
 [tool.poetry.group.dev]

--- a/splink/postgres/linker.py
+++ b/splink/postgres/linker.py
@@ -210,7 +210,7 @@ class PostgresLinker(Linker):
         WHERE table_name = '{table_name}';
         """
 
-        rec = self._run_sql_execution(sql).fetchall()
+        rec = self._run_sql_execution(sql).mappings().all()
         return len(rec) > 0
 
     def _delete_table_from_database(self, name):


### PR DESCRIPTION
Closes #1785 and #1906 and #1786

It turns out that the UDF registration only works correctly in sqlalchemy 2.0 if you use `begin`, which starts a transaction explicitly.  otherwise subsequent function registrations can't always 'see' previous ones.

`fetchall()` no longer works in sqlalchemy 2.0.0 see **[here](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#rowproxy-is-no-longer-a-proxy-is-now-called-row-and-behaves-like-an-enhanced-named-tuple) but luckily .mappings().all() seems to work fine

I have checked, and the following work:
```
sqlalchemy.__version__='1.4.49'
pd.__version__='1.5.0'

sqlalchemy.__version__='2.0.25'
pd.__version__='1.5.0'

sqlalchemy.__version__='2.0.25'
pd.__version__='2.2.0'
```
The only combination that doesn't is:
```
sqlalchemy.__version__='1.4.49'
pd.__version__='2.2.0'

```

`AttributeError: 'Engine' object has no attribute 'cursor'`


But that's fine because https://github.com/moj-analytical-services/splink/issues/1906#issuecomment-1915508671 
>  there was no version pin for [sqlalchemy] in the pandas 1.x dependencies  so you could easily end up installing pandas 1.x and SQLAlchemy 2.x,

