### PR TITLE
Changing args as kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleaesed
 
+### Fixed
+
+- Activates `higher_is_more_similar` kwarg in `cl.distance_function_at_thresholds`, see [here](https://github.com/moj-analytical-services/splink/pull/2116)
+
 ## [3.9.14] - 2024-03-25
 
 ### Fixed

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -285,13 +285,14 @@ class DistanceFunctionAtThresholdsBase(Comparison):
             comparison_levels.append(level)
 
         threshold_comparison_levels = distance_threshold_comparison_levels(
-            self,
-            col_name,
-            distance_function_name,
-            distance_threshold_or_thresholds,
-            regex_extract,
-            set_to_lowercase,
-            m_probability_or_probabilities_thres,
+            self=self,
+            col_name=col_name,
+            distance_function_name=distance_function_name,
+            distance_threshold_or_thresholds=distance_threshold_or_thresholds,
+            regex_extract=regex_extract,
+            set_to_lowercase=set_to_lowercase,
+            higher_is_more_similar=higher_is_more_similar,
+            m_probability_or_probabilities_thres=m_probability_or_probabilities_thres
         )
         comparison_levels = comparison_levels + threshold_comparison_levels
 

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -292,7 +292,7 @@ class DistanceFunctionAtThresholdsBase(Comparison):
             regex_extract=regex_extract,
             set_to_lowercase=set_to_lowercase,
             higher_is_more_similar=higher_is_more_similar,
-            m_probability_or_probabilities_thres=m_probability_or_probabilities_thres
+            m_probability_or_probabilities_thres=m_probability_or_probabilities_thres,
         )
         comparison_levels = comparison_levels + threshold_comparison_levels
 


### PR DESCRIPTION
### Type of PR

- [X] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?  

Addresses PR #1011

### Give a brief description for the solution you have provided

This issue resolves the inactivity of kwarg `higher_is_more_similar` in `cl.distance_function_at_thresholds`. 

Previously, `higher_is_more_similar` was not being passed to `distance_threshold_comparison_levels` and instead, the argument `m_probability_or_probabilities_thres` was passed in its place. The default to that arg is `None` so it was always resolving `False`. 

Now, `higher_is_more_similar` is passed as a kwarg and correctly changes the operator when toggled.

I didn't add any tests for this becuase I believe that would involve installing the jar file with custom comparisons in it, but please let me know if you'd like me to add some a different way.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [X] Updated CHANGELOG.md (if appropriate)
- [X] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint.html)
