### PR TITLE
Fix docs build

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes #1948.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
After #1917 the link-checking broke. This appears to be because the file `CONTRIBUTING.md` lives _outside_ the `docs/` folder and so is not included in the build. Presumably one of the dependencies I removed did some magic to allow this previously.

This adds a symlink in `docs/` to the original file, so that to `mkdocs` it appears in the correct place, and we don't need to worry about keeping both copies in sync. The link rewriting for `CONTRIBUTING.md` is already handled from #1913.

[This dummy PR](https://github.com/ADBond/splink/pull/24) shows the docs CI passing the link-checking okay now.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


