### PR TITLE
Bug report template - add label + update master install instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Create a report to help us improve
+labels: 'bug'
 body:
   - type: textarea
     attributes:
@@ -40,7 +41,7 @@ body:
     attributes:
       label: Have you tried this on the latest `master` branch?
       description: |
-        * **Python**: `pip install splink --upgrade --pre`
+        * **Python**: `pip install git+https://github.com/moj-analytical-services/splink.git@master`
 
       options:
         - label: I agree


### PR DESCRIPTION
Have updated the bug request template for the step of checking if the bug exists on `master` - the previous instructions now install our Splink 4 pre-release, so could lead to some confusion, assuming the reports are for existing Splink 3 releases (and those that aren't this doesn't really apply anyway).

Also now adds the 'bug' label automatically.