### PR TITLE
Fix mkdocs rendering symbols in notebook code

### DIFF
--- a/docs/hooks/__init__.py
+++ b/docs/hooks/__init__.py
@@ -73,7 +73,7 @@ def re_route_links(markdown: str, page_title: str) -> str | None:
     return re.sub(docs_folder_regex, "", markdown)
 
 
-def on_page_markdown_hook(
+def on_page_markdown(
     markdown: str, page: Page, config: MkDocsConfig, files: Files
 ) -> str | None:
     """

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,9 +67,8 @@ plugins:
       match_path: blog/posts/.*
       date_from_meta:
         as_creation: date
-  - mkdocs-simple-hooks:
-      hooks:
-        on_page_markdown: "docs.hooks:on_page_markdown_hook"
+hooks:
+  - docs/hooks/__init__.py
 
 markdown_extensions:
   - abbr

--- a/scripts/docs-requirements.txt
+++ b/scripts/docs-requirements.txt
@@ -7,7 +7,6 @@ mkdocs-autorefs
 mkdocs-material-extensions
 mkdocs-mermaid2-plugin
 mkdocs-monorepo-plugin
-mkdocs-simple-hooks==0.1.5
 mkdocstrings
 mkdocstrings-python
 mkdocstrings-python-legacy


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Closes #1767.

Was also ultimately the root cause of #2018.

The issue is that the [`mknotebooks` plugin](https://github.com/ADBond/splink/blob/gh-pages/demos/examples/spark/deduplicate_1k_synthetic.html) converts `.ipynb` files into `.html` files, via `nbconvert`. As such, in code-blocks when we have a `'<'` literal (such as in custom SQL for comparisons, or blocking rules) it is converted to `'&lt;'` so that it can be correctly displayed as part of the html.
But at some later stage this html is processed by `mkdocs` itself, and it escapes everything in a code-block (so that for instance blocks of html code would display correctly), so this then gets converted to `'&amp;lt;'` - i.e. the ampersand gets rendered as-is.

[NB: I'm not certain on all of the details here, but this seems to at least approximately be what is occurring]

Ultimately this means we end up with code that appears as e.g.
```py
deterministic_rules = [
    "l.first_name = r.first_name and levenshtein(r.dob, l.dob) &lt;= 1",
    "l.surname = r.surname and levenshtein(r.dob, l.dob) &lt;= 1",
    "l.first_name = r.first_name and levenshtein(r.surname, l.surname) &lt;= 2",
    "l.email = r.email"
]
```
which is incorrect, and as the code will copy as such, will lead to confusing errors for anyone who tries to run it.

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
In the end the most straightforward solution was to override the mkdocs `config` option which `mknotebooks` uses to convert notebook files with a class that converts to markdown, rather than html (with the md -> html conversion handled by mkdocs as usual).
This runs as a hook _after_ any other `on_config` hooks/plugins run, so we make sure to override the `mknotebooks` version.

This may not be a fully general solution for any configuration of `mknotebooks`, but as we are using only a simple set of its features there should not be a problem.

See [the built version on my fork](https://github.com/ADBond/splink/blob/gh-pages/demos/examples/spark/deduplicate_1k_synthetic.html).

Additionally in the course of researching this I discovered that `mkdocs-simple-hooks` (which I introduced in #1913) [is deprecated](https://github.com/aklajnert/mkdocs-simple-hooks?tab=readme-ov-file#deprecated), as the functionality is included in core `mkdocs` since 1.4, so I ditched this dependency and used the native `hooks` feature.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)


