### PR TITLE
Add comparison level validation check

### DIFF
--- a/splink/exceptions.py
+++ b/splink/exceptions.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import List, Union
 
 

--- a/splink/exceptions.py
+++ b/splink/exceptions.py
@@ -2,6 +2,10 @@ import warnings
 from typing import List, Union
 
 
+def format_text_as_red(text):
+    return f"\033[91m{text}\033[0m"
+
+
 # base class for any type of custom exception
 class SplinkException(Exception):
     pass
@@ -18,9 +22,9 @@ class EMTrainingException(SplinkException):
 class ComparisonSettingsException(SplinkException):
     def __init__(self, message=""):
         # Add the default message to the beginning of the provided message
-        full_message = "Errors were detected in your settings object's comparisons:"
+        full_message = "Errors were detected in your settings object's comparisons"
         if message:
-            full_message += ":\n" + message
+            full_message += "\n" + message
         super().__init__(full_message)
 
 
@@ -51,39 +55,39 @@ class ErrorLogger:
     @property
     def errors(self) -> str:
         """Return concatenated error messages."""
-        return "\n".join([f" - {e}" for e in self.error_queue])
 
-    def append(self, error: Union[list, str, Exception]) -> None:
-        """Append an error to the error list.
+        return "\n\n".join([f"{e}" for e in self.error_queue])
+
+    def log_error(self, error: Union[list, str, Exception]) -> None:
+        """
+        Log an error or a list of errors.
 
         Args:
-            error: An error message string, an Exception instance or
-                a list or tuple containing your strings or exceptions.
+            error: An error message, an Exception instance, or a list containing strings or exceptions.
         """
-
         if isinstance(error, (list, tuple)):
             for e in error:
-                self._append(e)
+                self._log_single_error(e)
         else:
-            self._append(error)
+            self._log_single_error(error)
 
-    def _append(self, error: Union[str, Exception]) -> None:
-        # Ignore if None
+    def _log_single_error(self, error: Union[str, Exception]) -> None:
+        """Log a single error message or Exception."""
         if error is None:
             return
 
         self.raw_errors.append(error)
+        error_str = self._format_error(error)
+        self.error_queue.append(error_str)
 
-        if isinstance(error, str):
-            self.error_queue.append(error)
-        elif isinstance(error, Exception):
-            error_name = error.__class__.__name__
-            logged_exception = f"{error_name}: {str(error)}"
-            self.error_queue.append(logged_exception)
+    def _format_error(self, error: Union[str, Exception]) -> str:
+        """Format an error message or Exception for logging."""
+        if isinstance(error, Exception):
+            return f"{format_text_as_red(error.__class__.__name__)}: {error}"
+        elif isinstance(error, str):
+            return f"{error}"
         else:
-            raise ValueError(
-                "The 'error' argument must be a string or an Exception instance."
-            )
+            raise ValueError("Error must be a string or an Exception instance.")
 
     def raise_and_log_all_errors(
         self, exception: Exception = SplinkException, additional_txt=""
@@ -95,4 +99,5 @@ class ErrorLogger:
             additional_txt: Additional text to append to the error message.
         """
         if self.error_queue:
-            raise exception(f"\n{self.errors}{additional_txt}")
+            error_message = f"\n{self.errors}\n{additional_txt}"
+            raise exception(error_message)

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1128,9 +1128,7 @@ class Linker:
         self._settings_dict = settings_dict  # overwrite or add
 
         # Get the SQL dialect from settings_dict or use the default
-        sql_dialect = settings_dict.get(
-            "sql_dialect", self._sql_dialect
-        )
+        sql_dialect = settings_dict.get("sql_dialect", self._sql_dialect)
         settings_dict["sql_dialect"] = sql_dialect
         settings_dict["linker_uid"] = settings_dict.get("linker_uid", cache_uid)
 

--- a/splink/settings_validation/settings_validation_log_strings.py
+++ b/splink/settings_validation/settings_validation_log_strings.py
@@ -1,6 +1,5 @@
 from functools import partial
-from typing import NamedTuple
-from typing import List, Tuple
+from typing import List, NamedTuple, Tuple
 
 
 def indent_error_message(message):

