### PR TITLE
allow getting case statement from comparison without settings

### DIFF
--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -80,9 +80,9 @@ class Comparison:
                 cl = ComparisonLevel(
                     **cl,
                     comparison=self,
-                    sqlglot_dialect_name=(
-                        None if settings_obj is None else settings_obj._sql_dialect
-                    ),
+                    sqlglot_dialect_name=None
+                    if settings_obj is None
+                    else settings_obj._sql_dialect,
                 )
 
             self.comparison_levels.append(cl)

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -80,9 +80,9 @@ class Comparison:
                 cl = ComparisonLevel(
                     **cl,
                     comparison=self,
-                    sqlglot_dialect_name=None
-                    if settings_obj is None
-                    else settings_obj._sql_dialect,
+                    sqlglot_dialect_name=(
+                        None if settings_obj is None else settings_obj._sql_dialect
+                    ),
                 )
 
             self.comparison_levels.append(cl)
@@ -143,6 +143,8 @@ class Comparison:
 
     @property
     def gamma_prefix(self):
+        if self.column_info_settings is None:
+            return "gamma_"
         return self.column_info_settings.comparison_vector_value_column_prefix
 
     @property
@@ -151,7 +153,10 @@ class Comparison:
 
     @property
     def _bf_column_name(self):
-        bf_prefix = self.column_info_settings.bayes_factor_column_prefix
+        if self.column_info_settings is None:
+            bf_prefix = "bf_"
+        else:
+            bf_prefix = self.column_info_settings.bayes_factor_column_prefix
         return f"{bf_prefix}{self.output_column_name}".replace(" ", "_")
 
     @property


### PR DESCRIPTION
Prior to this PR, code like:
```
from splink.comparison import Comparison
from splink.comparison_level import ComparisonLevel
from splink.comparison_library import ExactMatch

ExactMatch("dob").get_comparison("duckdb")._case_statement
```

Would fail with 
```
[~/Documents/data_linking/splink_4_311/splink/comparison.py](https://file+.vscode-resource.vscode-cdn.net/Users/robinlinacre/Documents/data_linking/splink_4_311/~/Documents/data_linking/splink_4_311/splink/comparison.py) in gamma_prefix(self)
    144     @property
    145     def gamma_prefix(self):
--> 146         return self.column_info_settings.comparison_vector_value_column_prefix
    147 
    148     @property

AttributeError: 'NoneType' object has no attribute 'comparison_vector_value_column_prefix'
```

It's quite useful to be able to quickly see the actual SQL generated.  This PR ensures that more of the `Comparison` functionality works even if it hasn't been passed `column_info_settings`