### PR TITLE
use .sql not .execute

### DIFF
--- a/splink/duckdb/linker.py
+++ b/splink/duckdb/linker.py
@@ -222,7 +222,7 @@ class DuckDBLinker(Linker):
         return DuckDBDataFrame(templated_name, physical_name, self)
 
     def _run_sql_execution(self, final_sql, templated_name, physical_name):
-        self._con.execute(final_sql)
+        self._con.sql(final_sql)
 
     def register_table(self, input, table_name, overwrite=False):
         # If the user has provided a table name, return it as a SplinkDataframe


### PR DESCRIPTION
Improves runtimes - see https://github.com/moj-analytical-services/splink/issues/1950 for description and benchmarking

Closes https://github.com/moj-analytical-services/splink/issues/1950