### PR TITLE
(Try to) fix css styling for the summary/details tags in .vega-embed

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,5 +1,12 @@
-
 code.language-python > span:not(:first-child) {
-    font-size: small;
-    color: rgb(113 112 112);
+  font-size: small;
+  color: rgb(113 112 112);
+}
+
+.vega-embed details,
+.vega-embed summary details,
+.vega-embed summary,
+.vega-embed summary::before,
+.vega-embed summary::after {
+  all: initial;
 }


### PR DESCRIPTION
An attempt to get rid of the blue box on the right here, which is inheriting styling from summary details tags in the main markdown content.  Seems to work locally, dunno if will work when deployed but shouldn't do any harm 🤞 

<img width="754" alt="image" src="https://github.com/moj-analytical-services/splink/assets/2608005/e6cc9f45-6a46-441c-96d6-5f605f68c2f8">

