### PR TITLE
Fixing spurious error messages with Databricks enable_splink

### DIFF
--- a/splink/databricks/enable_splink.py
+++ b/splink/databricks/enable_splink.py
@@ -34,7 +34,7 @@ def enable_splink(spark):
     optionModule = getattr(optionClass, "MODULE$")
 
     dbr_version = float(os.environ.get("DATABRICKS_RUNTIME_VERSION"))
-    
+
     try:
         if dbr_version >= 14:
             lib = JavaJarId(

--- a/splink/databricks/enable_splink.py
+++ b/splink/databricks/enable_splink.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from splink.spark.jar_location import similarity_jar_location
 
@@ -32,37 +33,34 @@ def enable_splink(spark):
     optionClass = getattr(sc._jvm.scala, "Option$")
     optionModule = getattr(optionClass, "MODULE$")
 
-    # Note(bobby): So dirty
+    dbr_version = float(os.environ.get("DATABRICKS_RUNTIME_VERSION"))
+    
     try:
-        # This will fix the exception when running on Databricks Runtime 14.x+
-        lib = JavaJarId(
-            JarURI,
-            ManagedLibraryId.defaultOrganization(),
-            NoVersionModule.simpleString(),
-            optionModule.apply(None),
-            optionModule.apply(None),
-            optionModule.apply(None),
-        )
+        if dbr_version >= 14:
+            lib = JavaJarId(
+                JarURI,
+                ManagedLibraryId.defaultOrganization(),
+                NoVersionModule.simpleString(),
+                optionModule.apply(None),
+                optionModule.apply(None),
+                optionModule.apply(None),
+            )
+        elif dbr_version >= 13:
+            lib = JavaJarId(
+                JarURI,
+                ManagedLibraryId.defaultOrganization(),
+                NoVersionModule.simpleString(),
+                optionModule.apply(None),
+                optionModule.apply(None),
+            )
+        else:
+            lib = JavaJarId(
+                JarURI,
+                ManagedLibraryId.defaultOrganization(),
+                NoVersionModule.simpleString(),
+            )
     except Exception as e:
-        logger.warn("failed to initialize for 14.x+", e)
-        try:
-            # This will fix the exception when running on Databricks Runtime 13.x
-            lib = JavaJarId(
-                JarURI,
-                ManagedLibraryId.defaultOrganization(),
-                NoVersionModule.simpleString(),
-                optionModule.apply(None),
-                optionModule.apply(None),
-            )
-        except Exception as ex:
-            logger.warn("failed to initialize for 13.x", ex)
-
-            # This will work for < 13.x
-            lib = JavaJarId(
-                JarURI,
-                ManagedLibraryId.defaultOrganization(),
-                NoVersionModule.simpleString(),
-            )
+        logger.warn("failed to enable similarity jar functions for Databricks", e)
 
     libSeq = converters.asScalaBufferConverter((lib,)).asScala().toSeq()
 


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->

Follow up to #1973.

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->

The existing solution involved a nested try-except block which logs an error message even if it succeeds for DBR 13.x or lower. I've changed this to check the environment variable `DATABRICKS_RUNTIME_VERSION` and act according to whether it's 14 or higher, 13, or lower than 13. 

I have quickly tested this in our Databricks environment, at least with DBR 11.3 LTS, DBR 13.3 LTS and DBR 14.3 LTS. It works to register the jar and executing `spark.sql("jaro_winkler('test', 'tst')")` runs and returns the correct result. 

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


