### PR TITLE
De-Comparison ComparisonLevel

### DIFF
--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -239,7 +239,10 @@ class Comparison:
                 output_cols.extend(col.tf_name_l_r)
 
         # Bayes factor case when statement
-        sqls = [cl._bayes_factor_sql for cl in self.comparison_levels]
+        sqls = [
+            cl._bayes_factor_sql(self._gamma_column_name)
+            for cl in self.comparison_levels
+        ]
         sql = " ".join(sqls)
         sql = f"CASE {sql} END as {self._bf_column_name} "
         output_cols.append(sql)
@@ -247,7 +250,10 @@ class Comparison:
         # tf adjustment case when statement
 
         if self._has_tf_adjustments:
-            sqls = [cl._tf_adjustment_sql for cl in self.comparison_levels]
+            sqls = [
+                cl._tf_adjustment_sql(self._gamma_column_name, self.comparison_levels)
+                for cl in self.comparison_levels
+            ]
             sql = " ".join(sqls)
             sql = f"CASE {sql} END as {self._bf_tf_adj_column_name} "
             output_cols.append(sql)
@@ -372,7 +378,10 @@ class Comparison:
         for cl in self.comparison_levels:
             record = {}
             record["comparison_name"] = self.output_column_name
-            record = {**record, **cl._as_detailed_record}
+            record = {
+                **record,
+                **cl._as_detailed_record(self._num_levels, self.comparison_levels),
+            }
             records.append(record)
         return records
 
@@ -380,7 +389,9 @@ class Comparison:
     def _parameter_estimates_as_records(self):
         records = []
         for cl in self.comparison_levels:
-            new_records = cl._parameter_estimates_as_records
+            new_records = cl._parameter_estimates_as_records(
+                self._num_levels, self.comparison_levels
+            )
             for r in new_records:
                 r["comparison_name"] = self.output_column_name
             records.extend(new_records)

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING, List, Optional
 
-from .comparison_level import ComparisonLevel
+from .comparison_level import ComparisonLevel, _default_m_values, _default_u_values
 from .misc import dedupe_preserving_order, join_list_with_commas_final_and
 
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
@@ -64,11 +64,7 @@ class Comparison:
         column_info_settings: ColumnInfoSettings = None,
     ):
 
-        self.comparison_levels: list[ComparisonLevel] = []
-
-        for cl in comparison_levels:
-            cl.comparison = self
-            self.comparison_levels.append(cl)
+        self.comparison_levels: list[ComparisonLevel] = comparison_levels
 
         self.column_info_settings: Optional[ColumnInfoSettings] = column_info_settings
 
@@ -84,6 +80,8 @@ class Comparison:
         num_levels = self._num_levels
         counter = num_levels - 1
 
+        default_m_values = _default_m_values(num_levels)
+        default_u_values = _default_u_values(num_levels)
         for level in self.comparison_levels:
             if level.is_null_level:
                 level._comparison_vector_value = -1
@@ -95,6 +93,12 @@ class Comparison:
                 else:
                     level._max_level = False
                 counter -= 1
