### PR TITLE
Mark spark tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ markers = [
     "spark_only",
     "sqlite",
     "sqlite_only",
+    "postgres",
+    "postgres_only",
 ]
 
 [tool.mypy]

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -2946,7 +2946,9 @@ class Linker:
                 f" have term frequency adjustment activated"
             )
 
-        vals_to_include = ensure_is_list(vals_to_include)
+        vals_to_include = (
+            [] if vals_to_include is None else ensure_is_list(vals_to_include)
+        )
 
         return tf_adjustment_chart(
             self,

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -158,6 +158,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
     Linker(df_spark, settings=path, database_api=spark_api)
 
 
+@mark_with_dialects_including("spark")
 def test_link_only(spark, df_spark, spark_api):
     settings = get_settings_dict()
     settings["link_type"] = "link_only"

--- a/tests/test_spark_udfs.py
+++ b/tests/test_spark_udfs.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 import splink.comparison_level_library as cll
 from splink.linker import Linker
+from tests.decorator import mark_with_dialects_including
 
 first_name_cc = {
     "output_column_name": "first_name",
@@ -51,6 +52,7 @@ settings = {
 }
 
 
+@mark_with_dialects_including("spark")
 def test_udf_registration(spark_api):
     spark = spark_api.spark
     # Integration test to ensure spark loads our udfs without any issues
@@ -72,6 +74,7 @@ def test_udf_registration(spark_api):
     linker.predict()
 
 
+@mark_with_dialects_including("spark")
 def test_damerau_levenshtein(spark_api):
     spark = spark_api.spark
     data = ["dave", "david", "", "dave"]
@@ -158,6 +161,7 @@ def test_damerau_levenshtein(spark_api):
     )
 
 
+@mark_with_dialects_including("spark")
 def test_jaro(spark_api):
     spark = spark_api.spark
     data = ["dave", "david", "", "dave"]
@@ -239,6 +243,7 @@ def test_jaro(spark_api):
     assert spark.sql("""SELECT jaro_sim("aaapppp", "")  """).first()[0] == 0.0
 
 
+@mark_with_dialects_including("spark")
 def test_jaro_winkler(spark_api):
     spark = spark_api.spark
     data = ["dave", "david", "", "dave"]


### PR DESCRIPTION
This marks the remaining spark-specific tests with the `spark` mark, to properly separate them all out when running. 

Also a couple of other things to reduce test warnings:
* register postgres marks with pytest
* tweak to tf_adjustment_chart so that we don't get an unnecessary warning if we have `vals_to_include=None`