### PR TITLE
Remove nullif wrapper from `try_strptime`

### DIFF
--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -105,7 +105,7 @@ class SplinkDialect(ABC):
         return nullif_wrapped_function
 
     def try_parse_date(self, name: str, date_format: str = None):
-        return self._wrap_in_nullif(self._try_parse_date_raw)(name, date_format)
+        return self._try_parse_date_raw(name, date_format)
 
     def _try_parse_date_raw(self, name: str, date_format: str = None):
         raise NotImplementedError(


### PR DESCRIPTION
I tracked the source of this problem to this comment:
https://github.com/moj-analytical-services/splink/pull/1844#issuecomment-1895879858

The summary is:
- A regex extract sometimes returns `''` if a capture group is specified but nothing is captured. We want it to return a true null because otherwise the '' may be used as part of a levenshtein comparison
- The regex extract should therefore be wrapped in nulliff (if the regex extract returns '', return null)
- We applied that also to `try_strptime` in error, since try_strptime returns a true null if the date can't be parsed, not `''`

Here's a description of the problem it causes:

```
from splink.comparison_level_library import DatediffLevel
from splink.comparison_library import DatediffAtThresholds
import duckdb

dd = DatediffAtThresholds(
    "dob", date_thresholds=[1], date_metrics=["day"], cast_strings_to_dates=True
).get_comparison("duckdb")

for cl in  dd.as_dict()["comparison_levels"]:
    print(cl["sql_condition"])
```

Before this PR, that produces:
```
NULLIF(try_strptime("dob_l", '%Y-%m-%d'), '') IS NULL OR NULLIF(try_strptime("dob_r", '%Y-%m-%d'), '') IS NULL
"dob_l" = "dob_r"
ABS(DATE_DIFF('day', NULLIF(try_strptime("dob_r", '%Y-%m-%d'), ''), NULLIF(try_strptime("dob_l", '%Y-%m-%d'), ''))) <= 1
ELSE
```

This breaks in `duckdb==0.9.3.dev3887`  (but not 0.9.2) because 
`NULLIF(try_strptime("dob_r", '%Y-%m-%d'), '')` is of 'two datatypes' (a datetime, but if the parse fails, a blank string)

with error 

```
Error was: Conversion Error: timestamp field value out of range: "", expected format is (YYYY-MM-DD HH:MM:SS[.US][±HH:MM| ZONE])
```

I believe the nullif was introduced to wrap a `regex_extract` to return a `` if the extract fails not null, but was accidentally also applied to `try_strptime`


After this pull request, the result of the above code is:

```
try_strptime("dob_l", '%Y-%m-%d') IS NULL OR try_strptime("dob_r", '%Y-%m-%d') IS NULL
"dob_l" = "dob_r"
ABS(DATE_DIFF('day', try_strptime("dob_r", '%Y-%m-%d'), try_strptime("dob_l", '%Y-%m-%d'))) <= 1
ELSE

```

which seems fine