### PR TITLE
SplinkDataFrame metadata in clustering + metrics

### DIFF
--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2102,6 +2102,7 @@ class Linker:
             pairwise_formatting,
             filter_pairwise_format_for_clusters,
         )
+        cc.metadata["threshold_match_probability"] = threshold_match_probability
 
         return cc
 
@@ -2152,6 +2153,9 @@ class Linker:
 
         df_node_metrics = self._execute_sql_pipeline()
 
+        df_node_metrics.metadata[
+            "threshold_match_probability"
+        ] = threshold_match_probability
         return df_node_metrics
 
     def _compute_metrics_edges(
@@ -2183,9 +2187,13 @@ class Linker:
         | s1-__-10021           | s1-__-10024             | True      |
         ...
         """
-        return compute_edge_metrics(
+        df_edge_metrics = compute_edge_metrics(
             self, df_node_metrics, df_predict, df_clustered, threshold_match_probability
         )
+        df_edge_metrics.metadata[
+            "threshold_match_probability"
+        ] = threshold_match_probability
+        return df_edge_metrics
 
     def _compute_metrics_clusters(
         self,
@@ -2224,6 +2232,9 @@ class Linker:
             self._enqueue_sql(sql["sql"], sql["output_table_name"])
 
         df_cluster_metrics = self._execute_sql_pipeline()
+        df_cluster_metrics.metadata[
+            "threshold_match_probability"
+        ] = df_node_metrics.metadata["threshold_match_probability"]
         return df_cluster_metrics
 
     # a user-facing function, which is currently 'private' (Beta functionality)
@@ -2233,7 +2244,7 @@ class Linker:
         df_predict: SplinkDataFrame,
         df_clustered: SplinkDataFrame,
         *,
-        threshold_match_probability: float,
+        threshold_match_probability: float = None,
     ) -> GraphMetricsResults:
         """
         Generates tables containing graph metrics (for nodes, edges and clusters),
@@ -2243,9 +2254,11 @@ class Linker:
             df_predict (SplinkDataFrame): The results of `linker.predict()`
             df_clustered (SplinkDataFrame): The outputs of
                 `linker.cluster_pairwise_predictions_at_threshold()`
-            threshold_match_probability (float): Filter the pairwise match predictions
-                to include only pairwise comparisons with a match_probability at or
-                above this threshold.
+            threshold_match_probability (float, optional): Filter the pairwise match
+                predictions to include only pairwise comparisons with a
+                match_probability at or above this threshold. If not provided, the value
+                will be taken from metadata on `df_clustered`. If no such metadata is
+                available, this value _must_ be provided.
 
         Returns:
             GraphMetricsResult: A data class containing SplinkDataFrames
@@ -2255,6 +2268,18 @@ class Linker:
                 attribute "clusters" for cluster metrics table
 
         """
+        if threshold_match_probability is None:
+            threshold_match_probability = df_clustered.metadata.get(
+                "threshold_match_probability", None
+            )
+            # we may not have metadata if clusters have been manually registered, or
+            # read in from a format that does not include it
+            if threshold_match_probability is None:
+                raise TypeError(
+                    "As `df_clustered` has no threshold metadata associated to it, "
+                    "to compute graph metrics you must provide "
+                    "`threshold_match_probability` manually"
+                )
         df_node_metrics = self._compute_metrics_nodes(
             df_predict, df_clustered, threshold_match_probability
         )

--- a/splink/splink_dataframe.py
+++ b/splink/splink_dataframe.py
@@ -18,13 +18,20 @@ class SplinkDataFrame:
     Uses methods like `as_pandas_dataframe()` and `as_record_dict()` to retrieve data
     """
 
-    def __init__(self, templated_name: str, physical_name: str, linker: Linker):
+    def __init__(
+        self,
+        templated_name: str,
+        physical_name: str,
+        linker: Linker,
+        metadata: dict = None,
+    ):
         self.templated_name = templated_name
         self.physical_name = physical_name
         self.linker = linker
         self._target_schema = "splink"
         self.created_by_splink = False
         self.sql_used_to_create = None
+        self.metadata = metadata or {}
 
     @property
     def columns(self):

--- a/tests/test_cluster_metrics.py
+++ b/tests/test_cluster_metrics.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from pandas.testing import assert_frame_equal
-from pytest import approx
+from pytest import approx, raises
 
 from splink.duckdb.duckdb_comparison_library import (
     exact_match,
@@ -40,7 +40,7 @@ def test_size_density_dedupe():
     df_clustered = linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.9)
 
     df_result = linker._compute_graph_metrics(
-        df_predict, df_clustered, threshold_match_probability=0.9
+        df_predict, df_clustered
     ).clusters.as_pandas_dataframe()
     # not testing this here - it's not relevant for small clusters anyhow
     del df_result["cluster_centralisation"]
@@ -361,3 +361,89 @@ def test_is_bridge(dialect, test_helpers):
                 f"Expected is_bridge {expected_is_bridge} for edge {node_l}, {node_r}, "
                 f"but found is_bridge: {calculated_is_bridge}"
             )
