### PR TITLE
Cast row_count as float8 in truth_table

### DIFF
--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -114,7 +114,7 @@ def truth_space_table_from_labels_with_predictions_sqls(
         truth_threshold,
         power(2, truth_threshold) / (1 + power(2, truth_threshold))
             as match_probability,
-        row_count,
+        cast(row_count as float8) as row_count,
         cast(P as float8) as p,
         cast(N as float8) as n,
         cast(TP as float8) as tp,


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
https://github.com/moj-analytical-services/splink/pull/1893

### Give a brief description for the solution you have provided
The above PR missed the `row_count` column when casting as `float8`. This results in that column alone being `numeric` (see below) which then fails to serialise into JSON when making the confusion matrix chart.

current data types:
```
                                    Table "splink.__splink__truth_space_table_30b2b43ea"
      Column       |       Type       | Collation | Nullable | Default | Storage | Compression | Stats target | Description
-------------------+------------------+-----------+----------+---------+---------+-------------+--------------+-------------
 truth_threshold   | double precision |           |          |         | plain   |             |              |
 match_probability | double precision |           |          |         | plain   |             |              |
 row_count         | numeric          |           |          |         | main    |             |              |
 p                 | double precision |           |          |         | plain   |             |              |
 n                 | double precision |           |          |         | plain   |             |              |
 tp                | double precision |           |          |         | plain   |             |              |
 tn                | double precision |           |          |         | plain   |             |              |
 fp                | double precision |           |          |         | plain   |             |              |
 fn                | double precision |           |          |         | plain   |             |              |
 p_rate            | double precision |           |          |         | plain   |             |              |
 n_rate            | double precision |           |          |         | plain   |             |              |
 tp_rate           | double precision |           |          |         | plain   |             |              |
 tn_rate           | double precision |           |          |         | plain   |             |              |
 fp_rate           | double precision |           |          |         | plain   |             |              |
 fn_rate           | double precision |           |          |         | plain   |             |              |
 precision         | double precision |           |          |         | plain   |             |              |
 recall            | double precision |           |          |         | plain   |             |              |
 specificity       | double precision |           |          |         | plain   |             |              |
 npv               | double precision |           |          |         | plain   |             |              |
 accuracy          | double precision |           |          |         | plain   |             |              |
 f1                | double precision |           |          |         | plain   |             |              |
 f2                | double precision |           |          |         | plain   |             |              |
 f0_5              | double precision |           |          |         | plain   |             |              |
 p4                | double precision |           |          |         | plain   |             |              |
 phi               | double precision |           |          |         | plain   |             |              |
```

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


