### PR TITLE
sqlglot.parse_one - use read keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Bug that prevented `sqlglot <= 17.0.0` from working properly ([#1996](https://github.com/moj-analytical-services/splink/pull/1996))
+
 ## [3.9.12] - 2024-01-30
 
 ### Fixed

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -106,7 +106,7 @@ class SqlglotColumnTreeBuilder:
 
         # If the raw string parses to a valid signature, use it
         try:
-            tree = sqlglot.parse_one(input_str, dialect=sqlglot_dialect)
+            tree = sqlglot.parse_one(input_str, read=sqlglot_dialect)
         except (sqlglot.ParseError, sqlglot.TokenError):
             pass
         else:
@@ -123,7 +123,7 @@ class SqlglotColumnTreeBuilder:
         q_s, q_e = _get_dialect_quotes(sqlglot_dialect)
         input_str = add_quotes_to_column_name(input_str, q_s, q_e)
         try:
-            tree = sqlglot.parse_one(input_str, dialect=sqlglot_dialect)
+            tree = sqlglot.parse_one(input_str, read=sqlglot_dialect)
         except (sqlglot.ParseError, sqlglot.TokenError):
             pass
         else:


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Fixes #1995.

For older versions (before `17.1.0`) of `sqlglot`, `SqlglotColumnTreeBuilder.from_raw_column_name_or_column_reference`
would break.

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
in 17.1.0 the `dialect` keyword argument was introduced as a synonym for `read`. But this breaks on earlier versions of `sqlglot`, so this changes to use the `read` parameter, which is compatible with 'all' (that we support) versions of `sqlglot`.

As a side-point, I wonder if it makes sense for us to wrap `parse_one`, as we use it in several places in the codebase? That way if in the future the api changes and we need to provide compatibility code, we only need it in one place. We also avoid these kinds of issues, as we wouldn't need to add further calls (directly) to `parse_one`, where it would be easy to accidentally use `dialect=` if the developer has a newer `sqlglot` installed (and as used in CI).

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [x] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


