### PR TITLE
Add dirty reload for much faster updates

### DIFF
--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -7,7 +7,7 @@
 if [[ "$VIRTUAL_ENV" != "$cwd/docs-venv" ]]; then
     if [ -n "$VIRTUAL_ENV" ]; then
         deactivate
-    else    
+    else
         :
     fi
     python3 -m venv docs-venv
@@ -26,4 +26,4 @@ then
 fi
 
 # can remove verbose flag if needed
-mkdocs serve -v
+mkdocs serve -v --dirtyreload

--- a/scripts/make_docs_locally.sh
+++ b/scripts/make_docs_locally.sh
@@ -7,7 +7,7 @@
 if [[ "$VIRTUAL_ENV" != "$cwd/docs-venv" ]]; then
     if [ -n "$VIRTUAL_ENV" ]; then
         deactivate
-    else
+    else    
         :
     fi
     python3 -m venv docs-venv


### PR DESCRIPTION
By adding `--dirtyreload` to mkdocs serve -v at the end of [the make docs locally](https://github.com/moj-analytical-services/splink/blob/bfaf8d142f7aad03f281b6324dd530e202eaec9a/scripts/make_docs_locally.sh#L29) script, you get almost immediate updates in the browser  of markdown docs you’re editing