### PR TITLE
Docs workflow - build and check links on PRs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - master
 
+  pull_request:
+    branches:
+      - master
+    paths:
+      # files that affect the docs build:
+      - docs/**
+      - CONTRIBUTING.md
+
   workflow_dispatch:
 
 jobs:
@@ -79,7 +87,7 @@ jobs:
           name: generated_files
           path: docs/includes/generated_files
 
-  deploy:
+  build:
     runs-on: ubuntu-latest
     needs: generate-files
     steps:
@@ -114,12 +122,39 @@ jobs:
           fail: true
           args: --offline site/ --verbose './**/*.html'
 
-      - run: |
+      - name: Upload built site
+        uses: actions/upload-artifact@v3
+        with:
+          name: built_site
+          path: site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    # we only deplot on push to master
+    # this job doesn't run if this is triggered by a PR
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: built_site
+          path: site
+
+      - name: commit and force-push to gh-pages branch
+        run: |
           pip install ghp-import==2.1.0
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           ghp-import -opfm "Update docs from commit ${{ github.sha }}" site
 
+      # some environment info:
       - run: pip freeze
       - run: mkdocs --version
-      - run: tree docs/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -128,6 +128,10 @@ jobs:
           name: built_site
           path: site
 
+      # some environment info:
+      - run: pip freeze
+      - run: mkdocs --version
+
   deploy:
     runs-on: ubuntu-latest
     needs: build
@@ -154,7 +158,3 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           ghp-import -opfm "Update docs from commit ${{ github.sha }}" site
-
-      # some environment info:
-      - run: pip freeze
-      - run: mkdocs --version


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Closes #1914, as mooted [in this comment](https://github.com/moj-analytical-services/splink/pull/1902#pullrequestreview-1850685203).


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
In documentation workflow splits `deploy` job into `build` (which also checks links) and `deploy` jobs.

Workflow runs on pushes to master (as before), and on PRs into master (in which case `deploy` does not run). PR version only runs if relevant files have changed.

See examples of the PR version (with no deploy) in [this PR](https://github.com/ADBond/splink/pull/22) - versions which pass and fail link checking. [Here is a run](https://github.com/ADBond/splink/actions/runs/7727414332/job/21065844220) coming from 'push' (that includes the `deploy` job running).

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


