### PR TITLE
Minor bug in filtering predict table

### DIFF
--- a/splink/predict.py
+++ b/splink/predict.py
@@ -55,7 +55,7 @@ def predict_from_comparison_vectors_sqls(
         thres_prob_as_weight = prob_to_match_weight(threshold_match_probability)
     else:
         thres_prob_as_weight = None
-    if threshold_match_probability or threshold_match_weight:
+    if threshold_match_probability is not None or threshold_match_weight is not None:
         thresholds = [
             thres_prob_as_weight,
             threshold_match_weight,


### PR DESCRIPTION
### Type of PR

- [X] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

No (sorry). I noticed this issue while running `linker.predict(threshold_match_weight=0.0)` and finding that the predictions table wasn't being filtered as expected.

### Give a brief description for the solution you have provided

Check for `if threshold_match_weight is not None` (evaluates to True when threshold is 0.0) rather than `if threshold_match_weight`.