### PR TITLE
Type decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,6 @@ strict_equality = true
 strict_concatenate = true
 check_untyped_defs = true
 disallow_subclassing_any = true
+disallow_untyped_decorators = true
 # next set to enforce:
-# disallow_untyped_decorators = true
 # disallow_any_generics = true

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -14,8 +14,9 @@ from .comparison_level_sql import great_circle_distance_km_sql
 from .dialects import SplinkDialect
 
 # type aliases:
-T = TypeVar('T', bound=ComparisonLevelCreator)
+T = TypeVar("T", bound=ComparisonLevelCreator)
 CreateSQLFunctionType = Callable[[T, SplinkDialect], str]
+
 
 def unsupported_splink_dialects(
     unsupported_dialects: List[str],

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List, Literal, Union
+from functools import wraps
+from typing import Callable, List, Literal, TypeVar, Union
 
 from sqlglot import TokenError, parse_one
 
@@ -12,16 +13,22 @@ from .comparison_level_creator import ComparisonLevelCreator
 from .comparison_level_sql import great_circle_distance_km_sql
 from .dialects import SplinkDialect
 
+# type aliases:
+T = TypeVar('T', bound=ComparisonLevelCreator)
+CreateSQLFunctionType = Callable[[T, SplinkDialect], str]
 
-def unsupported_splink_dialects(unsupported_dialects: List[str]):
-    def decorator(func):
-        def wrapper(self, splink_dialect: SplinkDialect, *args, **kwargs):
+def unsupported_splink_dialects(
+    unsupported_dialects: List[str],
+) -> Callable[[CreateSQLFunctionType], CreateSQLFunctionType]:
+    def decorator(func: CreateSQLFunctionType) -> CreateSQLFunctionType:
+        @wraps(func)
+        def wrapper(self, splink_dialect: SplinkDialect) -> str:
             if splink_dialect.name in unsupported_dialects:
                 raise ValueError(
                     f"Dialect {splink_dialect.name} is not supported "
                     f"for {self.__class__.__name__}"
                 )
-            return func(self, splink_dialect, *args, **kwargs)
+            return func(self, splink_dialect)
 
         return wrapper
 


### PR DESCRIPTION
A single extra mypy option, and typing annotations so that using the decorator `unsupported_splink_dialects` doesn't destroy the underlying typing information.