--- a/splink/settings_validation/settings_validation_log_strings.py
+++ b/splink/settings_validation/settings_validation_log_strings.py
@@ -1,5 +1,11 @@
 from functools import partial
 from typing import NamedTuple
+from typing import List, Tuple
+
+
+def indent_error_message(message):
+    """Indents an error message by 4 spaces."""
+    return "\n    ".join(message.splitlines())
 
 
 class InvalidColumnsLogGenerator(NamedTuple):
@@ -136,3 +142,62 @@ def construct_missing_column_in_comparison_level_log(invalid_cls) -> str:
         output_warning.append(construct_invalid_sql_log_string(comp_lvls))
 
     return "\n".join(output_warning)
+
+
+def create_invalid_comparison_level_log_string(
+    comparison_string: str, invalid_comparison_levels: List[Tuple[str, str]]
+):
+    invalid_levels_str = ",\n".join(
+        [
+            f"- Type: {type_name}. Level: {level}"
+            for level, type_name in invalid_comparison_levels
+        ]
+    )
+
+    log_message = (
+        f"\nThe comparison `{comparison_string}` contains the following invalid levels:\n"
+        f"{invalid_levels_str}\n\n"
+        "Please only include dictionaries or objects of "
+        "the `ComparisonLevel` class."
+    )
+
+    return indent_error_message(log_message)
+
+
+def create_invalid_comparison_log_string(
+    comparison_string: str, comparison_level: bool
+):
+    if comparison_level:
+        type_msg = "is a comparison level"
+    else:
+        type_msg = "is of an invalid data type"
+
+    log_message = (
+        f"\n{comparison_string}\n"
+        f"{type_msg} and cannot be used as a standalone comparison.\n"
+        "Please only include dictionaries or objects of the `Comparison` class.\n"
+    )
+    return indent_error_message(log_message)
+
+
+def create_no_comparison_levels_error_log_string(comparison_string: str):
+    log_message = (
+        f"\n{comparison_string}\n"
+        "is missing the required `comparison_levels` dictionary"
+        "key. Please ensure you\ninclude this in all comparisons"
+        "used in your settings object.\n"
+    )
+    return indent_error_message(log_message)
+
+
+def create_incorrect_dialect_import_log_string(
+    comparison_string: str, comparison_dialects: List[str]
+):
+    log_message = (
+        f"\n{comparison_string}\n"
+        "contains the following invalid SQL dialect(s)"
+        f"within its comparison levels - {', '.join(comparison_dialects)}.\n"
+        "Please ensure that you're importing comparisons designed "
+        "for your specified linker.\n"
+    )
+    return indent_error_message(log_message)

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -2,6 +2,7 @@ import logging
 
 import pandas as pd
 import pytest
+import re
 
 from splink.comparison import Comparison
 from splink.convert_v2_to_v3 import convert_settings_from_v2_to_v3
@@ -330,6 +331,7 @@ def test_validate_sql_dialect():
 def test_comparison_validation():
     import splink.athena.comparison_level_library as ath_cll
     import splink.duckdb.comparison_level_library as cll
+    import splink.duckdb.comparison_library as cl
     import splink.spark.comparison_level_library as sp_cll
     from splink.exceptions import InvalidDialect
     from splink.spark.comparison_library import exact_match
@@ -344,10 +346,7 @@ def test_comparison_validation():
     settings = get_settings_dict()
 
     # Contents aren't tested as of yet
-    email_no_comp_level = {
-        "comparison_lvls": [],
-    }
-
+    email_no_comp_level = {"comparison_lvls": []}
     # cll instead of cl
     email_cc = cll.exact_match_level("email")
     settings["comparisons"][3] = email_cc
@@ -368,6 +367,17 @@ def test_comparison_validation():
             ]
         }
     )
+    # a comparison containing another comparison
+    settings["comparisons"].append(
+        {
+            "comparison_levels": [
+                cll.null_level("test"),
+                # Invalid Spark cll
+                cl.exact_match("test"),
+                cll.else_level(),
+            ]
+        }
+    )
 
     log_comparison_errors(None, "duckdb")  # confirm it works with None as an input...
 
@@ -381,17 +391,25 @@ def test_comparison_validation():
 
     # Check our errors are raised
     errors = error_logger.raw_errors
+    # -3 as we have three valid comparisons
     assert len(error_logger.raw_errors) == len(settings["comparisons"]) - 3
 
