### PR TITLE
Comparison - structured interface

### DIFF
--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from .comparison_level import ComparisonLevel
 from .misc import dedupe_preserving_order, join_list_with_commas_final_and
@@ -55,17 +55,21 @@ class Comparison:
 
     """
 
-    def __init__(self, comparison_dict, settings_obj: Settings = None):
-        # Protected because we don't want to modify
-        self._comparison_dict = comparison_dict
-        comparison_level_list = comparison_dict["comparison_levels"]
+    def __init__(
+        self,
+        comparison_levels: List[ComparisonLevel],
+        output_column_name: str = None,
+        comparison_description: str = None,
+        settings_obj: Settings = None
+    ):
+
         self.comparison_levels: list[ComparisonLevel] = []
 
         # If comparison_levels are already of type ComparisonLevel, register
         # the settings object on them
         # otherwise turn the dictionaries into ComparisonLevel
 
-        for cl in comparison_level_list:
+        for cl in comparison_levels:
             if isinstance(cl, ComparisonLevel):
                 cl.comparison = self
             else:

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -127,7 +127,7 @@ class Comparison:
             )
             for cl_dict in comparison_dict["comparison_levels"]
         ]
-        cc = Comparison(comparison_dict, self._settings_obj)
+        cc = Comparison(**comparison_dict, settings_obj=self._settings_obj)
         return cc
 
     @property

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -87,7 +87,7 @@ class Comparison:
 
         self._settings_obj: Optional[Settings] = settings_obj
 
-        self._output_column_name = (
+        self.output_column_name = (
             output_column_name or self._default_output_column_name()
         )
         self.comparison_description = (
@@ -148,7 +148,7 @@ class Comparison:
 
     @property
     def _bf_column_name(self):
-        return f"{self._settings_obj._bf_prefix}{self._output_column_name}".replace(
+        return f"{self._settings_obj._bf_prefix}{self.output_column_name}".replace(
             " ", "_"
         )
 
@@ -160,7 +160,7 @@ class Comparison:
     def _bf_tf_adj_column_name(self):
         bf = self._settings_obj._bf_prefix
         tf = self._settings_obj._tf_prefix
-        cc_name = self._output_column_name
+        cc_name = self.output_column_name
         return f"{bf}{tf}adj_{cc_name}".replace(" ", "_")
 
     @property
@@ -201,11 +201,11 @@ class Comparison:
         return f"custom_{'_'.join(cols)}"
 
     def _default_comparison_description(self):
-        return self._output_column_name
+        return self.output_column_name
 
     @property
     def _gamma_column_name(self):
-        return f"{self._gamma_prefix}{self._output_column_name}".replace(" ", "_")
+        return f"{self._gamma_prefix}{self.output_column_name}".replace(" ", "_")
 
     @property
     def _tf_adjustment_input_col_names(self):
@@ -328,7 +328,7 @@ class Comparison:
 
     def as_dict(self):
         d = {
-            "output_column_name": self._output_column_name,
+            "output_column_name": self.output_column_name,
             "comparison_levels": [cl.as_dict() for cl in self.comparison_levels],
         }
         d["comparison_description"] = self.comparison_description
@@ -336,7 +336,7 @@ class Comparison:
 
     def _as_completed_dict(self):
         return {
-            "column_name": self._output_column_name,
+            "column_name": self.output_column_name,
             "comparison_levels": [
                 cl._as_completed_dict() for cl in self.comparison_levels
             ],
@@ -386,7 +386,7 @@ class Comparison:
             messages.append("some m values are not trained")
 
         message = ", ".join(messages)
-        message = f"    - {self._output_column_name} ({message})."
+        message = f"    - {self.output_column_name} ({message})."
         return message
 
     @property
@@ -398,7 +398,7 @@ class Comparison:
         records = []
         for cl in self.comparison_levels:
             record = {}
-            record["comparison_name"] = self._output_column_name
+            record["comparison_name"] = self.output_column_name
             record = {**record, **cl._as_detailed_record}
             records.append(record)
         return records
@@ -409,7 +409,7 @@ class Comparison:
         for cl in self.comparison_levels:
             new_records = cl._parameter_estimates_as_records
             for r in new_records:
-                r["comparison_name"] = self._output_column_name
+                r["comparison_name"] = self.output_column_name
             records.extend(new_records)
 
         return records
@@ -432,7 +432,7 @@ class Comparison:
     def _not_trained_messages(self):
         msgs = []
 
-        cname = self._output_column_name
+        cname = self.output_column_name
 
         header = f"Comparison: '{cname}':\n"
 

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -58,6 +58,7 @@ class Comparison:
     def __init__(
         self,
         comparison_levels: List[ComparisonLevel],
+        sqlglot_dialect_name: str,
         output_column_name: str = None,
         comparison_description: str = None,
         settings_obj: Settings = None,
@@ -87,6 +88,7 @@ class Comparison:
 
         self._settings_obj: Optional[Settings] = settings_obj
 
+        self.sqlglot_dialect_name = sqlglot_dialect_name
         self.output_column_name = (
             output_column_name or self._default_output_column_name()
         )
@@ -118,16 +120,14 @@ class Comparison:
         # want comparison levels to always be ComparisonLevel, not dict
         comparison_dict = deepcopy(self.as_dict())
         comparison_dict["comparison_levels"] = [
-            ComparisonLevel(
-                **cl_dict,
-                # TODO: Comparison should also store dialect
-                sqlglot_dialect_name=None
-                if self._settings_obj is None
-                else self._settings_obj._sql_dialect,
-            )
+            ComparisonLevel(**cl_dict, sqlglot_dialect_name=self.sqlglot_dialect_name)
             for cl_dict in comparison_dict["comparison_levels"]
         ]
-        cc = Comparison(**comparison_dict, settings_obj=self._settings_obj)
+        cc = Comparison(
+            **comparison_dict,
+            sqlglot_dialect_name=self.sqlglot_dialect_name,
+            settings_obj=self._settings_obj,
+        )
         return cc
 
     @property

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -60,7 +60,7 @@ class Comparison:
         comparison_levels: List[ComparisonLevel],
         output_column_name: str = None,
         comparison_description: str = None,
-        settings_obj: Settings = None
+        settings_obj: Settings = None,
     ):
 
         self.comparison_levels: list[ComparisonLevel] = []
@@ -86,6 +86,12 @@ class Comparison:
             self.comparison_levels.append(cl)
 
         self._settings_obj: Optional[Settings] = settings_obj
+
+        self.comparison_description = (
+            comparison_description
+            if comparison_description is not None
+            else self._default_comparison_description()
+        )
 
         # Assign comparison vector values starting at highest level, count down to 0
         num_levels = self._num_levels
@@ -198,12 +204,8 @@ class Comparison:
             else:
                 return f"custom_{'_'.join(cols)}"
 
-    @property
-    def _comparison_description(self):
-        if "comparison_description" in self._comparison_dict:
-            return self._comparison_dict["comparison_description"]
-        else:
-            return self._output_column_name
+    def _default_comparison_description(self):
+        return self._output_column_name
 
     @property
     def _gamma_column_name(self):
@@ -333,10 +335,7 @@ class Comparison:
             "output_column_name": self._output_column_name,
             "comparison_levels": [cl.as_dict() for cl in self.comparison_levels],
         }
-        if "comparison_description" in self._comparison_dict:
-            d["comparison_description"] = self._comparison_dict[
-                "comparison_description"
-            ]
+        d["comparison_description"] = self.comparison_description
         return d
 
     def _as_completed_dict(self):
@@ -429,7 +428,7 @@ class Comparison:
 
     def __repr__(self):
         return (
-            f"<Comparison {self._comparison_description} with "
+            f"<Comparison {self.comparison_description} with "
             f"{self._num_levels} levels at {hex(id(self))}>"
         )
 
@@ -473,12 +472,7 @@ class Comparison:
 
         comp_levels = self._comparison_level_description_list
 
-        if "comparison_description" in self._comparison_dict:
-            main_desc = (
-                f"of {input_cols}\nDescription: '{self._comparison_description}'"
-            )
-        else:
-            main_desc = f"of {input_cols}"
+        main_desc = f"of {input_cols}\nDescription: '{self.comparison_description}'"
 
         desc = f"Comparison {main_desc}\nComparison levels:\n{comp_levels}"
         return desc
@@ -491,10 +485,7 @@ class Comparison:
 
         comp_levels = self._comparison_level_description_list
 
-        if "comparison_description" in self._comparison_dict:
-            main_desc = f"'{self._comparison_description}' of {input_cols}"
-        else:
-            main_desc = f"of {input_cols}"
+        main_desc = f"'{self.comparison_description}' of {input_cols}"
 
         desc = (
             f"Comparison {main_desc}.\n"

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -87,10 +87,11 @@ class Comparison:
 
         self._settings_obj: Optional[Settings] = settings_obj
 
+        self._output_column_name = (
+            output_column_name or self._default_output_column_name()
+        )
         self.comparison_description = (
-            comparison_description
-            if comparison_description is not None
-            else self._default_comparison_description()
+            comparison_description or self._default_comparison_description()
         )
 
         # Assign comparison vector values starting at highest level, count down to 0
@@ -192,17 +193,12 @@ class Comparison:
 
         return deduped_cols
 
-    @property
-    def _output_column_name(self):
-        if "output_column_name" in self._comparison_dict:
-            return self._comparison_dict["output_column_name"]
-        else:
-            cols = self._input_columns_used_by_case_statement
-            cols = [c.input_name for c in cols]
-            if len(cols) == 1:
-                return cols[0]
-            else:
-                return f"custom_{'_'.join(cols)}"
+    def _default_output_column_name(self):
+        cols = self._input_columns_used_by_case_statement
+        cols = [c.input_name for c in cols]
+        if len(cols) == 1:
+            return cols[0]
+        return f"custom_{'_'.join(cols)}"
 
     def _default_comparison_description(self):
         return self._output_column_name

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -119,7 +119,7 @@ class ComparisonCreator(ABC):
     def get_comparison(self, sql_dialect_str: str) -> Comparison:
         """sql_dialect_str is a string to make this method easier to use
         for the end user - otherwise they'd need to import a SplinkDialect"""