+            level.default_m_probability = default_m_values[
+                level._comparison_vector_value
+            ]
+            level.default_u_probability = default_u_values[
+                level._comparison_vector_value
+            ]
 
     def __deepcopy__(self, memo):
         """When we do EM training, we need a copy of the Comparison which is independent

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -226,16 +226,6 @@ class ComparisonLevel:
     def m_probability(self, value):
         if self.is_null_level:
             raise AttributeError("Cannot set m_probability when is_null_level is true")
-        if value == LEVEL_NOT_OBSERVED_TEXT:
-            cc_n = self.comparison.output_column_name
-            cl_n = self.label_for_charts
-            if not self._m_warning_sent:
-                logger.warning(
-                    "WARNING:\n"
-                    f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
-                    "unable to train m value\n"
-                )
-                self._m_warning_sent = True
 
         self._m_probability = value
 
@@ -254,16 +244,6 @@ class ComparisonLevel:
     def u_probability(self, value):
         if self.is_null_level:
             raise AttributeError("Cannot set u_probability when is_null_level is true")
-        if value == LEVEL_NOT_OBSERVED_TEXT:
-            cc_n = self.comparison.output_column_name
-            cl_n = self.label_for_charts
-            if not self._u_warning_sent:
-                logger.warning(
-                    "WARNING:\n"
-                    f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
-                    "unable to train u value\n"
-                )
-                self._u_warning_sent = True
         self._u_probability = value
 
     @property

--- a/splink/estimate_u.py
+++ b/splink/estimate_u.py
@@ -179,7 +179,10 @@ def estimate_u_values(linker: Linker, max_pairs, seed=None):
     for c in original_settings_obj.comparisons:
         for cl in c._comparison_levels_excluding_null:
             append_u_probability_to_comparison_level_trained_probabilities(
-                cl, m_u_records_lookup, "estimate u by random sampling"
+                cl,
+                m_u_records_lookup,
+                c.output_column_name,
+                "estimate u by random sampling",
             )
 
     logger.info("\nEstimated u probabilities using random sampling")

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -161,20 +161,20 @@ def populate_m_u_from_lookup(
     fix_m_probabilities: bool,
     fix_u_probabilities: bool,
     comparison_level: ComparisonLevel,
+    output_column_name: str,
     m_u_records_lookup,
 ) -> None:
     cl = comparison_level
-    c = comparison_level.comparison
 
     if not fix_m_probabilities:
         try:
-            m_probability = m_u_records_lookup[c.output_column_name][
+            m_probability = m_u_records_lookup[output_column_name][
                 cl._comparison_vector_value
             ]["m_probability"]
 
         except KeyError:
             m_probability = LEVEL_NOT_OBSERVED_TEXT
-            cc_n = c.output_column_name
+            cc_n = output_column_name
             cl_n = cl.label_for_charts
             if not cl._m_warning_sent:
                 logger.warning(
@@ -187,14 +187,14 @@ def populate_m_u_from_lookup(
 
     if not fix_u_probabilities:
         try:
-            u_probability = m_u_records_lookup[c.output_column_name][
+            u_probability = m_u_records_lookup[output_column_name][
                 cl._comparison_vector_value
             ]["u_probability"]
 
         except KeyError:
             u_probability = LEVEL_NOT_OBSERVED_TEXT
 
-            cc_n = c.output_column_name
+            cc_n = output_column_name
             cl_n = cl.label_for_charts
             if not cl._u_warning_sent:
                 logger.warning(
@@ -231,6 +231,7 @@ def maximisation_step(
                 em_training_session._training_fix_m_probabilities,
                 em_training_session._training_fix_u_probabilities,
                 cl,
+                cc.output_column_name,
                 m_u_records_lookup,
             )
 

--- a/splink/expectation_maximisation.py
+++ b/splink/expectation_maximisation.py
@@ -165,7 +165,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
     c = comparison_level.comparison
-    # em_training_session._training_fix_m_probabilities
+
     if not fix_m_probabilities:
         try:
             m_probability = m_u_records_lookup[c.output_column_name][
@@ -174,6 +174,15 @@ def populate_m_u_from_lookup(
 
         except KeyError:
             m_probability = LEVEL_NOT_OBSERVED_TEXT
+            cc_n = c.output_column_name
+            cl_n = cl.label_for_charts
+            if not cl._m_warning_sent:
+                logger.warning(
+                    "WARNING:\n"
+                    f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
+                    "unable to train m value\n"
+                )
+                cl._m_warning_sent = True
         cl.m_probability = m_probability
 
     if not fix_u_probabilities:
@@ -184,6 +193,16 @@ def populate_m_u_from_lookup(
 
         except KeyError:
             u_probability = LEVEL_NOT_OBSERVED_TEXT
+
+            cc_n = c.output_column_name
+            cl_n = cl.label_for_charts
+            if not cl._u_warning_sent:
+                logger.warning(
+                    "WARNING:\n"
+                    f"Level {cl_n} on comparison {cc_n} not observed in dataset, "
+                    "unable to train u value\n"
+                )
+                cl._u_warning_sent = True
 
         cl.u_probability = u_probability
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -860,7 +860,7 @@ class Linker:
                 em_training_session._settings_obj._probability_two_random_records_match
             )
             training_lambda_bf = prob_to_bayes_factor(training_lambda)
-            reverse_levels = (
+            reverse_level_infos = (
                 em_training_session._comparison_levels_to_reverse_blocking_rule
             )
 
@@ -872,10 +872,13 @@ class Linker:
                 f"{training_lambda:,.3f}",
             )
 
-            for reverse_level in reverse_levels:
+            for reverse_level_info in reverse_level_infos:
                 # Get comparison level on current settings obj
+                # TODO: do we need this dance? We already have the level + comparison
+                # maybe they are different copies with different values?
+                reverse_level = reverse_level_info["level"]
                 cc = self._settings_obj._get_comparison_by_output_column_name(
-                    reverse_level.comparison.output_column_name
+                    reverse_level_info["output_column_name"]
                 )
 
                 cl = cc._get_comparison_level_by_comparison_vector_value(

--- a/splink/m_from_labels.py
+++ b/splink/m_from_labels.py
@@ -54,7 +54,10 @@ def estimate_m_from_pairwise_labels(linker, table_name):
     for cc in linker._settings_obj.comparisons:
         for cl in cc._comparison_levels_excluding_null:
             append_m_probability_to_comparison_level_trained_probabilities(
-                cl, m_u_records_lookup, "estimate m from pairwise labels"
+                cl,
+                m_u_records_lookup,
+                cc.output_column_name,
+                "estimate m from pairwise labels",
             )
 
     linker._populate_m_u_from_trained_values()

--- a/splink/m_training.py
+++ b/splink/m_training.py
@@ -71,5 +71,8 @@ def estimate_m_values_from_label_column(linker, df_dict, label_colname):
     for cc in original_settings_object.comparisons:
         for cl in cc._comparison_levels_excluding_null:
             append_m_probability_to_comparison_level_trained_probabilities(
-                cl, m_u_records_lookup, "estimate m from label column"
+                cl,
+                m_u_records_lookup,
+                cc.output_column_name,
+                "estimate m from label column",
             )

--- a/splink/m_u_records_to_parameters.py
+++ b/splink/m_u_records_to_parameters.py
@@ -29,11 +29,12 @@ def m_u_records_to_lookup_dict(m_u_records: List[dict]) -> Dict[str, dict]:
     return lookup
 
 
-def not_trained_message(comparison_level: ComparisonLevel) -> str:
-    c = comparison_level.comparison
+def not_trained_message(
+    comparison_level: ComparisonLevel, output_column_name: str
+) -> str:
     cl = comparison_level
     return (
-        f"not trained for {c.output_column_name} - "
+        f"not trained for {output_column_name} - "
         f"{cl.label_for_charts} (comparison vector value: "
         f"{cl._comparison_vector_value}). This usually means the "
         "comparison level was never observed in the training data."
@@ -43,20 +44,20 @@ def not_trained_message(comparison_level: ComparisonLevel) -> str:
 def append_u_probability_to_comparison_level_trained_probabilities(
     comparison_level: ComparisonLevel,
     m_u_records_lookup: Dict,
+    output_column_name: str,
     training_description: str,
 ) -> None:
     cl = comparison_level
-    c = cl.comparison
 
     try:
-        u_probability = m_u_records_lookup[c.output_column_name][
+        u_probability = m_u_records_lookup[output_column_name][
             cl._comparison_vector_value
         ]["u_probability"]
 
     except KeyError:
         u_probability = LEVEL_NOT_OBSERVED_TEXT
 
-        logger.info(f"u probability {not_trained_message(cl)}")
+        logger.info(f"u probability {not_trained_message(cl, output_column_name)}")
     cl._add_trained_u_probability(
         u_probability,
         training_description,
@@ -66,20 +67,20 @@ def append_u_probability_to_comparison_level_trained_probabilities(
 def append_m_probability_to_comparison_level_trained_probabilities(
     comparison_level: ComparisonLevel,
     m_u_records_lookup: Dict,
+    output_column_name: str,
     training_description: str,
 ) -> None:
     cl = comparison_level
-    c = cl.comparison
 
     try:
-        m_probability = m_u_records_lookup[c.output_column_name][
+        m_probability = m_u_records_lookup[output_column_name][
             cl._comparison_vector_value
         ]["m_probability"]
 
     except KeyError:
         m_probability = LEVEL_NOT_OBSERVED_TEXT
 
-        logger.info(f"m probability {not_trained_message(cl)}")
+        logger.info(f"m probability {not_trained_message(cl, output_column_name)}")
     cl._add_trained_m_probability(
         m_probability,
         training_description,

--- a/splink/predict.py
+++ b/splink/predict.py
@@ -100,7 +100,9 @@ def predict_from_agreement_pattern_counts_sqls(
     select_cols = []
 
     for cc in comparisons:
-        cc_sqls = [cl._bayes_factor_sql for cl in cc.comparison_levels]
+        cc_sqls = [
+            cl._bayes_factor_sql(cc._gamma_column_name) for cl in cc.comparison_levels
+        ]
         sql = " ".join(cc_sqls)
         sql = f"CASE {sql} END as {cc._bf_column_name}"
         select_cols.append(cc._gamma_column_name)


### PR DESCRIPTION
Partial work for #1983, but relatively self-contained.

This removes the `.comparison` attribute from `ComparisonLevel`, which IMO led to code that was a bit difficult to navigate/manage.
In almost all instances in which you wish to ask something of a `ComparisonLevel` which requires comparison-wide information, you have access to the `Comparison` itself (there were one or two small exceptions where that info was further upstream, but has not required too much hacking). This change therefore is to pass whatever information the `ComparisonLevel` needs when you are asking about properties, rather than it reading it off the `.comparison`.

We now don't have to manage copying so carefully, as there is no circular reference, which combined with removing the full `Settings` from `Comparison` (as in #1983) should simplify things somewhat.

A (possibly) noteworthy detail of this is that default m/u values now live on the `ComparisonLevel` itself, when it is associated to a `Comparison`. These are vestiges of the previous system, but I think that it is reasonable to keep them as
* they are simple values, and only have a small surface, so less complex to manage
* I think it is probably useful to have these default values a little more visible anyhow.