### PR TITLE
Remove reference to github action that will not come to be

### DIFF
--- a/docs/dev_guides/changing_splink/contributing_to_docs.md
+++ b/docs/dev_guides/changing_splink/contributing_to_docs.md
@@ -38,7 +38,7 @@ Spelling check passed :)
 
 otherwise, PySpelling will printout the spelling mistakes found in each file.
 
-Correct spellings of words not found in a standard dictionary (e.g. Splink) can be recorded as such by adding them to `scripts/pyspelling/custom_dictionary.txt`. (Don't worry about adding them in alphabetical order or accidental duplication as this will be handled automatically by a GitHub Action future.)
+Correct spellings of words not found in a standard dictionary (e.g. "Splink") can be recorded as such by adding them to `scripts/pyspelling/custom_dictionary.txt`.
 
 Please correct any mistakes found or update the custom dictionary to ensure the spellchecker passes before putting in a pull request containing updates to the documentation.
 


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->

(Sorry this has taken me a while to get to!)

This teenie tiny PR removes the reference to a GitHub Action that sorts the custom dictionary for the spellchecker in the Contributing to the Docs Guide, since this Action would be overkill (see issue #2100 and comments).

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)