-        return Comparison(self.create_comparison_dict(sql_dialect_str))
+        return Comparison(**self.create_comparison_dict(sql_dialect_str))
 
     @final
     def create_comparison_dict(self, sql_dialect_str: str) -> dict:

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -119,7 +119,10 @@ class ComparisonCreator(ABC):
     def get_comparison(self, sql_dialect_str: str) -> Comparison:
         """sql_dialect_str is a string to make this method easier to use
         for the end user - otherwise they'd need to import a SplinkDialect"""
-        return Comparison(**self.create_comparison_dict(sql_dialect_str))
+        return Comparison(
+            **self.create_comparison_dict(sql_dialect_str),
+            sqlglot_dialect_name=sql_dialect_str,
+        )
 
     @final
     def create_comparison_dict(self, sql_dialect_str: str) -> dict:

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -227,7 +227,7 @@ class ComparisonLevel:
         if self.is_null_level:
             raise AttributeError("Cannot set m_probability when is_null_level is true")
         if value == LEVEL_NOT_OBSERVED_TEXT:
-            cc_n = self.comparison._output_column_name
+            cc_n = self.comparison.output_column_name
             cl_n = self.label_for_charts
             if not self._m_warning_sent:
                 logger.warning(
@@ -255,7 +255,7 @@ class ComparisonLevel:
         if self.is_null_level:
             raise AttributeError("Cannot set u_probability when is_null_level is true")
         if value == LEVEL_NOT_OBSERVED_TEXT:
-            cc_n = self.comparison._output_column_name
+            cc_n = self.comparison.output_column_name
             cl_n = self.label_for_charts
             if not self._u_warning_sent:
                 logger.warning(

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -96,7 +96,7 @@ class EMTrainingSession:
                 if set(br_cols).intersection(cc_cols):
                     comparisons_to_deactivate.append(cc)
         cc_names_to_deactivate = [
-            cc._output_column_name for cc in comparisons_to_deactivate
+            cc.output_column_name for cc in comparisons_to_deactivate
         ]
         self._comparisons_that_cannot_be_estimated: list[
             Comparison
@@ -105,7 +105,7 @@ class EMTrainingSession:
         filtered_ccs = [
             cc
             for cc in self._settings_obj.comparisons
-            if cc._output_column_name not in cc_names_to_deactivate
+            if cc.output_column_name not in cc_names_to_deactivate
         ]
 
         self._settings_obj.comparisons = filtered_ccs
@@ -118,12 +118,12 @@ class EMTrainingSession:
 
     def _training_log_message(self):
         not_estimated = [
-            cc._output_column_name for cc in self._comparisons_that_cannot_be_estimated
+            cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated
         ]
         not_estimated = "".join([f"\n    - {cc}" for cc in not_estimated])
 
         estimated = [
-            cc._output_column_name for cc in self._comparisons_that_can_be_estimated
+            cc.output_column_name for cc in self._comparisons_that_can_be_estimated
         ]
         estimated = "".join([f"\n    - {cc}" for cc in estimated])
 
@@ -202,7 +202,7 @@ class EMTrainingSession:
         # Add m and u values to original settings
         for cc in self._settings_obj.comparisons:
             orig_cc = self._original_settings_obj._get_comparison_by_output_column_name(
-                cc._output_column_name
+                cc.output_column_name
             )
             for cl in cc._comparison_levels_excluding_null:
                 orig_cl = orig_cc._get_comparison_level_by_comparison_vector_value(
@@ -214,7 +214,7 @@ class EMTrainingSession:
                     if cl._m_probability == not_observed:
                         orig_cl._add_trained_m_probability(not_observed, training_desc)
                         logger.info(
-                            f"m probability not trained for {cc._output_column_name} - "
+                            f"m probability not trained for {cc.output_column_name} - "
                             f"{cl.label_for_charts} (comparison vector value: "
                             f"{cl._comparison_vector_value}). This usually means the "
                             "comparison level was never observed in the training data."
@@ -229,7 +229,7 @@ class EMTrainingSession:
                     if cl._u_probability == not_observed:
                         orig_cl._add_trained_u_probability(not_observed, training_desc)
                         logger.info(
-                            f"u probability not trained for {cc._output_column_name} - "
+                            f"u probability not trained for {cc.output_column_name} - "
                             f"{cl.label_for_charts} (comparison vector value: "
                             f"{cl._comparison_vector_value}). This usually means the "
                             "comparison level was never observed in the training data."
@@ -264,7 +264,7 @@ class EMTrainingSession:
             logger.log(
                 15,
                 f"Increasing prob two random records match using "
-                f"{cl.comparison._output_column_name} - {cl.label_for_charts}"
+                f"{cl.comparison.output_column_name} - {cl.label_for_charts}"
                 f" using bayes factor {cl._bayes_factor:,.3f}",
             )
 
@@ -332,7 +332,7 @@ class EMTrainingSession:
         else:
             cl = max_change_dict["current_comparison_level"]
             m_u = max_change_dict["max_change_type"]
-            cc_name = cl.comparison._output_column_name
+            cc_name = cl.comparison.output_column_name
 
             cl_label = cl.label_for_charts
             level_text = f"{cc_name}, level `{cl_label}`"
@@ -408,7 +408,7 @@ class EMTrainingSession:
     def __repr__(self):
         deactivated_cols = ", ".join(
             [
-                cc._output_column_name
+                cc.output_column_name
                 for cc in self._comparisons_that_cannot_be_estimated
             ]
         )

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -407,10 +407,7 @@ class EMTrainingSession:
 
     def __repr__(self):
         deactivated_cols = ", ".join(
-            [
-                cc.output_column_name
-                for cc in self._comparisons_that_cannot_be_estimated
-            ]
+            [cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated]
         )
         blocking_rule = self._blocking_rule_for_training.blocking_rule_sql
         return (

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -60,7 +60,7 @@ def compute_new_parameters_sql(settings_obj: Settings):
     union_sqls = [
         sql_template.format(
             gamma_column=cc._gamma_column_name,
-            output_column_name=cc._output_column_name,
+            output_column_name=cc.output_column_name,
             agreement_pattern_count=agreement_pattern_count,
         )
         for cc in settings_obj.comparisons
@@ -162,7 +162,7 @@ def populate_m_u_from_lookup(
     c = comparison_level.comparison
     if not em_training_session._training_fix_m_probabilities:
         try:
-            m_probability = m_u_records_lookup[c._output_column_name][
+            m_probability = m_u_records_lookup[c.output_column_name][
                 cl._comparison_vector_value
             ]["m_probability"]
 
@@ -172,7 +172,7 @@ def populate_m_u_from_lookup(
 
     if not em_training_session._training_fix_u_probabilities:
         try:
-            u_probability = m_u_records_lookup[c._output_column_name][
+            u_probability = m_u_records_lookup[c.output_column_name][
                 cl._comparison_vector_value
             ]["u_probability"]
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -947,7 +947,7 @@ class Linker:
             for reverse_level in reverse_levels:
                 # Get comparison level on current settings obj
                 cc = self._settings_obj._get_comparison_by_output_column_name(
-                    reverse_level.comparison._output_column_name
+                    reverse_level.comparison.output_column_name
                 )
 
                 cl = cc._get_comparison_level_by_comparison_vector_value(
@@ -961,7 +961,7 @@ class Linker:
 
                 logger.log(
                     15,
-                    f"Reversing comparison level {cc._output_column_name}"
+                    f"Reversing comparison level {cc.output_column_name}"
                     f" using bayes factor {bf:,.3f}",
                 )
 
@@ -3323,7 +3323,7 @@ class Linker:
 
         # Comparisons with TF adjustments
         tf_comparisons = [
-            c._output_column_name
+            c.output_column_name
             for c in self._settings_obj.comparisons
             if any([cl._has_tf_adjustments for cl in c.comparison_levels])
         ]

--- a/splink/m_u_records_to_parameters.py
+++ b/splink/m_u_records_to_parameters.py
@@ -32,7 +32,7 @@ def not_trained_message(comparison_level: ComparisonLevel):
     c = comparison_level.comparison
     cl = comparison_level
     return (
-        f"not trained for {c._output_column_name} - "
+        f"not trained for {c.output_column_name} - "
         f"{cl.label_for_charts} (comparison vector value: "
         f"{cl._comparison_vector_value}). This usually means the "
         "comparison level was never observed in the training data."
@@ -46,7 +46,7 @@ def append_u_probability_to_comparison_level_trained_probabilities(
     c = cl.comparison
 
     try:
-        u_probability = m_u_records_lookup[c._output_column_name][
+        u_probability = m_u_records_lookup[c.output_column_name][
             cl._comparison_vector_value
         ]["u_probability"]
 
@@ -67,7 +67,7 @@ def append_m_probability_to_comparison_level_trained_probabilities(
     c = cl.comparison
 
     try:
-        m_probability = m_u_records_lookup[c._output_column_name][
+        m_probability = m_u_records_lookup[c.output_column_name][
             cl._comparison_vector_value
         ]["m_probability"]
 

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -44,12 +44,16 @@ class Settings:
         self._settings_dict = settings_dict
         s_else_d = self._from_settings_dict_else_default
         ccs = self._settings_dict["comparisons"]
-        # TODO: I think this should _not_ be dialected
+        # TODO: Probably want a 'dialected' version, and the Creator-type non-dialected
         self._sql_dialect = s_else_d("sql_dialect")
 
         self.comparisons: list[Comparison] = []
         for cc in ccs:
-            self.comparisons.append(Comparison(**cc, settings_obj=self))
+            self.comparisons.append(
+                Comparison(
+                    **cc, settings_obj=self, sqlglot_dialect_name=self._sql_dialect
+                )
+            )
 
         self._link_type = s_else_d("link_type")
         self._probability_two_random_records_match = s_else_d(

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -49,7 +49,7 @@ class Settings:
 
         self.comparisons: list[Comparison] = []
         for cc in ccs:
-            self.comparisons.append(Comparison(cc, self))
+            self.comparisons.append(Comparison(**cc, settings_obj=self))
 
         self._link_type = s_else_d("link_type")
         self._probability_two_random_records_match = s_else_d(

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -101,7 +101,7 @@ class Settings:
             if not c._has_null_level:
                 logger.warning(
                     "Warning: No null level found for comparison "
-                    f"{c._output_column_name}.\n"
+                    f"{c.output_column_name}.\n"
                     "In most cases you want to define a comparison level that deals"
                     " with the case that one or both sides of the comparison are null."
                     "\nThis comparison level should have the `is_null_level` flag to "
@@ -293,7 +293,7 @@ class Settings:
 
     def _get_comparison_by_output_column_name(self, name):
         for cc in self.comparisons:
-            if cc._output_column_name == name:
+            if cc.output_column_name == name:
                 return cc
         raise ValueError(f"No comparison column with name {name}")
 

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -49,7 +49,7 @@ def _comparison_records(record_as_dict, comparison: Comparison):
 
     cl = c._get_comparison_level_by_comparison_vector_value(cv_value)
 
-    waterfall_record["column_name"] = c._output_column_name
+    waterfall_record["column_name"] = c.output_column_name
     waterfall_record["label_for_charts"] = cl.label_for_charts
 
     waterfall_record["sql_condition"] = cl.sql_condition
@@ -87,7 +87,7 @@ def _comparison_records(record_as_dict, comparison: Comparison):
             waterfall_record_2["value_l"] = ""
             waterfall_record_2["value_r"] = ""
 
-        waterfall_record_2["column_name"] = "tf_" + c._output_column_name
+        waterfall_record_2["column_name"] = "tf_" + c.output_column_name
         waterfall_record_2["term_frequency_adjustment"] = True
         waterfall_record_2["bayes_factor"] = 1.0
         waterfall_record_2["log2_bayes_factor"] = math.log2(1.0)

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -218,7 +218,7 @@ def test_lambda():
     )
 
     for cc in linker._settings_obj.comparisons:
-        if cc._output_column_name not in ("first_name", "surname"):
+        if cc.output_column_name not in ("first_name", "surname"):
             cl = cc._get_comparison_level_by_comparison_vector_value(1)
             cl.m_probability = 0.9
             cl.u_probability = 0.1

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -218,8 +218,8 @@ def test_check_for_missing_or_invalid_columns_in_sql_strings():
         check_comparison_for_missing_or_invalid_sql_strings(
             sql_dialect="duckdb",
             comparisons_to_check=[
-                Comparison(**email_comparison_to_check),
-                Comparison(**city_comparison_to_check),
+                Comparison(**email_comparison_to_check, sqlglot_dialect_name="duckdb"),
+                Comparison(**city_comparison_to_check, sqlglot_dialect_name="duckdb"),
                 LevenshteinAtThresholds("first_name").get_comparison("duckdb"),
             ],
             valid_input_dataframe_columns=VALID_INPUT_COLUMNS,

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -218,8 +218,8 @@ def test_check_for_missing_or_invalid_columns_in_sql_strings():
         check_comparison_for_missing_or_invalid_sql_strings(
             sql_dialect="duckdb",
             comparisons_to_check=[
-                Comparison(email_comparison_to_check),
-                Comparison(city_comparison_to_check),
+                Comparison(**email_comparison_to_check),
+                Comparison(**city_comparison_to_check),
                 LevenshteinAtThresholds("first_name").get_comparison("duckdb"),
             ],
             valid_input_dataframe_columns=VALID_INPUT_COLUMNS,


### PR DESCRIPTION
Following on from #1904, this does a similar thing from `Comparison` - namely it switches from accepting a dictionary to using specific parameters.

This is fairly 'light touch', as any more serious work requires the next step (the `Settings`) to be done first. Included:
* `comparison_dict` arg dropped in favour of the entry parameters
* `Comparison` is now dialected (at least for the moment), so don't need to handle optional case any longer
* `output_column_name` and `comparison_description` are simple (public) attributes, using the existing logic for default values