### PR TITLE
Feature/add single comparison column validation check

### DIFF
--- a/splink/exceptions.py
+++ b/splink/exceptions.py
@@ -36,6 +36,10 @@ class SplinkDeprecated(DeprecationWarning):
     pass
 
 
+class InvalidSplinkInput(SplinkException):
+    pass
+
+
 class InvalidDialect(SplinkException):
     pass
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -19,8 +19,9 @@ from splink.settings_validation.log_invalid_columns import (
     SettingsColumnCleaner,
 )
 from splink.settings_validation.valid_types import (
+    _check_input_dataframes_for_single_comparison_column,
+    _log_comparison_errors,
     _validate_dialect,
-    log_comparison_errors,
 )
 
 from .accuracy import (
@@ -515,7 +516,7 @@ class Linker:
         # Constructs output logs for our various settings inputs
         cleaned_settings = SettingsColumnCleaner(
             settings_object=self._settings_obj,
-            input_columns=self._input_tables_dict,
+            splink_input_table_dfs=self._input_tables_dict,
         )
         InvalidColumnsLogger(cleaned_settings).construct_output_logs(validate_settings)
 
@@ -1133,8 +1134,13 @@ class Linker:
         settings_dict["sql_dialect"] = sql_dialect
         settings_dict["linker_uid"] = settings_dict.get("linker_uid", cache_uid)
 
+        _check_input_dataframes_for_single_comparison_column(
+            self._input_tables_dict,
+            source_dataset_column_name=settings_dict.get("source_dataset_column_name"),
+            unique_id_column_name=settings_dict.get("unique_id_column_name"),
+        )
         # Check the user's comparisons (if they exist)
-        log_comparison_errors(settings_dict.get("comparisons"), sql_dialect)
+        _log_comparison_errors(settings_dict.get("comparisons"), sql_dialect)
         self._settings_obj_ = Settings(settings_dict)
         # Check the final settings object
         self._validate_settings(validate_settings)

--- a/splink/settings_validation/settings_column_cleaner.py
+++ b/splink/settings_validation/settings_column_cleaner.py
@@ -5,7 +5,7 @@ import re
 from copy import deepcopy
 from functools import reduce
 from operator import and_
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List
 
 import sqlglot
 
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..settings import Settings
+    from ..splink_dataframe import SplinkDataFrame
 
 
 def remove_suffix(c):
@@ -81,7 +82,9 @@ def clean_list_of_column_names(col_list: List[InputColumn]):
     return set((c.unquote().name for c in col_list))
 
 
-def clean_user_input_columns(input_columns: dict, return_as_single_column: bool = True):
+def clean_user_input_columns(
+    input_columns: Dict[str, "SplinkDataFrame"], return_as_single_column: bool = True
+):
     """A dictionary containing all input dataframes and the columns located
     within.
 
@@ -104,11 +107,11 @@ class SettingsColumnCleaner:
     cleaned up settings columns and SQL strings.
     """
 
-    def __init__(self, settings_object: Settings, input_columns: dict):
+    def __init__(self, settings_object: Settings, splink_input_table_dfs: dict):
         self.sql_dialect = settings_object._sql_dialect
         self._settings_obj = settings_object
         self.input_columns = clean_user_input_columns(
-            input_columns.items(), return_as_single_column=True
+            splink_input_table_dfs.items(), return_as_single_column=True
         )
 
     @property

--- a/splink/settings_validation/settings_validation_log_strings.py
+++ b/splink/settings_validation/settings_validation_log_strings.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import List, NamedTuple, Tuple
+from typing import Dict, List, NamedTuple, Tuple
 
 
 def indent_error_message(message):
@@ -200,3 +200,21 @@ def create_incorrect_dialect_import_log_string(
         "for your specified linker.\n"
     )
     return indent_error_message(log_message)
+
+
+def construct_single_dataframe_log_str(input_columns: Dict[str, str]) -> str:
+    if len(input_columns) == 1:
+        df_txt = "dataframe is"
+    else:
+        df_txt = "dataframes are"
+
+    log_message = (
+        f"\nThe provided {df_txt} unsuitable for linkage with Splink as\n"
+        "it contains only a single column for matching.\n"
+        "Splink is not designed for linking based on a single 'bag of words'\n"
+        "column, such as a table with only a 'company name' column and\n"
+        "no other details.\n\nFor more information see: \n"
+        "https://github.com/moj-analytical-services/splink/issues/1362"
+    )
+
+    return log_message

--- a/splink/settings_validation/valid_types.py
+++ b/splink/settings_validation/valid_types.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Union
+from typing import TYPE_CHECKING, Dict, List, Union
 
 from ..comparison import Comparison
 from ..comparison_level import ComparisonLevel
-from ..exceptions import ComparisonSettingsException, ErrorLogger, InvalidDialect
+from ..default_from_jsonschema import default_value_from_schema
+from ..exceptions import (
+    ComparisonSettingsException,
+    ErrorLogger,
+    InvalidDialect,
+    InvalidSplinkInput,
+)
+from .settings_column_cleaner import clean_user_input_columns
 from .settings_validation_log_strings import (
+    construct_single_dataframe_log_str,
     create_incorrect_dialect_import_log_string,
     create_invalid_comparison_level_log_string,
     create_invalid_comparison_log_string,
     create_no_comparison_levels_error_log_string,
 )
+
+if TYPE_CHECKING:
+    from ..splink_dataframe import SplinkDataFrame
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,15 +36,41 @@ def extract_sql_dialect_from_cll(cll):
 
 
 def _validate_dialect(settings_dialect: str, linker_dialect: str, linker_type: str):
-    # settings_dialect = self.linker._settings_obj._sql_dialect
-    # linker_dialect = self.linker._sql_dialect
-    # linker_type = self.linker.__class__.__name__
     if settings_dialect != linker_dialect:
         raise ValueError(
             f"Incompatible SQL dialect! `settings` dictionary uses "
             f"dialect {settings_dialect}, but expecting "
             f"'{linker_dialect}' for Linker of type `{linker_type}`"
         )
+
+
+def _check_input_dataframes_for_single_comparison_column(
+    input_columns: Dict[str, "SplinkDataFrame"],
+    source_dataset_column_name: str = None,
+    unique_id_column_name: str = None,
+):
+
+    if source_dataset_column_name is None:
+        source_dataset_column_name = default_value_from_schema(
+            "source_dataset_column_name", "root"
+        )
+    if unique_id_column_name is None:
+        unique_id_column_name = default_value_from_schema(
+            "unique_id_column_name", "root"
+        )
+
+    input_columns = clean_user_input_columns(
+        input_columns.items(), return_as_single_column=False
+    )
+
+    required_cols = (source_dataset_column_name, unique_id_column_name)
+
+    # Loop and exit if any dataframe has only possible comparison column
+    for columns in input_columns.values():
+        unique_columns = set(columns) - set(required_cols)
+
+        if len(unique_columns) == 1:
+            raise InvalidSplinkInput(construct_single_dataframe_log_str(input_columns))
 
 
 def validate_comparison_levels(
@@ -53,38 +91,10 @@ def validate_comparison_levels(
         # If no error is found, append won't do anything
         error_logger.log_error(evaluate_comparison_dtype_and_contents(c_dict))
         error_logger.log_error(
-            evaluate_comparisons_for_imports_from_incorrect_dialects(
-                c_dict, linker_dialect
-            )
+            check_comparison_imported_for_correct_dialect(c_dict, linker_dialect)
         )
 
     return error_logger
-
-
-def log_comparison_errors(comparisons, linker_dialect):
-    """
-    Log any errors arising from `validate_comparison_levels`.
-    """
-
-    # Check for empty inputs - Expecting None or []
-    if not comparisons:
-        return
-
-    error_logger = ErrorLogger()
-
-    error_logger = validate_comparison_levels(error_logger, comparisons, linker_dialect)
-
-    # Raise and log any errors identified
-    plural_this = "this" if len(error_logger.raw_errors) == 1 else "these"
-    comp_hyperlink_txt = (
-        f"\nFor more info on how to construct comparisons and avoid {plural_this} "
-        "error, please visit:\n"
-        "https://moj-analytical-services.github.io/splink/topic_guides/comparisons/customising_comparisons.html"
-    )
-
-    error_logger.raise_and_log_all_errors(
-        exception=ComparisonSettingsException, additional_txt=comp_hyperlink_txt
-    )
 
 
 def check_comparison_level_types(
@@ -146,9 +156,7 @@ def evaluate_comparison_dtype_and_contents(comparison_dict):
     return check_comparison_level_types(comp_levels, comp_str)
 
 
-def evaluate_comparisons_for_imports_from_incorrect_dialects(
-    comparison_dict, sql_dialect
-):
+def check_comparison_imported_for_correct_dialect(comparison_dict, sql_dialect):
     """
     Given a comparison_dict, assess whether the sql dialect is valid for
     your selected linker.
@@ -198,3 +206,29 @@ def evaluate_comparisons_for_imports_from_incorrect_dialects(
             comp_str, sorted(invalid_dialects)
         )
         return InvalidDialect(error_message)
+
+
+def _log_comparison_errors(comparisons: List[Comparison], linker_dialect: str):
+    """
+    Log any errors arising from various comparison validation checks.
+    """
+
+    # Check for empty inputs - Expecting None or []
+    if not comparisons:
+        return
+
+    error_logger = ErrorLogger()
+
+    error_logger = validate_comparison_levels(error_logger, comparisons, linker_dialect)
+
+    # Raise and log any errors identified
+    plural_this = "this" if len(error_logger.raw_errors) == 1 else "these"
+    comp_hyperlink_txt = (
+        f"\nFor more info on how to construct comparisons and avoid {plural_this} "
+        "error, please visit:\n"
+        "https://moj-analytical-services.github.io/splink/topic_guides/comparisons/customising_comparisons.html"
+    )
+
+    error_logger.raise_and_log_all_errors(
+        exception=ComparisonSettingsException, additional_txt=comp_hyperlink_txt
+    )


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Adds a validation check to assess whether any input data frames entered by a user have only a single comparison column  - https://github.com/moj-analytical-services/splink/issues/1392.




### Give a brief description for the solution you have provided
This function adds a basic check to determine whether any of the user's data frames contain only one comparison column after excluding the unique_id and source_dataset columns.

Where this is true, Splink will generate invalid SQL, leading to cryptic SQL errors that may be difficult to interpret.

_NB:_ this check only activates if the user has correctly specified unique_id and source_dataset. Should there be any mistakes in entering these variables in the settings, other validation checks will identify and highlight these errors.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


