### PR TITLE
Stricter mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,3 @@ implicit_optional = true
 # for now, ignore missing imports
 # can remove later and install stubs, where existent
 ignore_missing_imports = true
-# don't follow imports to modules we don't want to typecheck yet
-# eventually restore this back to the default "normal"
-follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ packages = "splink"
 # temporary exclusions
 exclude = [
     # modules with large number of errors
-    '.*comparison.*library\.py',
     '.*linker\.py',
     '/settings_validation/'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ packages = "splink"
 # temporary exclusions
 exclude = [
     # modules with large number of errors
-    '.*linker\.py',
     '/settings_validation/'
 ]
 # for now at least allow implicit optionals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,7 @@ strict_equality = true
 # don't worry about warning: https://github.com/python/mypy/issues/16189
 strict_concatenate = true
 check_untyped_defs = true
+disallow_subclassing_any = true
+# next set to enforce:
+# disallow_untyped_decorators = true
+# disallow_any_generics = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,10 @@ implicit_optional = true
 # for now, ignore missing imports
 # can remove later and install stubs, where existent
 ignore_missing_imports = true
+
+# options for strict mode
+# too much to handle at once, so opt-in a little at a time
+# https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,4 @@ warn_unused_ignores = true
 strict_equality = true
 # don't worry about warning: https://github.com/python/mypy/issues/16189
 strict_concatenate = true
+check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,6 @@ ignore_missing_imports = true
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+strict_equality = true
+# don't worry about warning: https://github.com/python/mypy/issues/16189
+strict_concatenate = true

--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -44,8 +44,8 @@ def truth_space_table_from_labels_with_predictions_sqls(
     order by match_weight
     """
 
-    sql = {"sql": sql, "output_table_name": "__splink__labels_with_pos_neg"}
-    sqls.append(sql)
+    sql_info = {"sql": sql, "output_table_name": "__splink__labels_with_pos_neg"}
+    sqls.append(sql_info)
 
     sql = """
     select
@@ -59,8 +59,8 @@ def truth_space_table_from_labels_with_predictions_sqls(
     order by truth_threshold
     """
 
-    sql = {"sql": sql, "output_table_name": "__splink__labels_with_pos_neg_grouped"}
-    sqls.append(sql)
+    sql_info = {"sql": sql, "output_table_name": "__splink__labels_with_pos_neg_grouped"}
+    sqls.append(sql_info)
 
     sql = """
     select
@@ -83,11 +83,11 @@ def truth_space_table_from_labels_with_predictions_sqls(
     order by  truth_threshold
     """
 
-    sql = {
+    sql_info = {
         "sql": sql,
         "output_table_name": "__splink__labels_with_pos_neg_grouped_with_stats",
     }
-    sqls.append(sql)
+    sqls.append(sql_info)
 
     sql = """
     select
@@ -105,11 +105,11 @@ def truth_space_table_from_labels_with_predictions_sqls(
     from __splink__labels_with_pos_neg_grouped_with_stats
     """
 
-    sql = {
+    sql_info = {
         "sql": sql,
         "output_table_name": "__splink__labels_with_pos_neg_grouped_with_truth_stats",
     }
-    sqls.append(sql)
+    sqls.append(sql_info)
 
     sql = """
     select
@@ -144,8 +144,8 @@ def truth_space_table_from_labels_with_predictions_sqls(
     from __splink__labels_with_pos_neg_grouped_with_truth_stats
     """
 
-    sql = {"sql": sql, "output_table_name": "__splink__truth_space_table"}
-    sqls.append(sql)
+    sql_info = {"sql": sql, "output_table_name": "__splink__truth_space_table"}
+    sqls.append(sql_info)
     return sqls
 
 
@@ -228,7 +228,7 @@ def predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename):
         linker, labels_tablename, include_clerical_match_score=True
     )
 
-    sql = {
+    sql_info = {
         "sql": compute_comparison_vector_values_sql(
             linker._settings_obj._columns_to_select_for_comparison_vector_values,
             include_clerical_match_score=True,
@@ -236,7 +236,7 @@ def predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename):
         "output_table_name": "__splink__df_comparison_vectors",
     }
 
-    sqls.append(sql)
+    sqls.append(sql_info)
 
     sqls_2 = predict_from_comparison_vectors_sqls_using_settings(
         linker._settings_obj,
@@ -252,13 +252,13 @@ def predictions_from_sample_of_pairwise_labels_sql(linker, labels_tablename):
     from __splink__df_predict
     """
 
-    sql = {
+    sql_info = {
         "sql": sql,
         "output_table_name": "__splink__labels_with_predictions",
     }
 
     # Clearer name than just df_predict
-    sqls.append(sql)
+    sqls.append(sql_info)
 
     return sqls
 

--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -59,7 +59,10 @@ def truth_space_table_from_labels_with_predictions_sqls(
     order by truth_threshold
     """
 
-    sql_info = {"sql": sql, "output_table_name": "__splink__labels_with_pos_neg_grouped"}
+    sql_info = {
+        "sql": sql,
+        "output_table_name": "__splink__labels_with_pos_neg_grouped"
+    }
     sqls.append(sql_info)
 
     sql = """

--- a/splink/accuracy.py
+++ b/splink/accuracy.py
@@ -61,7 +61,7 @@ def truth_space_table_from_labels_with_predictions_sqls(
 
     sql_info = {
         "sql": sql,
-        "output_table_name": "__splink__labels_with_pos_neg_grouped"
+        "output_table_name": "__splink__labels_with_pos_neg_grouped",
     }
     sqls.append(sql_info)
 

--- a/splink/athena/linker.py
+++ b/splink/athena/linker.py
@@ -1,561 +1,561 @@
-from __future__ import annotations
+# from __future__ import annotations
 
-import logging
-import os
-from typing import Union
+# import logging
+# import os
+# from typing import Union
 
-import awswrangler as wr
-import boto3
-import numpy as np
-import pandas as pd
+# import awswrangler as wr
+# import boto3
+# import numpy as np
+# import pandas as pd
 
-from ..input_column import InputColumn
-from ..linker import Linker
-from ..logging_messages import execute_sql_logging_message_info, log_sql
-from ..misc import ensure_is_list
-from ..splink_dataframe import SplinkDataFrame
-from ..sql_transform import sqlglot_transform_sql
-from .athena_helpers.athena_transforms import cast_concat_as_varchar
-from .athena_helpers.athena_utils import (
-    _garbage_collection,
-    _verify_athena_inputs,
-)
+# from ..input_column import InputColumn
+# from ..linker import Linker
+# from ..logging_messages import execute_sql_logging_message_info, log_sql
+# from ..misc import ensure_is_list
+# from ..splink_dataframe import SplinkDataFrame
+# from ..sql_transform import sqlglot_transform_sql
+# from .athena_helpers.athena_transforms import cast_concat_as_varchar
+# from .athena_helpers.athena_utils import (
+#     _garbage_collection,
+#     _verify_athena_inputs,
+# )
 
-logger = logging.getLogger(__name__)
-
-
-class AthenaDataFrame(SplinkDataFrame):
-    linker: AthenaLinker
-
-    @property
-    def columns(self):
-        db, tb = self.linker.get_schema_info(self.physical_name)
-        d = wr.catalog.get_table_types(
-            database=db,
-            table=tb,
-            boto3_session=self.linker.boto3_session,
-        )
-
-        cols = list(d.keys())
-        return [InputColumn(c, sql_dialect="presto") for c in cols]
-
-    def validate(self):
-        pass
-
-    def _drop_table_from_database(
-        self, force_non_splink_table=False, delete_s3_data=True
-    ):
-        # Check folder and table set for deletion
-        self._check_drop_folder_created_by_splink(force_non_splink_table)
-        self._check_drop_table_created_by_splink(force_non_splink_table)
-
-        # Delete the table from s3 and your database
-        table_deleted = self.linker._drop_table_from_database_if_exists(
-            self.physical_name
-        )
-        if delete_s3_data and table_deleted:
-            self.linker._delete_table_from_s3(self.physical_name)
-
-    def drop_table_from_database_and_remove_from_cache(
-        self,
-        force_non_splink_table=False,
-        delete_s3_data=True,
-    ):
-        self._drop_table_from_database(
-            force_non_splink_table=force_non_splink_table, delete_s3_data=delete_s3_data
-        )
-        self.linker._remove_splinkdataframe_from_cache(self)
-
-    def _check_drop_folder_created_by_splink(self, force_non_splink_table=False):
-        filepath = self.linker.s3_output
-        filename = self.physical_name
-        # Validate that the folder is a splink generated folder...
-        files = wr.s3.list_objects(
-            path=os.path.join(filepath, filename),
-            boto3_session=self.linker.boto3_session,
-            ignore_empty=True,
-        )
-
-        if len(files) == 0:
-            if not force_non_splink_table:
-                raise ValueError(
-                    f"You've asked to drop data housed under the filepath "
-                    f"{self.linker.s3_output} from your "
-                    "s3 output bucket, which is not a folder created by "
-                    "Splink. If you really want to delete this data, you "
-                    "can do so by setting force_non_splink_table=True."
-                )
-
-        # validate that the ctas_query_info is for the given table
-        # we're interacting with
-        if (
-            self.linker.ctas_query_info[self.physical_name]["ctas_table"]
-            != self.physical_name
-        ):
-            raise ValueError(
-                f"The recorded metadata for {self.physical_name} that you're "
-                "attempting to delete does not match the recorded metadata on s3. "
-                "To prevent any tables becoming corrupted on s3, this run will be "
-                "terminated. Please retry the link/dedupe job and report the issue "
-                "if this error persists."
-            )
-
-    def as_pandas_dataframe(self, limit=None):
-        sql = f"""
-        select *
-        from {self.physical_name}
-        """
-        if limit:
-            sql += f" limit {limit}"
-
-        out_df = wr.athena.read_sql_query(
-            sql=sql,
-            database=self.linker.output_schema,
-            s3_output=self.linker.s3_output,
-            keep_files=False,
-            ctas_approach=True,
-            use_threads=True,
-            boto3_session=self.linker.boto3_session,
-        )
-        return out_df
-
-    def as_record_dict(self, limit=None):
-        out_df = self.as_pandas_dataframe(limit)
-        out_df = out_df.fillna(np.nan).replace([np.nan], [None])
-        return out_df.to_dict(orient="records")
+# logger = logging.getLogger(__name__)
 
 
-class AthenaLinker(Linker):
-    def __init__(
-        self,
-        input_table_or_tables,
-        boto3_session: boto3.session.Session,
-        output_database: str,
-        output_bucket: str,
-        settings_dict: dict | str = None,
-        input_table_aliases: str | list = None,
-        set_up_basic_logging=True,
-        output_filepath: str = "",
-        validate_settings: bool = True,
-    ):
-        """An athena backend for our main linker class. This funnels our generated SQL
-        through athena using awswrangler.
-        See linker.py for more information on the main linker class.
-        Attributes:
-            input_table_or_tables (Union[str, list]): Input data into the linkage model.
-                Either a single string (the name of a table in a database) for
-                deduplication jobs, or a list of strings  (the name of tables in a
-                database) for link_only or link_and_dedupe.
-            boto3_session (boto3.session.Session): A working boto3 session, which
-                should contain user credentials and region information.
-            output_database (str): The name of the database you wish to export the
-                results of the link job to. This should be created prior to performing
-                your link.
-            output_bucket (str): The name of the bucket and the filepath you wish to
-                store your outputs in on aws. The bucket should be created prior to
-                performing your link.
-            settings_dict (dict | Path, optional): A Splink settings dictionary, or
-                 a path to a json defining a settingss dictionary or pre-trained model.
-                  If not provided when the object is created, can later be added using
-                `linker.load_settings()` or `linker.load_model()` Defaults to None.
-            input_table_aliases: Aliases/custom names for your input tables, if
-                a pandas df or a list of dfs are used as inputs. None by default, which
-                saves your tables under a custom name: '__splink__input_table_{n}';
-                where n is the list index.
-            set_up_basic_logging (bool, optional): If true, sets ups up basic logging
-                so that Splink sends messages at INFO level to stdout. Defaults to True.
-            output_filepath (str, optional): Inside of your selected output bucket,
-                where to write output files to.
-                Defaults to "splink_warehouse/{unique_id}".
-            validate_settings (bool, optional): When True, check your settings
-                dictionary for any potential errors that may cause splink to fail.
-        Examples:
-            ```py
-            # Creating a database in athena and writing to it
-            import awswrangler as wr
-            wr.catalog.create_database("splink_awswrangler_test", exist_ok=True)
-            >>>
-            from splink.athena.linker import AthenaLinker
-            import boto3
-            # Create a session - please see the boto3 documentation for more info
-            my_session = boto3.Session(region_name="eu-west-1")
-            >>>
-            linker = AthenaLinker(
-                settings_dict=settings_dict,
-                input_table_or_tables="synthetic_data_all",
-                boto3_session=my_session,
-                output_bucket="alpha-splink-db-testing",
-                output_database="splink_awswrangler_test",
-            )
-            ```
-            ```py
-            # Creating a secondary database and use data on and existing db
-            import awswrangler as wr
-            wr.catalog.create_database("splink_awswrangler_test2", exist_ok=True)
-            >>>
-            from splink.athena.linker import AthenaLinker
-            import boto3
-            my_session = boto3.Session(region_name="eu-west-1")
-            >>>
-            # To read and write from separate databases, specify your secondary
-            # database as the output and enter your primary database as a schema
-            # for your input table(s)
-            linker = AthenaLinker(
-                settings_dict=settings_dict,
-                input_table_or_tables="splink_awswrangler_test.synthetic_data_all",
-                boto3_session=my_session,
-                output_bucket="alpha-splink-db-testing",
-                output_database="splink_awswrangler_test2",
-            )
-            ```
-        """
+# class AthenaDataFrame(SplinkDataFrame):
+#     linker: AthenaLinker
 
-        if not type(boto3_session) == boto3.session.Session:
-            raise ValueError("Please enter a valid boto3 session object.")
+#     @property
+#     def columns(self):
+#         db, tb = self.linker.get_schema_info(self.physical_name)
+#         d = wr.catalog.get_table_types(
+#             database=db,
+#             table=tb,
+#             boto3_session=self.linker.boto3_session,
+#         )
 
-        self._sql_dialect_ = "presto"
+#         cols = list(d.keys())
+#         return [InputColumn(c, sql_dialect="presto") for c in cols]
 
-        _verify_athena_inputs(output_database, output_bucket, boto3_session)
-        self.boto3_session = boto3_session
-        self.output_schema = output_database
-        self.output_bucket = output_bucket
+#     def validate(self):
+#         pass
 
-        # If the default folder is blank, name it `splink_warehouse`
-        if output_filepath:
-            self.output_filepath = output_filepath
-        else:
-            self.output_filepath = "splink_warehouse"
+#     def _drop_table_from_database(
+#         self, force_non_splink_table=False, delete_s3_data=True
+#     ):
+#         # Check folder and table set for deletion
+#         self._check_drop_folder_created_by_splink(force_non_splink_table)
+#         self._check_drop_table_created_by_splink(force_non_splink_table)
 
-        # This query info dictionary is used to circumvent the need to run
-        # `wr.catalog.get_table_location` every time we want to delete
-        # the backing data from s3.
-        self.ctas_query_info = {}
+#         # Delete the table from s3 and your database
+#         table_deleted = self.linker._drop_table_from_database_if_exists(
+#             self.physical_name
+#         )
+#         if delete_s3_data and table_deleted:
+#             self.linker._delete_table_from_s3(self.physical_name)
 
-        # If user has provided pandas dataframes, need to register
-        # them with the database, using user-provided aliases
-        # if provided or a created alias if not
-        input_tables = ensure_is_list(input_table_or_tables)
+#     def drop_table_from_database_and_remove_from_cache(
+#         self,
+#         force_non_splink_table=False,
+#         delete_s3_data=True,
+#     ):
+#         self._drop_table_from_database(
+#             force_non_splink_table=force_non_splink_table, delete_s3_data=delete_s3_data
+#         )
+#         self.linker._remove_splinkdataframe_from_cache(self)
 
-        input_aliases = self._ensure_aliases_populated_and_is_list(
-            input_table_or_tables, input_table_aliases
-        )
-        accepted_df_dtypes = pd.DataFrame
+#     def _check_drop_folder_created_by_splink(self, force_non_splink_table=False):
+#         filepath = self.linker.s3_output
+#         filename = self.physical_name
+#         # Validate that the folder is a splink generated folder...
+#         files = wr.s3.list_objects(
+#             path=os.path.join(filepath, filename),
+#             boto3_session=self.linker.boto3_session,
+#             ignore_empty=True,
+#         )
 
-        # Run a quick check against our inputs to check if they
-        # exist in the database
-        for table in input_tables:
-            if not isinstance(table, accepted_df_dtypes):
-                db, tb = self.get_schema_info(table)
-                self.check_table_exists(db, tb)
+#         if len(files) == 0:
+#             if not force_non_splink_table:
+#                 raise ValueError(
+#                     f"You've asked to drop data housed under the filepath "
+#                     f"{self.linker.s3_output} from your "
+#                     "s3 output bucket, which is not a folder created by "
+#                     "Splink. If you really want to delete this data, you "
+#                     "can do so by setting force_non_splink_table=True."
+#                 )
 
-        super().__init__(
-            input_tables,
-            settings_dict,
-            accepted_df_dtypes,
-            set_up_basic_logging,
-            input_table_aliases=input_aliases,
-            validate_settings=validate_settings,
-        )
+#         # validate that the ctas_query_info is for the given table
+#         # we're interacting with
+#         if (
+#             self.linker.ctas_query_info[self.physical_name]["ctas_table"]
+#             != self.physical_name
+#         ):
+#             raise ValueError(
+#                 f"The recorded metadata for {self.physical_name} that you're "
+#                 "attempting to delete does not match the recorded metadata on s3. "
+#                 "To prevent any tables becoming corrupted on s3, this run will be "
+#                 "terminated. Please retry the link/dedupe job and report the issue "
+#                 "if this error persists."
+#             )
 
-    def _table_to_splink_dataframe(self, templated_name, physical_name):
-        return AthenaDataFrame(templated_name, physical_name, self)
+#     def as_pandas_dataframe(self, limit=None):
+#         sql = f"""
+#         select *
+#         from {self.physical_name}
+#         """
+#         if limit:
+#             sql += f" limit {limit}"
 
-    def change_output_filepath(self, new_filepath):
-        self.output_filepath = new_filepath
+#         out_df = wr.athena.read_sql_query(
+#             sql=sql,
+#             database=self.linker.output_schema,
+#             s3_output=self.linker.s3_output,
+#             keep_files=False,
+#             ctas_approach=True,
+#             use_threads=True,
+#             boto3_session=self.linker.boto3_session,
+#         )
+#         return out_df
 
-    def get_schema_info(self, input_table):
-        t = input_table.split(".")
-        return t if len(t) > 1 else [self.output_schema, input_table]
+#     def as_record_dict(self, limit=None):
+#         out_df = self.as_pandas_dataframe(limit)
+#         out_df = out_df.fillna(np.nan).replace([np.nan], [None])
+#         return out_df.to_dict(orient="records")
 
-    @property
-    def s3_output(self):
-        out_path = os.path.join(
-            "s3://",
-            self.output_bucket,
-            self.output_filepath,
-            self._cache_uid,  # added in the super() step
-        )
-        if out_path[-1] != "/":
-            out_path += "/"
 
-        return out_path
+# class AthenaLinker(Linker):
+#     def __init__(
+#         self,
+#         input_table_or_tables,
+#         boto3_session: boto3.session.Session,
+#         output_database: str,
+#         output_bucket: str,
+#         settings_dict: dict | str = None,
+#         input_table_aliases: str | list = None,
+#         set_up_basic_logging=True,
+#         output_filepath: str = "",
+#         validate_settings: bool = True,
+#     ):
+#         """An athena backend for our main linker class. This funnels our generated SQL
+#         through athena using awswrangler.
+#         See linker.py for more information on the main linker class.
+#         Attributes:
+#             input_table_or_tables (Union[str, list]): Input data into the linkage model.
+#                 Either a single string (the name of a table in a database) for
+#                 deduplication jobs, or a list of strings  (the name of tables in a
+#                 database) for link_only or link_and_dedupe.
+#             boto3_session (boto3.session.Session): A working boto3 session, which
+#                 should contain user credentials and region information.
+#             output_database (str): The name of the database you wish to export the
+#                 results of the link job to. This should be created prior to performing
+#                 your link.
+#             output_bucket (str): The name of the bucket and the filepath you wish to
+#                 store your outputs in on aws. The bucket should be created prior to
+#                 performing your link.
+#             settings_dict (dict | Path, optional): A Splink settings dictionary, or
+#                  a path to a json defining a settingss dictionary or pre-trained model.
+#                   If not provided when the object is created, can later be added using
+#                 `linker.load_settings()` or `linker.load_model()` Defaults to None.
+#             input_table_aliases: Aliases/custom names for your input tables, if
+#                 a pandas df or a list of dfs are used as inputs. None by default, which
+#                 saves your tables under a custom name: '__splink__input_table_{n}';
+#                 where n is the list index.
+#             set_up_basic_logging (bool, optional): If true, sets ups up basic logging
+#                 so that Splink sends messages at INFO level to stdout. Defaults to True.
+#             output_filepath (str, optional): Inside of your selected output bucket,
+#                 where to write output files to.
+#                 Defaults to "splink_warehouse/{unique_id}".
+#             validate_settings (bool, optional): When True, check your settings
+#                 dictionary for any potential errors that may cause splink to fail.
+#         Examples:
+#             ```py
+#             # Creating a database in athena and writing to it
+#             import awswrangler as wr
+#             wr.catalog.create_database("splink_awswrangler_test", exist_ok=True)
+#             >>>
+#             from splink.athena.linker import AthenaLinker
+#             import boto3
+#             # Create a session - please see the boto3 documentation for more info
+#             my_session = boto3.Session(region_name="eu-west-1")
+#             >>>
+#             linker = AthenaLinker(
+#                 settings_dict=settings_dict,
+#                 input_table_or_tables="synthetic_data_all",
+#                 boto3_session=my_session,
+#                 output_bucket="alpha-splink-db-testing",
+#                 output_database="splink_awswrangler_test",
+#             )
+#             ```
+#             ```py
+#             # Creating a secondary database and use data on and existing db
+#             import awswrangler as wr
+#             wr.catalog.create_database("splink_awswrangler_test2", exist_ok=True)
+#             >>>
+#             from splink.athena.linker import AthenaLinker
+#             import boto3
+#             my_session = boto3.Session(region_name="eu-west-1")
+#             >>>
+#             # To read and write from separate databases, specify your secondary
+#             # database as the output and enter your primary database as a schema
+#             # for your input table(s)
+#             linker = AthenaLinker(
+#                 settings_dict=settings_dict,
+#                 input_table_or_tables="splink_awswrangler_test.synthetic_data_all",
+#                 boto3_session=my_session,
+#                 output_bucket="alpha-splink-db-testing",
+#                 output_database="splink_awswrangler_test2",
+#             )
+#             ```
+#         """
 
-    def check_table_exists(self, db, tb):
-        # A quick function to check if a table exists
-        # and spit out a warning if it is not found.
-        table_exists = wr.catalog.does_table_exist(
-            database=db,
-            table=tb,
-            boto3_session=self.boto3_session,
-        )
-        if not table_exists:
-            raise wr.exceptions.InvalidTable(
-                f"Table '{tb}' was not found within your selected "
-                f"database '{db}'. Please verify your input table "
-                "exists."
-            )
+#         if not type(boto3_session) == boto3.session.Session:
+#             raise ValueError("Please enter a valid boto3 session object.")
 
-    def register_data_on_s3(self, table, alias):
-        out_loc = f"{self.s3_output}{alias}"
+#         self._sql_dialect_ = "presto"
 
-        wr.s3.to_parquet(
-            df=table,
-            path=out_loc,
-            dataset=True,
-            mode="overwrite",
-            database=self.output_schema,
-            table=alias,
-            boto3_session=self.boto3_session,
-            compression="snappy",
-            use_threads=True,
-        )
-        # Construct the ctas metadata that we require
-        ctas_metadata = {
-            "ctas_database": self.output_schema,
-            "ctas_table": alias,
-        }
-        self.ctas_query_info.update({alias: ctas_metadata})
+#         _verify_athena_inputs(output_database, output_bucket, boto3_session)
+#         self.boto3_session = boto3_session
+#         self.output_schema = output_database
+#         self.output_bucket = output_bucket
 
-    def __sql_to_splink_dataframe(self, sql, templated_name, physical_name):
-        self.delete_table_from_database(physical_name)
-        sql = sqlglot_transform_sql(sql, cast_concat_as_varchar, dialect="presto")
-        sql = sql.replace("FLOAT", "double").replace("float", "double")
+#         # If the default folder is blank, name it `splink_warehouse`
+#         if output_filepath:
+#             self.output_filepath = output_filepath
+#         else:
+#             self.output_filepath = "splink_warehouse"
 
-        logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
-        logger.log(5, log_sql(sql))
+#         # This query info dictionary is used to circumvent the need to run
+#         # `wr.catalog.get_table_location` every time we want to delete
+#         # the backing data from s3.
+#         self.ctas_query_info = {}
 
-        # create our table on athena and extract the metadata information
-        query_metadata = self.create_table(sql, physical_name=physical_name)
-        # append our metadata locations
-        query_metadata = self._extract_ctas_metadata(query_metadata)
-        self.ctas_query_info.update({physical_name: query_metadata})
+#         # If user has provided pandas dataframes, need to register
+#         # them with the database, using user-provided aliases
+#         # if provided or a created alias if not
+#         input_tables = ensure_is_list(input_table_or_tables)
 
-        output_obj = self._table_to_splink_dataframe(templated_name, physical_name)
-        return output_obj
+#         input_aliases = self._ensure_aliases_populated_and_is_list(
+#             input_table_or_tables, input_table_aliases
+#         )
+#         accepted_df_dtypes = pd.DataFrame
 
-    def register_table(self, input, table_name, overwrite=False):
-        # If the user has provided a table name, return it as a SplinkDataframe
-        if isinstance(input, str):
-            return self._table_to_splink_dataframe(table_name, input)
+#         # Run a quick check against our inputs to check if they
+#         # exist in the database
+#         for table in input_tables:
+#             if not isinstance(table, accepted_df_dtypes):
+#                 db, tb = self.get_schema_info(table)
+#                 self.check_table_exists(db, tb)
 
-        # Check if table name is already in use
-        exists = self._table_exists_in_database(table_name)
-        if exists:
-            if not overwrite:
-                raise ValueError(
-                    f"Table '{table_name}' already exists in database. "
-                    "Please use the 'overwrite' argument if you wish to overwrite"
-                )
-            else:
-                self.delete_table_from_database(table_name)
+#         super().__init__(
+#             input_tables,
+#             settings_dict,
+#             accepted_df_dtypes,
+#             set_up_basic_logging,
+#             input_table_aliases=input_aliases,
+#             validate_settings=validate_settings,
+#         )
 
-        self._table_registration(input, table_name)
-        return self._table_to_splink_dataframe(table_name, table_name)
+#     def _table_to_splink_dataframe(self, templated_name, physical_name):
+#         return AthenaDataFrame(templated_name, physical_name, self)
 
-    def _table_registration(self, input, table_name):
-        if isinstance(input, dict):
-            input = pd.DataFrame(input)
-        elif isinstance(input, list):
-            input = pd.DataFrame.from_records(input)
+#     def change_output_filepath(self, new_filepath):
+#         self.output_filepath = new_filepath
 
-        # Errors if an invalid data type is passed
-        self.register_data_on_s3(input, table_name)
+#     def get_schema_info(self, input_table):
+#         t = input_table.split(".")
+#         return t if len(t) > 1 else [self.output_schema, input_table]
 
-    def _random_sample_sql(
-        self, proportion, sample_size, seed=None, table=None, unique_id=None
-    ):
-        if proportion == 1.0:
-            return ""
-        percent = proportion * 100
-        return f" TABLESAMPLE BERNOULLI ({percent})"
+#     @property
+#     def s3_output(self):
+#         out_path = os.path.join(
+#             "s3://",
+#             self.output_bucket,
+#             self.output_filepath,
+#             self._cache_uid,  # added in the super() step
+#         )
+#         if out_path[-1] != "/":
+#             out_path += "/"
 
-    @property
-    def _infinity_expression(self):
-        return "infinity()"
+#         return out_path
 
-    def _table_exists_in_database(self, table_name):
-        return wr.catalog.does_table_exist(
-            database=self.output_schema,
-            table=table_name,
-            boto3_session=self.boto3_session,
-        )
+#     def check_table_exists(self, db, tb):
+#         # A quick function to check if a table exists
+#         # and spit out a warning if it is not found.
+#         table_exists = wr.catalog.does_table_exist(
+#             database=db,
+#             table=tb,
+#             boto3_session=self.boto3_session,
+#         )
+#         if not table_exists:
+#             raise wr.exceptions.InvalidTable(
+#                 f"Table '{tb}' was not found within your selected "
+#                 f"database '{db}'. Please verify your input table "
+#                 "exists."
+#             )
 
-    def create_table(self, sql, physical_name):
-        database = self.output_schema
-        ctas_metadata = wr.athena.create_ctas_table(
-            sql=sql,
-            database=database,
-            ctas_table=physical_name,
-            storage_format="parquet",
-            write_compression="snappy",
-            boto3_session=self.boto3_session,
-            s3_output=self.s3_output,
-            wait=True,
-        )
-        return ctas_metadata
+#     def register_data_on_s3(self, table, alias):
+#         out_loc = f"{self.s3_output}{alias}"
 
-    def _drop_table_from_database_if_exists(self, table):
-        return wr.catalog.delete_table_if_exists(
-            database=self.output_schema, table=table, boto3_session=self.boto3_session
-        )
+#         wr.s3.to_parquet(
+#             df=table,
+#             path=out_loc,
+#             dataset=True,
+#             mode="overwrite",
+#             database=self.output_schema,
+#             table=alias,
+#             boto3_session=self.boto3_session,
+#             compression="snappy",
+#             use_threads=True,
+#         )
+#         # Construct the ctas metadata that we require
+#         ctas_metadata = {
+#             "ctas_database": self.output_schema,
+#             "ctas_table": alias,
+#         }
+#         self.ctas_query_info.update({alias: ctas_metadata})
 
-    def _delete_table_from_s3(self, physical_name):
-        path = f"{self.s3_output}{physical_name}/"
-        # delete our folder
-        wr.s3.delete_objects(
-            path=path,
-            use_threads=True,
-            boto3_session=self.boto3_session,
-        )
+#     def __sql_to_splink_dataframe(self, sql, templated_name, physical_name):
+#         self.delete_table_from_database(physical_name)
+#         sql = sqlglot_transform_sql(sql, cast_concat_as_varchar, dialect="presto")
+#         sql = sql.replace("FLOAT", "double").replace("float", "double")
 
-        metadata = self.ctas_query_info[physical_name]
-        if "output_location" in metadata:
-            metadata_urls = [
-                # metadata output location
-                f"{metadata['output_location']}.metadata",
-                # manifest location
-                metadata["manifest_location"],
-            ]
-            # delete our metadata
-            wr.s3.delete_objects(
-                path=metadata_urls,
-                use_threads=True,
-                boto3_session=self.boto3_session,
-            )
+#         logger.debug(execute_sql_logging_message_info(templated_name, physical_name))
+#         logger.log(5, log_sql(sql))
 
-        self.ctas_query_info.pop(physical_name)
+#         # create our table on athena and extract the metadata information
+#         query_metadata = self.create_table(sql, physical_name=physical_name)
+#         # append our metadata locations
+#         query_metadata = self._extract_ctas_metadata(query_metadata)
+#         self.ctas_query_info.update({physical_name: query_metadata})
 
-    def delete_table_from_database(self, name):
-        if name in self.ctas_query_info:
-            # Use ctas metadata to delete backing data
-            self._delete_table_from_s3(name)
-        else:
-            # If the location we want to write to already exists,
-            # clean this before continuing.
-            loc = f"{self.s3_output}{name}"
-            folder_exists = wr.s3.list_directories(
-                loc,
-                boto3_session=self.boto3_session,
-            )
-            if folder_exists:
-                # This will only delete objects we are required to delete
-                wr.s3.delete_objects(
-                    path=loc,
-                    use_threads=True,
-                    boto3_session=self.boto3_session,
-                )
+#         output_obj = self._table_to_splink_dataframe(templated_name, physical_name)
+#         return output_obj
 
-        self._drop_table_from_database_if_exists(name)
+#     def register_table(self, input, table_name, overwrite=False):
+#         # If the user has provided a table name, return it as a SplinkDataframe
+#         if isinstance(input, str):
+#             return self._table_to_splink_dataframe(table_name, input)
 
-    def _extract_ctas_metadata(self, ctas_metadata):
-        query_meta = ctas_metadata.pop("ctas_query_metadata")
-        out_locs = {
-            "output_location": query_meta.output_location,
-            "manifest_location": query_meta.manifest_location,
-        }
-        ctas_metadata.update(out_locs)
-        return ctas_metadata
+#         # Check if table name is already in use
+#         exists = self._table_exists_in_database(table_name)
+#         if exists:
+#             if not overwrite:
+#                 raise ValueError(
+#                     f"Table '{table_name}' already exists in database. "
+#                     "Please use the 'overwrite' argument if you wish to overwrite"
+#                 )
+#             else:
+#                 self.delete_table_from_database(table_name)
 
-    def drop_all_tables_created_by_splink(
-        self,
-        delete_s3_folders=True,
-        tables_to_exclude: list[Union[SplinkDataFrame, str]] = [],
-    ):
-        """Run a cleanup process for the tables created by splink and
-        currently contained in your output database.
-        Only those tables currently contained within your database
-        will be permanently deleted. Anything existing on s3 that
-        isn't connected to your database will not be removed.
-        Attributes:
-            delete_s3_folders (bool, optional): Whether to delete the
-                backing data contained on s3. If False, the tables created
-                by splink will be removed from your database, but the parquet
-                outputs will remain on s3. Defaults to True.
-            tables_to_exclude (list[SplinkDataFrame | str], optional): A list
-                of input tables you wish to add to an ignore list. These
-                will not be removed during garbage collection.
-        """
-        # Run cleanup on the cache before checking the db
-        self.drop_tables_in_current_splink_run(
-            delete_s3_folders,
-            tables_to_exclude,
-        )
-        _garbage_collection(
-            self.output_schema,
-            self.boto3_session,
-            delete_s3_folders,
-            tables_to_exclude,
-        )
+#         self._table_registration(input, table_name)
+#         return self._table_to_splink_dataframe(table_name, table_name)
 
-    def drop_splink_tables_from_database(
-        self,
-        database_name: str,
-        delete_s3_folders: bool = True,
-        tables_to_exclude: list[Union[SplinkDataFrame, str]] = [],
-    ):
-        """Run a cleanup process for the tables created by splink
-        in a specified database.
-        Only those tables currently contained within your database
-        will be permanently deleted. Anything existing on s3 that
-        isn't connected to your database will not be removed.
-        Attributes:
-            database_name (str): The name of the database to delete splink tables from.
-            delete_s3_folders (bool, optional): Whether to delete the
-                backing data contained on s3. If False, the tables created
-                by splink will be removed from your database, but the parquet
-                outputs will remain on s3. Defaults to True.
-            tables_to_exclude (list[SplinkDataFrame | str], optional): A list
-                of input tables you wish to add to an ignore list. These
-                will not be removed during garbage collection.
-        """
-        _garbage_collection(
-            database_name,
-            self.boto3_session,
-            delete_s3_folders,
-            tables_to_exclude,
-        )
+#     def _table_registration(self, input, table_name):
+#         if isinstance(input, dict):
+#             input = pd.DataFrame(input)
+#         elif isinstance(input, list):
+#             input = pd.DataFrame.from_records(input)
 
-    def drop_tables_in_current_splink_run(
-        self,
-        delete_s3_folders: bool = True,
-        tables_to_exclude: list[Union[SplinkDataFrame, str]] = [],
-    ):
-        """Run a cleanup process for the tables created
-        by the current splink linker.
-        This leaves tables from previous runs untouched.
-        Only those tables currently contained within your database
-        will be permanently deleted. Anything existing on s3 that
-        isn't connected to your database will not be removed.
-        Attributes:
-            delete_s3_folders (bool, optional): Whether to delete the
-                backing data contained on s3. If False, the tables created
-                by splink will be removed from your database, but the parquet
-                outputs will remain on s3. Defaults to True.
-            tables_to_exclude (list[SplinkDataFrame | str], optional): A list
-                of input tables you wish to add to an ignore list. These
-                will not be removed during garbage collection.
-        """
+#         # Errors if an invalid data type is passed
+#         self.register_data_on_s3(input, table_name)
 
-        tables_to_exclude = ensure_is_list(tables_to_exclude)
-        tables_to_exclude = {
-            df.physical_name if isinstance(df, SplinkDataFrame) else df
-            for df in tables_to_exclude
-        }
+#     def _random_sample_sql(
+#         self, proportion, sample_size, seed=None, table=None, unique_id=None
+#     ):
+#         if proportion == 1.0:
+#             return ""
+#         percent = proportion * 100
+#         return f" TABLESAMPLE BERNOULLI ({percent})"
 
-        # Exclude tables that the user doesn't want to delete
-        cached_tables = self._intermediate_table_cache
+#     @property
+#     def _infinity_expression(self):
+#         return "infinity()"
 
-        # Loop through our cached tables and delete all those not in our exclusion
-        # list.
-        for splink_df in list(cached_tables.values()):
-            if (splink_df.physical_name not in tables_to_exclude) and (
-                splink_df.templated_name not in tables_to_exclude
-            ):
-                splink_df.drop_table_from_database_and_remove_from_cache(
-                    force_non_splink_table=False, delete_s3_data=delete_s3_folders
-                )
-            # As our cache contains duplicate term frequency tables and AWSwrangler
-            # run deletions asynchronously, add any previously seen tables to the
-            # list of tables to exclude from deletion.
-            # This prevents attempts to delete a table that has already been purged.
-            tables_to_exclude.add(splink_df.physical_name)
+#     def _table_exists_in_database(self, table_name):
+#         return wr.catalog.does_table_exist(
+#             database=self.output_schema,
+#             table=table_name,
+#             boto3_session=self.boto3_session,
+#         )
+
+#     def create_table(self, sql, physical_name):
+#         database = self.output_schema
+#         ctas_metadata = wr.athena.create_ctas_table(
+#             sql=sql,
+#             database=database,
+#             ctas_table=physical_name,
+#             storage_format="parquet",
+#             write_compression="snappy",
+#             boto3_session=self.boto3_session,
+#             s3_output=self.s3_output,
+#             wait=True,
+#         )
+#         return ctas_metadata
+
+#     def _drop_table_from_database_if_exists(self, table):
+#         return wr.catalog.delete_table_if_exists(
+#             database=self.output_schema, table=table, boto3_session=self.boto3_session
+#         )
+
+#     def _delete_table_from_s3(self, physical_name):
+#         path = f"{self.s3_output}{physical_name}/"
+#         # delete our folder
+#         wr.s3.delete_objects(
+#             path=path,
+#             use_threads=True,
+#             boto3_session=self.boto3_session,
+#         )
+
+#         metadata = self.ctas_query_info[physical_name]
+#         if "output_location" in metadata:
+#             metadata_urls = [
+#                 # metadata output location
+#                 f"{metadata['output_location']}.metadata",
+#                 # manifest location
+#                 metadata["manifest_location"],
+#             ]
+#             # delete our metadata
+#             wr.s3.delete_objects(
+#                 path=metadata_urls,
+#                 use_threads=True,
+#                 boto3_session=self.boto3_session,
+#             )
+
+#         self.ctas_query_info.pop(physical_name)
+
+#     def delete_table_from_database(self, name):
+#         if name in self.ctas_query_info:
+#             # Use ctas metadata to delete backing data
+#             self._delete_table_from_s3(name)
+#         else:
+#             # If the location we want to write to already exists,
+#             # clean this before continuing.
+#             loc = f"{self.s3_output}{name}"
+#             folder_exists = wr.s3.list_directories(
+#                 loc,
+#                 boto3_session=self.boto3_session,
+#             )
+#             if folder_exists:
+#                 # This will only delete objects we are required to delete
+#                 wr.s3.delete_objects(
+#                     path=loc,
+#                     use_threads=True,
+#                     boto3_session=self.boto3_session,
+#                 )
+
+#         self._drop_table_from_database_if_exists(name)
+
+#     def _extract_ctas_metadata(self, ctas_metadata):
+#         query_meta = ctas_metadata.pop("ctas_query_metadata")
+#         out_locs = {
+#             "output_location": query_meta.output_location,
+#             "manifest_location": query_meta.manifest_location,
+#         }
+#         ctas_metadata.update(out_locs)
+#         return ctas_metadata
+
+#     def drop_all_tables_created_by_splink(
+#         self,
+#         delete_s3_folders=True,
+#         tables_to_exclude: list[Union[SplinkDataFrame, str]] = [],
+#     ):
+#         """Run a cleanup process for the tables created by splink and
+#         currently contained in your output database.
+#         Only those tables currently contained within your database
+#         will be permanently deleted. Anything existing on s3 that
+#         isn't connected to your database will not be removed.
+#         Attributes:
+#             delete_s3_folders (bool, optional): Whether to delete the
+#                 backing data contained on s3. If False, the tables created
+#                 by splink will be removed from your database, but the parquet
+#                 outputs will remain on s3. Defaults to True.
+#             tables_to_exclude (list[SplinkDataFrame | str], optional): A list
+#                 of input tables you wish to add to an ignore list. These
+#                 will not be removed during garbage collection.
+#         """
+#         # Run cleanup on the cache before checking the db
+#         self.drop_tables_in_current_splink_run(
+#             delete_s3_folders,
+#             tables_to_exclude,
+#         )
+#         _garbage_collection(
+#             self.output_schema,
+#             self.boto3_session,
+#             delete_s3_folders,
+#             tables_to_exclude,
+#         )
+
+#     def drop_splink_tables_from_database(
+#         self,
+#         database_name: str,
+#         delete_s3_folders: bool = True,
+#         tables_to_exclude: list[Union[SplinkDataFrame, str]] = [],
+#     ):
+#         """Run a cleanup process for the tables created by splink
+#         in a specified database.
+#         Only those tables currently contained within your database
+#         will be permanently deleted. Anything existing on s3 that
+#         isn't connected to your database will not be removed.
+#         Attributes:
+#             database_name (str): The name of the database to delete splink tables from.
+#             delete_s3_folders (bool, optional): Whether to delete the
+#                 backing data contained on s3. If False, the tables created
+#                 by splink will be removed from your database, but the parquet
+#                 outputs will remain on s3. Defaults to True.
+#             tables_to_exclude (list[SplinkDataFrame | str], optional): A list
+#                 of input tables you wish to add to an ignore list. These
+#                 will not be removed during garbage collection.
+#         """
+#         _garbage_collection(
+#             database_name,
+#             self.boto3_session,
+#             delete_s3_folders,
+#             tables_to_exclude,
+#         )
+
+#     def drop_tables_in_current_splink_run(
+#         self,
+#         delete_s3_folders: bool = True,
+#         tables_to_exclude: list[Union[SplinkDataFrame, str]] = [],
+#     ):
+#         """Run a cleanup process for the tables created
+#         by the current splink linker.
+#         This leaves tables from previous runs untouched.
+#         Only those tables currently contained within your database
+#         will be permanently deleted. Anything existing on s3 that
+#         isn't connected to your database will not be removed.
+#         Attributes:
+#             delete_s3_folders (bool, optional): Whether to delete the
+#                 backing data contained on s3. If False, the tables created
+#                 by splink will be removed from your database, but the parquet
+#                 outputs will remain on s3. Defaults to True.
+#             tables_to_exclude (list[SplinkDataFrame | str], optional): A list
+#                 of input tables you wish to add to an ignore list. These
+#                 will not be removed during garbage collection.
+#         """
+
+#         tables_to_exclude = ensure_is_list(tables_to_exclude)
+#         tables_to_exclude = {
+#             df.physical_name if isinstance(df, SplinkDataFrame) else df
+#             for df in tables_to_exclude
+#         }
+
+#         # Exclude tables that the user doesn't want to delete
+#         cached_tables = self._intermediate_table_cache
+
+#         # Loop through our cached tables and delete all those not in our exclusion
+#         # list.
+#         for splink_df in list(cached_tables.values()):
+#             if (splink_df.physical_name not in tables_to_exclude) and (
+#                 splink_df.templated_name not in tables_to_exclude
+#             ):
+#                 splink_df.drop_table_from_database_and_remove_from_cache(
+#                     force_non_splink_table=False, delete_s3_data=delete_s3_folders
+#                 )
+#             # As our cache contains duplicate term frequency tables and AWSwrangler
+#             # run deletions asynchronously, add any previously seen tables to the
+#             # list of tables to exclude from deletion.
+#             # This prevents attempts to delete a table that has already been purged.
+#             tables_to_exclude.add(splink_df.physical_name)

--- a/splink/athena/linker.py
+++ b/splink/athena/linker.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E501
+# ignore line-too-long while commented out
 # from __future__ import annotations
 
 # import logging

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -159,7 +159,9 @@ class BlockingRule:
 
         rmtp = remove_table_prefix
 
-        keys_de_prefixed: list[tuple[Expression, Expression]] = [(rmtp(i), rmtp(j)) for (i, j) in keys_zipped]
+        keys_de_prefixed: list[tuple[Expression, Expression]] = [
+            (rmtp(i), rmtp(j)) for (i, j) in keys_zipped
+        ]
 
         keys_strings: list[tuple[str, str]] = [
             (i.sql(dialect=self.sqlglot_dialect), j.sql(self.sqlglot_dialect))

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, List, Optional
 
 from sqlglot import parse_one
-from sqlglot.expressions import Column, Join
+from sqlglot.expressions import Column, Expression, Join
 from sqlglot.optimizer.eliminate_joins import join_condition
 
 from .exceptions import SplinkException
@@ -130,7 +130,7 @@ class BlockingRule:
         return sql
 
     @property
-    def _parsed_join_condition(self):
+    def _parsed_join_condition(self) -> Join:
         br = self.blocking_rule_sql
         return parse_one("INNER JOIN r", into=Join).on(
             br, dialect=self.sqlglot_dialect
@@ -146,27 +146,27 @@ class BlockingRule:
             list of tuples like [(name, name), (substr(name,1,2), substr(name,2,3))]
         """
 
-        def remove_table_prefix(tree):
+        def remove_table_prefix(tree: Expression) -> Expression:
             for c in tree.find_all(Column):
                 del c.args["table"]
             return tree
 
-        j = self._parsed_join_condition
+        j: Join = self._parsed_join_condition
 
         source_keys, join_keys, _ = join_condition(j)
 
-        keys = zip(source_keys, join_keys)
+        keys_zipped = zip(source_keys, join_keys)
 
         rmtp = remove_table_prefix
 
-        keys = [(rmtp(i), rmtp(j)) for (i, j) in keys]
+        keys_de_prefixed: list[tuple[Expression, Expression]] = [(rmtp(i), rmtp(j)) for (i, j) in keys_zipped]
 
-        keys = [
+        keys_strings: list[tuple[str, str]] = [
             (i.sql(dialect=self.sqlglot_dialect), j.sql(self.sqlglot_dialect))
-            for (i, j) in keys
+            for (i, j) in keys_de_prefixed
         ]
 
-        return keys
+        return keys_strings
 
     @property
     def _filter_conditions(self):

--- a/splink/blocking.py
+++ b/splink/blocking.py
@@ -319,7 +319,8 @@ class ExplodingBlockingRule(BlockingRule):
         return sql
 
     def drop_materialised_id_pairs_dataframe(self):
-        self.exploded_id_pair_table.drop_table_from_database_and_remove_from_cache()
+        if self.exploded_id_pair_table is not None:
+            self.exploded_id_pair_table.drop_table_from_database_and_remove_from_cache()
         self.exploded_id_pair_table = None
 
     def exclude_pairs_generated_by_this_rule_sql(self, linker: Linker):

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -65,7 +65,7 @@ class Comparison:
 
         self.comparison_levels: list[ComparisonLevel] = comparison_levels
 
-        self.column_info_settings: Optional[ColumnInfoSettings] = column_info_settings
+        self._column_info_settings: Optional[ColumnInfoSettings] = column_info_settings
 
         self.sqlglot_dialect_name = sqlglot_dialect_name
         self.output_column_name = (
@@ -106,6 +106,16 @@ class Comparison:
     @property
     def _comparison_levels_excluding_null(self):
         return [cl for cl in self.comparison_levels if not cl.is_null_level]
+
+    @property
+    def column_info_settings(self) -> ColumnInfoSettings:
+        if (column_info_settings := self._column_info_settings) is None:
+            raise AttributeError(f"No column_info_settings set on Comparison {self}")
+        return column_info_settings
+    
+    @column_info_settings.setter
+    def column_info_settings(self, column_info_settings: ColumnInfoSettings) -> None:
+        self._column_info_settings = column_info_settings
 
     @property
     def gamma_prefix(self):

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -293,13 +293,6 @@ class Comparison:
             cols.append(self._bf_tf_adj_column_name)
         return cols
 
-    @property
-    def _term_frequency_columns(self):
-        cols = set()
-        for cl in self.comparison_levels:
-            cols.add(cl.tf_adjustment_input_col_name)
-        return list(cols)
-
     def as_dict(self):
         d = {
             "output_column_name": self.output_column_name,

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -429,8 +429,8 @@ class Comparison:
             )
             for cl in self.comparison_levels
         ]
-        comp_levels = "".join(comp_levels)
-        return comp_levels
+        comp_levels_str = "".join(comp_levels)
+        return comp_levels_str
 
     @property
     def _human_readable_description_succinct(self):

--- a/splink/comparison.py
+++ b/splink/comparison.py
@@ -112,7 +112,7 @@ class Comparison:
         if (column_info_settings := self._column_info_settings) is None:
             raise AttributeError(f"No column_info_settings set on Comparison {self}")
         return column_info_settings
-    
+
     @column_info_settings.setter
     def column_info_settings(self, column_info_settings: ColumnInfoSettings) -> None:
         self._column_info_settings = column_info_settings

--- a/splink/comparison_creator.py
+++ b/splink/comparison_creator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Union, final
+from typing import Dict, List, Optional, Union, final
 
 from .column_expression import ColumnExpression
 from .comparison import Comparison
@@ -112,7 +112,8 @@ class ComparisonCreator(ABC):
         pass
 
     @abstractmethod
-    def create_output_column_name(self) -> str:
+    def create_output_column_name(self) -> Optional[str]:
+        # should be str where possible, otherwise a default will be created
         pass
 
     @final

--- a/splink/comparison_level.py
+++ b/splink/comparison_level.py
@@ -156,8 +156,9 @@ class ComparisonLevel:
         self._tf_adjustment_weight = tf_adjustment_weight
         self._tf_minimum_u_value = tf_minimum_u_value
 
-        self._m_probability = m_probability
-        self._u_probability = u_probability
+        # internally these can be LEVEL_NOT_OBSERVED_TEXT, so allow for this
+        self._m_probability: float | None | str = m_probability
+        self._u_probability: float | None | str = u_probability
         self.default_m_probability = None
         self.default_u_probability = None
 
@@ -594,7 +595,7 @@ class ComparisonLevel:
 
     def as_dict(self):
         "The minimal representation of this level to use as an input to Splink"
-        output = {}
+        output: dict[str, Any] = {}
 
         output["sql_condition"] = self.sql_condition
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -264,9 +264,7 @@ class LiteralMatchLevel(ComparisonLevelCreator):
             return f"{col.name_r} = {dialected}"
         elif self.side_of_comparison == "both":
             return f"{col.name_l} = {dialected}" f" AND {col.name_r} = {dialected}"
-        raise ValueError(
-            f"Invalid `side_of_comparison`: {self.side_of_comparison}."
-        )
+        raise ValueError(f"Invalid `side_of_comparison`: {self.side_of_comparison}.")
 
     def create_label_for_charts(self) -> str:
         return (

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -264,6 +264,9 @@ class LiteralMatchLevel(ComparisonLevelCreator):
             return f"{col.name_r} = {dialected}"
         elif self.side_of_comparison == "both":
             return f"{col.name_l} = {dialected}" f" AND {col.name_r} = {dialected}"
+        raise ValueError(
+            f"Invalid `side_of_comparison`: {self.side_of_comparison}."
+        )
 
     def create_label_for_charts(self) -> str:
         return (
@@ -573,7 +576,7 @@ class AbsoluteTimeDifferenceLevel(ComparisonLevelCreator):
         self.datetime_format = datetime_format
         self.input_is_string = input_is_string
 
-    def convert_time_metric_to_seconds(self, threshold: int, metric: str) -> float:
+    def convert_time_metric_to_seconds(self, threshold: float, metric: str) -> float:
 
         conversion_factors = {
             "second": 1,

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -185,7 +185,8 @@ class ExactMatchLevel(ComparisonLevelCreator):
 
     @property
     def term_frequency_adjustments(self):
-        return self.tf_adjustment_column is not None
+        # mypy doesn't know about attribute as we use magic in .configure()
+        return self.tf_adjustment_column is not None  # type: ignore [attr-defined]
 
     @term_frequency_adjustments.setter
     def term_frequency_adjustments(self, term_frequency_adjustments: bool):

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union
 
 from . import comparison_level_library as cll
 from .comparison_creator import ComparisonCreator
@@ -85,7 +85,8 @@ class CustomComparison(ComparisonCreator):
             else f"Comparison for {self._output_column_name}"
         )
 
-    def create_output_column_name(self) -> str:
+    def create_output_column_name(self) -> Optional[str]:
+        # TODO: should default logic be here? would need column-extraction logic also
         return self._output_column_name
 
 

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List, Type, Union
 
 from . import comparison_level_library as cll
 from .column_expression import ColumnExpression
@@ -11,10 +11,10 @@ from .misc import ensure_is_iterable
 
 # alternatively we could stick an inheritance layer in these, just for typing:
 _fuzzy_cll_type = (
-    type[cll.DamerauLevenshteinLevel]
-    | type[cll.JaroLevel]
-    | type[cll.JaroWinklerLevel]
-    | type[cll.LevenshteinLevel]
+    Type[cll.DamerauLevenshteinLevel]
+    | Type[cll.JaroLevel]
+    | Type[cll.JaroWinklerLevel]
+    | Type[cll.LevenshteinLevel]
 )
 _fuzzy_levels: dict[str, _fuzzy_cll_type] = {
     "damerau_levenshtein": cll.DamerauLevenshteinLevel,

--- a/splink/comparison_template_library.py
+++ b/splink/comparison_template_library.py
@@ -10,12 +10,12 @@ from .comparison_level_library import DateMetricType
 from .misc import ensure_is_iterable
 
 # alternatively we could stick an inheritance layer in these, just for typing:
-_fuzzy_cll_type = (
-    Type[cll.DamerauLevenshteinLevel]
-    | Type[cll.JaroLevel]
-    | Type[cll.JaroWinklerLevel]
-    | Type[cll.LevenshteinLevel]
-)
+_fuzzy_cll_type = Union[
+    Type[cll.DamerauLevenshteinLevel],
+    Type[cll.JaroLevel],
+    Type[cll.JaroWinklerLevel],
+    Type[cll.LevenshteinLevel],
+]
 _fuzzy_levels: dict[str, _fuzzy_cll_type] = {
     "damerau_levenshtein": cll.DamerauLevenshteinLevel,
     "jaro": cll.JaroLevel,

--- a/splink/em_training_session.py
+++ b/splink/em_training_session.py
@@ -148,12 +148,12 @@ class EMTrainingSession:
         not_estimated = [
             cc.output_column_name for cc in self._comparisons_that_cannot_be_estimated
         ]
-        not_estimated = "".join([f"\n    - {cc}" for cc in not_estimated])
+        not_estimated_str = "".join([f"\n    - {cc}" for cc in not_estimated])
 
         estimated = [
             cc.output_column_name for cc in self.core_model_settings.comparisons
         ]
-        estimated = "".join([f"\n    - {cc}" for cc in estimated])
+        estimated_str = "".join([f"\n    - {cc}" for cc in estimated])
 
         if {"m", "u"}.issubset(self.training_fixed_probabilities):
             raise ValueError("Can't train model if you fix both m and u probabilites")
@@ -170,9 +170,9 @@ class EMTrainingSession:
             f"Estimating the {mu} of the model by blocking on:\n"
             f"{blocking_rule}\n\n"
             "Parameter estimates will be made for the following comparison(s):"
-            f"{estimated}\n"
+            f"{estimated_str}\n"
             "\nParameter estimates cannot be made for the following comparison(s)"
-            f" since they are used in the blocking rules: {not_estimated}"
+            f" since they are used in the blocking rules: {not_estimated_str}"
         )
 
     def _comparison_vectors(self):

--- a/splink/find_matches_to_new_records.py
+++ b/splink/find_matches_to_new_records.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from .input_column import InputColumn
@@ -11,8 +13,8 @@ if TYPE_CHECKING:
 def add_unique_id_and_source_dataset_cols_if_needed(
     linker: "Linker", new_records_df: "SplinkDataFrame", pipeline: CTEPipeline
 ) -> CTEPipeline:
-    cols = new_records_df.columns
-    cols = [c.unquote().name for c in cols]
+    input_cols: list[InputColumn] = new_records_df.columns
+    cols: list[str] = [c.unquote().name for c in input_cols]
 
     # Add source dataset column to new records if required and not exists
     sds_sel_sql = ""

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -337,10 +337,10 @@ def _get_dialect_quotes(dialect):
 
 def _get_sqlglot_dialect_quotes(dialect: sqlglot.Dialect):
     try:
-        # For sqlglot >= 16.0.0
-        start = dialect.IDENTIFIER_START  # type: ignore [attr-defined]
-        end = dialect.IDENTIFIER_END  # type: ignore [attr-defined]
+        start = dialect.IDENTIFIER_START
+        end = dialect.IDENTIFIER_END
     except AttributeError:
+        # For sqlglot < 16.0.0
         start = dialect.identifier_start  # type: ignore [attr-defined]
         end = dialect.identifier_end  # type: ignore [attr-defined]
     return start, end

--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Type
 
 import sqlglot
 import sqlglot.expressions as exp
@@ -329,13 +329,13 @@ def _get_dialect_quotes(dialect):
     if dialect is None:
         return start, end
     try:
-        sqlglot_dialect = sqlglot.Dialect[dialect.lower()]
+        sqlglot_dialect: Type[sqlglot.Dialect] = sqlglot.Dialect[dialect.lower()]
     except KeyError:
         return start, end
     return _get_sqlglot_dialect_quotes(sqlglot_dialect)
 
 
-def _get_sqlglot_dialect_quotes(dialect: sqlglot.Dialect):
+def _get_sqlglot_dialect_quotes(dialect: Type[sqlglot.Dialect]):
     try:
         start = dialect.IDENTIFIER_START
         end = dialect.IDENTIFIER_END

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -149,7 +149,7 @@ class Linker:
         settings: SettingsCreator | dict | Path | str,
         database_api: DatabaseAPI,
         set_up_basic_logging: bool = True,
-        input_table_aliases: str | list = None,
+        input_table_aliases: str | list | None = None,
         validate_settings: bool = True,
     ):
         """Initialise the linker object, which manages the data linkage process and
@@ -943,7 +943,7 @@ class Linker:
     def estimate_parameters_using_expectation_maximisation(
         self,
         blocking_rule: Union[str, BlockingRuleCreator],
-        comparisons_to_deactivate: list[str | Comparison] = None,
+        comparisons_to_deactivate: list[Comparison] = None,
         comparison_levels_to_reverse_blocking_rule: list[ComparisonLevel] = None,
         estimate_without_term_frequencies: bool = False,
         fix_probability_two_random_records_match: bool = False,
@@ -1469,16 +1469,16 @@ class Linker:
 
         pipeline.enqueue_sql(sql, "__splink__df_comparison_vectors")
 
-        sqls = predict_from_comparison_vectors_sqls(
+        sql_infos = predict_from_comparison_vectors_sqls(
             unique_id_input_columns=uid_cols,
             core_model_settings=self._settings_obj.core_model_settings,
             sql_dialect=self._sql_dialect,
             sql_infinity_expression=self._infinity_expression,
         )
-        for sql in sqls:
-            output_table_name = sql["output_table_name"]
+        for sql_info in sql_infos:
+            output_table_name = sql_info["output_table_name"]
             output_table_name = output_table_name.replace("predict", "self_link")
-            pipeline.enqueue_sql(sql["sql"], output_table_name)
+            pipeline.enqueue_sql(sql_info["sql"], output_table_name)
 
         predictions = self.db_api.sql_pipeline_to_splink_dataframe(pipeline)
 

--- a/splink/match_weights_histogram.py
+++ b/splink/match_weights_histogram.py
@@ -38,22 +38,22 @@ def _hist_sql(bin_width):
     group by {bin_width} * floor(match_weight / {bin_width})
     order by {bin_width} * floor(match_weight / {bin_width}) asc
     """
-    sql = {
+    sql_info = {
         "sql": sql,
         "output_table_name": "__splink__df_hist_raw",
     }
-    sqls.append(sql)
+    sqls.append(sql_info)
 
     sql = f"""
     select *, splink_score_bin_low + cast({bin_width} as float) as splink_score_bin_high
     from __splink__df_hist_raw
     """
 
-    sql = {
+    sql_info = {
         "sql": sql,
         "output_table_name": "__splink__df_hist",
     }
-    sqls.append(sql)
+    sqls.append(sql_info)
 
     return sqls
 

--- a/splink/postgres/dataframe.py
+++ b/splink/postgres/dataframe.py
@@ -34,7 +34,7 @@ class PostgresDataFrame(SplinkDataFrame):
     def validate(self):
         if type(self.physical_name) is not str:
             raise ValueError(
-                f"{self.df_name} is not a string dataframe.\n"
+                f"{self.templated_name} is not a string dataframe.\n"
                 "Postgres Linker requires input data"
                 " to be a string containing the name of the"
                 " postgres table."

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -153,11 +153,11 @@ def _col_or_expr_frequencies_raw_data_sql(cols_or_exprs, table_name):
         # a null value.
         if isinstance(raw_expr, list):
             null_exprs = [f"{c} is null" for c in raw_expr]
-            null_exprs = " OR ".join(null_exprs)
+            null_expr_str = " OR ".join(null_exprs)
 
             col_or_expr = f"""
                 case when
-                {null_exprs} then null
+                {null_expr_str} then null
                 else
                 {col_or_expr}
                 end

--- a/splink/settings.py
+++ b/splink/settings.py
@@ -636,12 +636,12 @@ class Settings:
         comparison_descs = [
             c._human_readable_description_succinct for c in self.comparisons
         ]
-        comparison_descs = "\n".join(comparison_descs)
+        comparison_desc_str = "\n".join(comparison_descs)
         desc = (
             "SUMMARY OF LINKING MODEL\n"
             "------------------------\n"
             "The similarity of pairwise record comparison in your model will be "
-            f"assessed as follows:\n\n{comparison_descs}"
+            f"assessed as follows:\n\n{comparison_desc_str}"
         )
         return desc
 

--- a/splink/spark/dataframe.py
+++ b/splink/spark/dataframe.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from pandas import DataFrame as PandasDataFrame
+
 from ..input_column import InputColumn
 from ..splink_dataframe import SplinkDataFrame
 from .spark_helpers.custom_spark_dialect import Dialect
@@ -33,11 +35,7 @@ class SparkDataFrame(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
 
-        return (
-            self.db_api._execute_sql_against_backend(sql)
-            .toPandas()
-            .to_dict(orient="records")
-        )
+        return self.as_pandas_dataframe(limit=limit).to_dict(orient="records")
 
     def _drop_table_from_database(self, force_non_splink_table=False):
         if self.db_api.break_lineage_method == "delta_lake_table":
@@ -46,7 +44,7 @@ class SparkDataFrame(SplinkDataFrame):
         else:
             pass
 
-    def as_pandas_dataframe(self, limit=None):
+    def as_pandas_dataframe(self, limit=None) -> PandasDataFrame:
         sql = f"select * from {self.physical_name}"
         if limit:
             sql += f" limit {limit}"

--- a/splink/sqlite/dataframe.py
+++ b/splink/sqlite/dataframe.py
@@ -34,7 +34,7 @@ class SQLiteDataFrame(SplinkDataFrame):
     def validate(self):
         if type(self.physical_name) is not str:
             raise ValueError(
-                f"{self.df_name} is not a string dataframe.\n"
+                f"{self.templated_name} is not a string dataframe.\n"
                 "SQLite Linker requires input data"
                 " to be a string containing the name of the "
                 " sqlite table."

--- a/splink/waterfall_chart.py
+++ b/splink/waterfall_chart.py
@@ -1,12 +1,13 @@
 import math
 from copy import deepcopy
+from typing import Any, Dict
 
 from .comparison import Comparison
 from .misc import prob_to_bayes_factor
 
 
 def _prior_record(settings_obj):
-    rec = {}
+    rec: Dict[str, Any] = {}
     rec["column_name"] = "Prior"
     rec["label_for_charts"] = "Starting match weight (prior)"
     rec["sql_condition"] = None
@@ -24,7 +25,7 @@ def _prior_record(settings_obj):
 
 
 def _final_score_record(record_as_dict):
-    rec = {}
+    rec: Dict[str, Any] = {}
     rec["column_name"] = "Final score"
     rec["label_for_charts"] = "Final score"
     rec["sql_condition"] = None


### PR DESCRIPTION
Stricter use of mypy:
* removing some excluded modules (i.e. no longer excluded)
* remove a softer checking parameter we had (following imports)
* add in a few stricter checking options (a subset of full `--strict` mode - see [the relevant docs](https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options))

Nothing particularly special about the set of options I have added - just following the mypy suggested route, and stopped at a point before the changeset became too large (maybe? sorry if I missed that point!).
We can continue incrementally adding remaining options in follow-ups as and when.

In terms of the code changes to get this up to spec, I don't think there is anything particularly crazy here. Much of it is adding/correcting annotations + renaming variables, but there are a few genuine code changes - don't think anything noteworthy however.