### PR TITLE
Process input tables simplification

### DIFF
--- a/splink/database_api.py
+++ b/splink/database_api.py
@@ -271,9 +271,9 @@ class DatabaseAPI(ABC, Generic[TablishType]):
     def register_table(
         self, input_table, table_name, overwrite=False
     ) -> SplinkDataFrame:
-        input_tables = self.process_input_tables([input_table])
+
         tables_dict = self.register_multiple_tables(
-            input_tables, [table_name], overwrite=overwrite
+            [input_table], [table_name], overwrite=overwrite
         )
         return tables_dict[table_name]
 

--- a/splink/database_api.py
+++ b/splink/database_api.py
@@ -13,10 +13,7 @@ from .dialects import (
 )
 from .exceptions import SplinkException
 from .logging_messages import execute_sql_logging_message_info, log_sql
-from .misc import (
-    ascii_uid,
-    parse_duration,
-)
+from .misc import ascii_uid, ensure_is_list, parse_duration
 from .pipeline import CTEPipeline
 from .splink_dataframe import SplinkDataFrame
 
@@ -191,7 +188,6 @@ class DatabaseAPI(ABC, Generic[TablishType]):
         """
 
         if not self.debug_mode:
-
             sql_gen = pipeline.generate_cte_pipeline_sql()
             output_tablename_templated = pipeline.output_table_name
 
@@ -231,6 +227,7 @@ class DatabaseAPI(ABC, Generic[TablishType]):
         input_aliases: Optional[List[str]] = None,
         overwrite: bool = False,
     ) -> Dict[str, SplinkDataFrame]:
+        input_tables = self.process_input_tables(input_tables)
 
         tables_as_splink_dataframes = {}
         existing_tables = []
@@ -271,9 +268,12 @@ class DatabaseAPI(ABC, Generic[TablishType]):
         return tables_as_splink_dataframes
 
     @final
-    def register_table(self, input, table_name, overwrite=False) -> SplinkDataFrame:
+    def register_table(
+        self, input_table, table_name, overwrite=False
+    ) -> SplinkDataFrame:
+        input_tables = self.process_input_tables([input_table])
         tables_dict = self.register_multiple_tables(
-            [input], [table_name], overwrite=overwrite
+            input_tables, [table_name], overwrite=overwrite
         )
         return tables_dict[table_name]
 
@@ -328,6 +328,7 @@ class DatabaseAPI(ABC, Generic[TablishType]):
         for linker.
         Default just passes through - backends can specialise if desired
         """
+        input_tables = ensure_is_list(input_tables)
         return input_tables
 
     # should probably also be responsible for cache

--- a/splink/duckdb/database_api.py
+++ b/splink/duckdb/database_api.py
@@ -107,6 +107,7 @@ class DuckDBAPI(DatabaseAPI):
         return accepted_df_dtypes
 
     def process_input_tables(self, input_tables):
+        input_tables = super().process_input_tables(input_tables)
         return [
             self.load_from_file(t) if isinstance(t, str) else t for t in input_tables
         ]

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -230,11 +230,9 @@ class Linker:
 
         # TODO: Add test of what happens if the db_api is for a different backend
         # to the sql_dialect set in the settings dict
-        input_tables = ensure_is_list(input_table_or_tables)
-        input_tables = self.db_api.process_input_tables(input_tables)
 
         self._input_tables_dict = self._register_input_tables(
-            input_tables,
+            input_table_or_tables,
             input_table_aliases,
         )
 

--- a/splink/profile_data.py
+++ b/splink/profile_data.py
@@ -234,11 +234,7 @@ def profile_columns(
             values to display in the respective charts.
     """
 
-    tables = ensure_is_list(table_or_tables)
-
-    tables = db_api.process_input_tables(tables)
-
-    splink_df_dict = db_api.register_multiple_tables(tables)
+    splink_df_dict = db_api.register_multiple_tables(table_or_tables)
     input_dataframes = list(splink_df_dict.values())
     input_aliases = list(splink_df_dict.keys())
     input_columns = input_dataframes[0].columns_escaped


### PR DESCRIPTION
A small PR setting some of the foundations to do analysis of blocking rule without a linker.

This is a step towards solving https://github.com/moj-analytical-services/splink/issues/2142

Since the `process_input_tables` function is used only during table registration (and is part of the table registration logic) it makes senes to perform is as _part_ of table registration as opposed to a separate function call.

This means that e.g. in `profile_columns` we need a single `register_multiple_tables` call rather than three lines:
```
tables = ensure_is_list(table_or_tables)
tables = db_api.process_input_tables(tables)
splink_df_dict = db_api.register_multiple_tables(tables)
```

We'll need similar logic for any functions that do exploratory analysis without a linker, so we don't want to have to repeatedly write this logic.

Don't know why the docs build triggered here, but all the other tests are passing