### PR TITLE
Refine additional installs in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Splink is a Python package for probabilistic record linkage (entity resolution) 
 🎓 **Unsupervised Learning:** No training data is required for model training.  
 📊 **Interactive Outputs:** A suite of interactive visualisations help users understand their model and diagnose problems.  
 
-Splink's linkage algorithm is based on Fellegi-Sunter's model of record linkage, with various customizations to improve accuracy.
+Splink's linkage algorithm is based on Fellegi-Sunter's model of record linkage, with various customisations to improve accuracy.
 
 ## What does Splink do?
 
@@ -38,7 +38,7 @@ and clusters these links to produce an estimated person ID:
 
 ## What data does Splink work best with?
 
-Before using Splink, input data should be standardized, with consistent column names and formatting (e.g., lowercased, punctuation cleaned up, etc.).
+Before using Splink, input data should be standardised, with consistent column names and formatting (e.g., lowercased, punctuation cleaned up, etc.).
 
 Splink performs best with input data containing **multiple** columns that are **not highly correlated**. For instance, if the entity type is persons, you may have columns for full name, date of birth, and city. If the entity type is companies, you could have columns for name, turnover, sector, and telephone number.
 

--- a/README.md
+++ b/README.md
@@ -70,40 +70,18 @@ or, if you prefer, you can instead install splink using conda:
 conda install -c conda-forge splink
 ```
 
+### Installing Splink for Specific Backends
+
+
+For projects requiring specific backends, Splink offers optional installations for **Spark**, **Athena**, and **PostgreSQL**. These can be installed by appending the backend name in brackets to the pip install command:
+```sh
+pip install 'splink[{backend}]'
+```
+
+Should you require a version of Splink without **DuckDB**, see our section on [DuckDBLess Splink Installation](https://moj-analytical-services.github.io/splink/installations.html#duckdb-less-installation).
+
 <details>
-<summary><h3>Additional installation methods</h3></summary>
-
-<br>
-
-### Backend Specific Installs
-From Splink v3.9.7, packages required by specific splink backends can be optionally installed by adding the `[<backend>]` suffix to the end of your `pip install`.
-
-**Note** that **SQLite** and **DuckDB** come packaged with Splink and do not need to be optionally installed.
-
-Backends supported by optional installs:
-
-**Spark**
-```sh
-pip install 'splink[spark]'
-```
-
-**Athena**
-```sh
-pip install 'splink[athena]'
-```
-
-**PostgreSQL**
-```sh
-pip install 'splink[postgres]'
-```
-
-<br>
-
-### DuckDBLess Splink
-Should you require a more bare-bones version of Splink **without DuckDB**, please see the following area of the docs:
-> [DuckDBless Splink Installation](https://moj-analytical-services.github.io/splink/installations.html#duckdb-less-installation)
-
-</details>
+<summary>Click here for backend-specific installation commands</summary>
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,23 @@ pip install 'splink[{backend}]'
 Should you require a version of Splink without **DuckDB**, see our section on [DuckDBLess Splink Installation](https://moj-analytical-services.github.io/splink/installations.html#duckdb-less-installation).
 
 <details>
-<summary>Click here for backend-specific installation commands</summary>
+<summary><i>Click here for backend-specific installation commands</i></summary>
+
+#### Spark
+```sh
+pip install 'splink[spark]'
+```
+
+#### Athena
+```sh
+pip install 'splink[athena]'
+```
+
+#### PostgreSQL
+```sh
+pip install 'splink[postgres]'
+```
+</details>
 
 ## Quickstart
 


### PR DESCRIPTION
I noticed earlier that the installation steps in our README have started acting up:
![Screenshot 2024-02-28 at 13 53 30](https://github.com/moj-analytical-services/splink/assets/45356472/b8dedcfd-295c-416f-9e89-169b0e509b47)

I've done some quick tidying to this section of the docs, that should resolve this issue and clean up some of the language used.

While I was at it, I also removed a couple of Americanism I identified in the README.