+
+
+def test_no_threshold_provided():
+    df_e = pd.DataFrame(
+        [
+            {
+                "unique_id_l": 1,
+                "name_l": "trame",
+                "unique_id_r": 2,
+                "name_r": "scrame",
+                "match_probability": 0.99,
+            },
+        ]
+    )
+    df_c = pd.DataFrame(
+        [
+            {"cluster_id": 1, "unique_id": 1, "name": "trame"},
+            {"cluster_id": 1, "unique_id": 2, "name": "scrame"},
+        ]
+    )
+
+    settings = {"link_type": "dedupe_only"}
+    linker = DuckDBLinker(df_1, settings)
+
+    df_predict = linker.register_table(df_e, "predict")
+    df_clustered = linker.register_table(df_c, "clusters")
+
+    with raises(TypeError):
+        # no threshold_match_probability, no metadata
+        _ = linker._compute_graph_metrics(df_predict, df_clustered)
+
+
+def test_override_metadata_threshold():
+    df_e = pd.DataFrame(
+        [
+            # three edges at >= 0.9
+            # two at >= 0.95
+            make_edge_row(1, 2, 1, 0.95, None),
+            make_edge_row(2, 3, 1, 0.96, None),
+            make_edge_row(1, 3, 1, 0.92, None),
+        ]
+    )
+    df_c = pd.DataFrame([{"cluster_id": 1, "unique_id": i} for i in range(1, 3 + 1)])
+    settings = {"link_type": "dedupe_only"}
+    linker = DuckDBLinker(df_1, settings)
+    # linker.debug_mode = True
+    df_predict = linker.register_table(df_e, "predict")
+    df_clustered = linker.register_table(df_c, "clusters")
+    df_clustered.metadata["threshold_match_probability"] = 0.95
+
+    gm_results_95 = linker._compute_graph_metrics(df_predict, df_clustered)
+    gm_results_9 = linker._compute_graph_metrics(
+        df_predict, df_clustered, threshold_match_probability=0.9
+    )
+    df_expected_95 = pd.DataFrame(
+        [
+            {
+                "cluster_id": 1,
+                "n_nodes": 3,
+                "n_edges": 2.0,
+                "density": 2 / 3,
+                "cluster_centralisation": 1.0,
+            },
+        ]
+    )
+    df_expected_9 = pd.DataFrame(
+        [
+            {
+                "cluster_id": 1,
+                "n_nodes": 3,
+                "n_edges": 3.0,
+                "density": 1.0,
+                "cluster_centralisation": 0.0,
+            },
+        ]
+    )
+    assert_frame_equal(
+        gm_results_95.clusters.as_pandas_dataframe(),
+        df_expected_95,
+        check_index_type=False,
+    )
+    assert_frame_equal(
+        gm_results_9.clusters.as_pandas_dataframe(),
+        df_expected_9,
+        check_index_type=False,
+    )


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Closes #1971. It does not include saving metadata in parquet - will open a separate issue for this.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
`SplinkDataFrame` holds a dict attribute `metadata` which we can use to store whatever we want.

This stores `threshold_match_probability` on frames when we:
* cluster pairwise
* compute cluster metrics

In the latter we use the former metadata (if available) when no explicit threshold parameter is provided.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


