### PR TITLE
Docs/more spellchecking

### DIFF
--- a/docs/dev_guides/changing_splink/development_quickstart.md
+++ b/docs/dev_guides/changing_splink/development_quickstart.md
@@ -8,7 +8,7 @@ We highly recommend developing Splink on a Unix-like operating system, such as M
 While it is possible to develop on another operating system such as Windows, we do not provide
 instructions for how to do so.
 
-**Luckily, Windows users can easily fulfill this requirement by installing the Windows Subsystem for Linux (WSL):**
+**Luckily, Windows users can easily fulfil this requirement by installing the Windows Subsystem for Linux (WSL):**
 
 - Open PowerShell as Administrator: Right-click the Start button, select “Windows Terminal (Admin)”, and ensure PowerShell is the selected shell.
 - Run the command `wsl --install`.
@@ -42,7 +42,7 @@ On the other hand, `conda` is particularly suitable if:
 - You're working in an environment where security policies prevent the installation of system level packages like Java
 - You don't want to do global installs of some of the requirements like Java
 
-## Step 3, Manual install option: Install system depedencies
+## Step 3, Manual install option: Install system dependencies
 
 ### Python
 
@@ -114,7 +114,7 @@ and the teardown script each time you want to stop it:
 Included in the docker-compose file is a [pgAdmin](https://www.pgadmin.org/) container to allow easy exploration of the database as you work, which can be accessed in-browser on the default port.
 The default username is `a@b.com` with password `b`.
 
-## Step 3, Conda install option: Install system depedencies
+## Step 3, Conda install option: Install system dependencies
 
 These instructions are the same no matter what operating system you are using.
 As an added benefit, these installations will be specific to the conda environment

--- a/docs/settings_dict_guide.md
+++ b/docs/settings_dict_guide.md
@@ -168,7 +168,7 @@ A list specifying how records should be compared for probabilistic matching.  Ea
 
         #### `sql_condition`
 
-        A branch of a SQL case expression without WHEN and THEN e.g. 'jaro_winkler_sim(surname_l, surname_r) > 0.88'
+        A branch of a SQL case expression without WHEN and THEN e.g. `jaro_winkler_sim(surname_l, surname_r) > 0.88`
 
         **Examples**: `['forename_l = forename_r', 'jaro_winkler_sim(surname_l, surname_r) > 0.88']`
 

--- a/docs/topic_guides/comparisons/phonetic.md
+++ b/docs/topic_guides/comparisons/phonetic.md
@@ -38,7 +38,7 @@ E.g. For a comparison including a [Double Metaphone](#double-metaphone) phonetic
     print(first_name_comparison.human_readable_description)
     ```
 
-> Comparison 'Exact match vs. First_Name within levenshtein threshold 1 vs. First_Name within damerau-levenshtein threshold 1 vs. First_Name within jaro_winkler thresholds 0.9, 0.8 vs. anything else' of "first_name".
+> Comparison 'Exact match vs. First_Name within Levenshtein threshold 1 vs. First_Name within Damerau-Levenshtein threshold 1 vs. First_Name within jaro_winkler thresholds 0.9, 0.8 vs. anything else' of "first_name".
 >
 > Similarity is assessed using the following ComparisonLevels:
 >

--- a/docs/topic_guides/comparisons/phonetic.md
+++ b/docs/topic_guides/comparisons/phonetic.md
@@ -38,7 +38,7 @@ E.g. For a comparison including a [Double Metaphone](#double-metaphone) phonetic
     print(first_name_comparison.human_readable_description)
     ```
 
-> Comparison 'Exact match vs. First_Name within Levenshtein threshold 1 vs. First_Name within Damerau-Levenshtein threshold 1 vs. First_Name within jaro_winkler thresholds 0.9, 0.8 vs. anything else' of "first_name".
+> Comparison 'Exact match vs. First_Name within Levenshtein threshold 1 vs. First_Name within Damerau-Levenshtein threshold 1 vs. First_Name within Jaro-Winkler thresholds 0.9, 0.8 vs. anything else' of "first_name".
 >
 > Similarity is assessed using the following ComparisonLevels:
 >

--- a/docs/topic_guides/comparisons/regular_expressions.md
+++ b/docs/topic_guides/comparisons/regular_expressions.md
@@ -62,7 +62,7 @@ This is achieved below by using `regex_extract="^[0-9]{1,4}"` within a Levenshte
 which gives a comparison with the following levels:
 
 ??? note "Output"
-    > Comparison 'Exact match vs. telephone within levenshtein thresholds 1, 2 vs. anything else' of "telephone".
+    > Comparison 'Exact match vs. telephone within Levenshtein thresholds 1, 2 vs. anything else' of "telephone".
     >
     > Similarity is assessed using the following ComparisonLevels:
     >
@@ -88,8 +88,8 @@ Here is an example set of record comparisons that could have been generated usin
 | person_id_l | person_id_r | telephone_l | telephone_r | comparison_level |
 |-------------|-------------|-------------|-------------|------------------|
 | 7           | 1           | **020** 5555 1234| **020** 4444 4573| exact match |
-| 5           | 3           | **0161** 999 5678| **0160** 333 6521| levenshtein distance <= 1|
-| 5           | 2           | **0161** 999 5678| **160** 221 2198| levenshtein distance <= 2|
+| 5           | 3           | **0161** 999 5678| **0160** 333 6521| Levenshtein distance <= 1|
+| 5           | 2           | **0161** 999 5678| **160** 221 2198| Levenshtein distance <= 2|
 | 4           | 1           | **0141** 777 9876| **020** 4444 4573 | else level|
 | 6           | 7           |                  | **020** 5555 1234 | null level       |
 
@@ -136,8 +136,8 @@ Here is an example set of record comparisons that could have been generated usin
 | person_id_l | person_id_r | email_l | email_r | comparison_level               |
 |-------------|-------------|---------|---------|--------------------------------|
 | 7           | 1           |         |         | exact match                    |
-| 5           | 1           |         |         | jaro-winkler similarity >= 0.9 |
-| 9           | 2           |         |         | jaro-winkler similarity >= 0.7 |
+| 5           | 1           |         |         | Jaro-Winkler similarity >= 0.9 |
+| 9           | 2           |         |         | Jaro-Winkler similarity >= 0.7 |
 | 4           | 8           |         |         | else level                     |
 | 6           | 3           |         |         | null level                     |
 

--- a/docs/topic_guides/comparisons/regular_expressions.md
+++ b/docs/topic_guides/comparisons/regular_expressions.md
@@ -3,7 +3,7 @@
 
 It can sometimes be useful to make comparisons based on substrings or parts of column values. For example, one approach to comparing postcodes is to consider their constituent components, e.g. area, district, etc (see [Featuring Engineering](../data_preparation/feature_engineering.md) for more details).
 
-The `regex_extract` option enables users to do this by supplying a regular expression pattern that defines the substring upon which to evaluate a comparison. This option gives users a convenient means of comparing data within existing columns without needing to engineer new features from source data. `regex_extract` is available to all string comparators, as well as 'exact match' and 'columns reversed' comparisons and levels. 
+The `regex_extract` option enables users to do this by supplying a regular expression pattern that defines the substring upon which to evaluate a comparison. This option gives users a convenient means of comparing data within existing columns without needing to engineer new features from source data. `regex_extract` is available to all string comparators, as well as 'exact match' and 'columns reversed' comparisons and levels.
 
 Further regex functionality is provided by the `valid_string_pattern` option. This option allows users to define a regular expression pattern that specifies a valid string format. Any column value that does not adhere to the given pattern will be treated as a null. This can be useful for enforcing a specific data format during record comparison without needing to revisit and standardised data again. The `valid_string_pattern` argument is available to the null level and can be used with any comparison that contains a null level, e.g. [`exact_match()`](../../comparison_library.md).
 
@@ -28,11 +28,11 @@ This gives a comparison with the following levels:
     > Similarity is assessed using the following ComparisonLevels:
     >
     >    - 'Null' with SQL rule: "postcode_l" IS NULL OR "postcode_r" IS NULL
-    >    - 'Exact match' with SQL rule: 
+    >    - 'Exact match' with SQL rule:
         regexp_extract("postcode_l", '^[A-Z]{1,2}')
-     = 
-        regexp_extract("postcode_r", '^[A-Z]{1,2}')      
-    >    - 'All other comparisons' with SQL rule: ELSE 
+     =
+        regexp_extract("postcode_r", '^[A-Z]{1,2}')
+    >    - 'All other comparisons' with SQL rule: ELSE
 
 Below is an example set of record comparisons that could have been generated using `pc_comparison`. The part of the postcode actually being compared under the hood (the area code) is indicated in bold.
 
@@ -51,7 +51,7 @@ The [postcode comparison template](comparison_templates.ipynb) provides an examp
 
 Using `regex_extract` in a Levenshtein comparison could be useful when comparing telephone numbers. For example, perhaps you only care about matches on dialling code but still want to account for potential typos in the data. (For more information on the different types of string comparators, see [String Comparators](comparators.md).)
 
-This is achieved below by using `regex_extract="^[0-9]{1,4}"` within a levenshtein comparison to restrict the comparison to only the first 3 to 4 digits of a telephone number:
+This is achieved below by using `regex_extract="^[0-9]{1,4}"` within a Levenshtein comparison to restrict the comparison to only the first 3 to 4 digits of a telephone number:
 
 === "DuckDB"
     ```python
@@ -67,21 +67,21 @@ which gives a comparison with the following levels:
     > Similarity is assessed using the following ComparisonLevels:
     >
     >    - 'Null' with SQL rule: "telephone_l" IS NULL OR "telephone_r" IS NULL
-    >    - 'Exact match' with SQL rule: 
+    >    - 'Exact match' with SQL rule:
         regexp_extract("telephone_l", '^[0-9]{1,4}')
-     = 
-        regexp_extract("telephone_r", '^[0-9]{1,4}')      
+     =
+        regexp_extract("telephone_r", '^[0-9]{1,4}')
     >    - 'Levenshtein <= 1' with SQL rule: levenshtein(
         regexp_extract("telephone_l", '^[0-9]{1,4}')
-    , 
+    ,
         regexp_extract("telephone_r", '^[0-9]{1,4}')
-    ) <= 1 
+    ) <= 1
     >    - 'Levenshtein <= 2' with SQL rule: levenshtein(
         regexp_extract("telephone_l", '^[0-9]{1,4}')
-    , 
+    ,
         regexp_extract("telephone_r", '^[0-9]{1,4}')
-    ) <= 2 
-    >    - 'All other comparisons' with SQL rule: ELSE 
+    ) <= 2
+    >    - 'All other comparisons' with SQL rule: ELSE
 
 Here is an example set of record comparisons that could have been generated using `tel_comparison`. The part of the telephone number actually being compared under the hood (the dialling code) is highlighted in bold:
 
@@ -115,18 +115,18 @@ This gives a comparison with the following levels:
     > Similarity is assessed using the following ComparisonLevels:
     >
     > - 'Null' with SQL rule: "email_l" IS NULL OR "email_r" IS NULL
-    > - 'Exact match' with SQL rule: 
+    > - 'Exact match' with SQL rule:
         regexp_extract("email_l", '^[^@]+')
-     = 
+     =
         regexp_extract("email_r", '^[^@]+')
     > - 'Jaro_winkler_similarity >= 0.9' with SQL rule: jaro_winkler_similarity(
         regexp_extract("email_l", '^[^@]+')
-    , 
+    ,
         regexp_extract("email_r", '^[^@]+')
     ) >= 0.9
     > - 'Jaro_winkler_similarity >= 0.7' with SQL rule: jaro_winkler_similarity(
         regexp_extract("email_l", '^[^@]+')
-    , 
+    ,
         regexp_extract("email_r", '^[^@]+')
     ) >= 0.7
     > - 'All other comparisons' with SQL rule: ELSE
@@ -160,13 +160,13 @@ which gives a comparison with the following levels:
     > Comparison 'Exact match vs. anything else' of "postcode".
     >
     > Similarity is assessed using the following ComparisonLevels:
-    > - 'Null' with SQL rule: 
+    > - 'Null' with SQL rule:
         regexp_extract("postcode_l", '^[A-Z]{1,2}[0-9][A-Z0-9]? [0-9][A-Z]{2}$')
-     IS NULL OR 
+     IS NULL OR
         regexp_extract("postcode_r", '^[A-Z]{1,2}[0-9][A-Z0-9]? [0-9][A-Z]{2}$')
-     IS NULL OR  
+     IS NULL OR
         regexp_extract("postcode_l", '^[A-Z]{1,2}[0-9][A-Z0-9]? [0-9][A-Z]{2}$')
-    =='' OR 
+    =='' OR
         regexp_extract("postcode_r", '^[A-Z]{1,2}[0-9][A-Z0-9]? [0-9][A-Z]{2}$')
      ==''
     > - 'Exact match' with SQL rule: "postcode_l" = "postcode_r"

--- a/docs/topic_guides/data_preparation/feature_engineering.md
+++ b/docs/topic_guides/data_preparation/feature_engineering.md
@@ -434,7 +434,7 @@ Now that the dmetaphone columns have been added, they can be used within compari
 
 ## Full name
 
-When comparing names, it can be helpful to [construct a single comparison for for comparing the forename and surname](../comparisons/comparison_templates.ipynb#forename-and-surname-comparisons) of two records. If a splink model has a single comparison for forename and surname, one of the major benefits is being able to consider the term frequency of the full name, as well as for forename and surname individually.
+When comparing names, it can be helpful to [construct a single comparison for for comparing the forename and surname](../comparisons/comparison_templates.ipynb#forename-and-surname-comparisons) of two records. If a Splink model has a single comparison for forename and surname, one of the major benefits is being able to consider the term frequency of the full name, as well as for forename and surname individually.
 
 For example, in the UK, “Mohammed Khan” is a relatively common full name despite neither "Mohammed" or "Khan" occurring frequently as forename or surname, respectively.
 

--- a/docs/topic_guides/splink_fundamentals/backends/postgres.md
+++ b/docs/topic_guides/splink_fundamentals/backends/postgres.md
@@ -102,7 +102,7 @@ When you are finished you can remove these resources:
 
 ### Running with a pre-existing database
 
-If you have a pre-existing postgres server you wish to use to run the tests against, you will need to specify environment variables for the credentials where they differ from default (in parentheses):
+If you have a pre-existing Postgres server you wish to use to run the tests against, you will need to specify environment variables for the credentials where they differ from default (in parentheses):
 
 * `SPLINKTEST_PG_USER` (`splinkognito`)
 * `SPLINKTEST_PG_PASSWORD` (`splink123!`)

--- a/scripts/pyspelling/custom_dictionary.txt
+++ b/scripts/pyspelling/custom_dictionary.txt
@@ -196,6 +196,7 @@ linter
 linters
 missingness
 Missingness
+Miniforge
 PyPI
 paralleism
 parallelise
@@ -217,8 +218,12 @@ schemas
 Splink
 Splink's
 Sunter
+teardown
 tradeoff
+tf
 transpilation
 Transpilation
 unlinkables
 Winkler
+WSL
+zsh


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
This builds on https://github.com/moj-analytical-services/splink/pull/2025, adding more words to the dictionary and correcting any spelling errors that were identified by the spellchecker.


### Give a brief description for the solution you have provided
I have:
* Added some more words and acronyms to the dictionary
* Attempted to capitalise and fix any spelling errors that I found. There are now only two scripts with outstanding errors - more below.

<hr>

## Spelling Changes

As discussed, I've tried to capitalise any names I could find, to remove those spelling errors. However, there are still some outstanding issues in:
1. docs/topic_guides/data_preparation/feature_engineering.md
2. docs/topic_guides/comparisons/regular_expressions.md

Here, we have a series of "output blocks" (see image) which showcase the outputs you'd receive in python were you to run this code. Annoyingly, these also contain references to the Splink and SQL functions being used - `jaro_winkler_sim`, for example - without wrapping them in code blocks:
![Screenshot 2024-03-27 at 14 34 06](https://github.com/moj-analytical-services/splink/assets/45356472/65e93cbe-8849-4252-bf68-9b9bfd45384f)

#### Summary of changes

**topics_guides/comparisons/Phonetics.md**
* jaro_winkler -> Jaro-Winkler
* demaerau-levenshtein -> Demaerau-Levenshtein

**docs/topic_guides/comparisons/regular_expressions.md**
* Any references to names included in tables have been capitalised.
* `jaro_winkler_similarity` has been included in an output block, meaning there's no easy solution.

**Docs/settings_dict_guide.md**
* Same issue as above - function names included outside of code blocks

**docs/topic_guides/data_preparation/feature_engineering.md**
* Again, `jaro_winkler_sim` function is being flagged

#### Suggestion solution to errors

There appear to be two possible solutions to the above:
1. We wrap function names in code blocks - ` - precluding them from being checked
2. We try to find a way to get the spellchecker to ignore anything that includes a `_` - I have no idea if this is possible.

I'd lean towards option 1, as it's far simpler to implement.

I'm going to squash all of the commits below into one, so ignore how messy they are.