### PR TITLE
Use CASE instead of bool to float casting in truth_space_table

### DIFF
--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -197,7 +197,7 @@ def truth_space_table_from_labels_column(
 
     sql = f"""
     select
-    cast(({label_colname}_l = {label_colname}_r) as float) as clerical_match_score,
+    case when ({label_colname}_l = {label_colname}_r) then cast(1.0 as float8) else cast(0.0 as float8) end AS clerical_match_score,
     not (cast(match_key as int) = {new_matchkey})
         as found_by_blocking_rules,
     *
@@ -353,7 +353,7 @@ def prediction_errors_from_label_column(
 
     sql = f"""
     select
-    cast(({label_colname}_l = {label_colname}_r) as float) as clerical_match_score,
+    case when ({label_colname}_l = {label_colname}_r) then cast(1.0 as float8) else cast(0.0 as float8) end AS clerical_match_score,
     not (cast(match_key as int) = {new_matchkey})
         as found_by_blocking_rules,
     *

--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -197,7 +197,10 @@ def truth_space_table_from_labels_column(
 
     sql = f"""
     select
-    case when ({label_colname}_l = {label_colname}_r) then cast(1.0 as float8) else cast(0.0 as float8) end AS clerical_match_score,
+    case
+        when ({label_colname}_l = {label_colname}_r)
+        then cast(1.0 as float8) else cast(0.0 as float8)
+    end AS clerical_match_score,
     not (cast(match_key as int) = {new_matchkey})
         as found_by_blocking_rules,
     *
@@ -353,7 +356,10 @@ def prediction_errors_from_label_column(
 
     sql = f"""
     select
-    case when ({label_colname}_l = {label_colname}_r) then cast(1.0 as float8) else cast(0.0 as float8) end AS clerical_match_score,
+    case
+        when ({label_colname}_l = {label_colname}_r)
+        then cast(1.0 as float8) else cast(0.0 as float8)
+    end AS clerical_match_score,
     not (cast(match_key as int) = {new_matchkey})
         as found_by_blocking_rules,
     *


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
https://github.com/moj-analytical-services/splink/pull/1893

### Give a brief description for the solution you have provided
Casting boolean to float doesn't work in Postgres. This PR uses CASE instead to do that casting, when making the truth_space_table

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