-    # Our expected error types and part of the corresponding error text
+    # These errors are raised in the order they are defined in the settings
     expected_errors = (
         (TypeError, "is a comparison level"),
         (TypeError, "is of an invalid data type."),
         (SyntaxError, "missing the required `comparison_levels`"),
         (InvalidDialect, "within its comparison levels - spark."),
-        (InvalidDialect, "within its comparison levels - presto, spark."),
+        (InvalidDialect, re.compile(r".*(presto.*spark|spark.*presto).*")),
+        (TypeError, "contains the following invalid levels"),
     )
 
     for n, (e, txt) in enumerate(expected_errors):
-        with pytest.raises(e, match=txt):
-            raise errors[n]
+        if isinstance(txt, re.Pattern):
+            # If txt is a compiled regular expression, use re.search
+            with pytest.raises(e) as exc_info:
+                raise errors[n]
+            assert txt.search(str(exc_info.value)), f"Regex did not match for error {n}"
+        else:
+            with pytest.raises(e, match=txt):
+                raise errors[n]

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,8 +1,8 @@
 import logging
+import re
 
 import pandas as pd
 import pytest
-import re
 
 from splink.comparison import Comparison
 from splink.convert_v2_to_v3 import convert_settings_from_v2_to_v3


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Tags onto https://github.com/moj-analytical-services/splink/pull/1921 and addresses a "bug" that Chloe was getting in one of our pipeline runs.

<hr>

### Give a brief description for the solution you have provided
Previously, if a user attempted to use a **comparison** as a **comparison level**, they would be greeted with a "not JSON serializable" error:
![Screenshot 2024-02-05 at 11 20 39](https://github.com/moj-analytical-services/splink/assets/45356472/2ba438b1-d5ef-4ded-bde8-995e3f253b6c)
due to `Comparison` not being "dumpable" - https://github.com/moj-analytical-services/splink/blob/master/splink/validate_jsonschema.py#L65.


This is hard to interpret and debug for anyone unfamiliar with Splink. 

This PR primarily aims to address this by adding an explicit validation check for invalid comparison levels (i.e. a level that is neither a dict or a `ComparisonLevel`). This check is performed within the [`check_comparison_level_types`](https://github.com/moj-analytical-services/splink/blob/0dc4cf34d89cb78e9184d232ac8e4bc2d4aa705c/splink/settings_validation/valid_types.py#L90) function, which simply loops through a Comparison and checks the data types within.

Any errors identified will be added to the `ErrorLogger` and printed to console once all settings have been checked.

<details>
<summary><b>Example of new breakdown with broken settings</b></summary>

```python
from splink.duckdb.linker import DuckDBLinker
import splink.duckdb.comparison_library as cl
import splink.duckdb.comparison_level_library as cll
import splink.duckdb.comparison_template_library as ctl
from splink.duckdb.blocking_rule_library import block_on
from splink.datasets import splink_datasets

df = splink_datasets.fake_1000


def compare_postcodes(col_name: str):
    comparison_dict = {
        "output_column_name": col_name,
        "comparison_description": col_name + " distance",
        "comparison_levels": [
            cll.null_level(col_name),
            cl.exact_match(col_name, term_frequency_adjustments=False),
            "abcde",
            cll.else_level(),
        ],
    }

    return comparison_dict


settings = {
    "link_type": "dedupe_only",
    "blocking_rules_to_generate_predictions": [
        block_on("first_name"),
        block_on("surname"),
    ],
    "comparisons": [
        {"comparison_levels": []},
        compare_postcodes("test"),
        cll.exact_match_level("email"),
        cll.exact_match_level("apple"),
    ],
}

linker = DuckDBLinker(df, settings)
```

</details>

<hr>

### Other Changes

* The `ErrorLogger` class. This now has more descriptive method names, easier to interpret code and logs the errors in red text (more on this below).
* All logging messages have been migrated to [`settings_validation_log_strings.py`](https://github.com/moj-analytical-services/splink/blob/0dc4cf34d89cb78e9184d232ac8e4bc2d4aa705c/splink/settings_validation/settings_validation_log_strings.py).
* Removed `sorted()` method from `evaluate_comparison_dialects` and switched off SplinkDeprecation warnings unless requested by the user.

<hr>

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


