### PR TITLE
Fix Splink 4 blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Documentation](https://img.shields.io/badge/API-documentation-blue)](https://moj-analytical-services.github.io/splink/)
 
 > [!IMPORTANT]
-> Development has begun on Splink 4 on the `splink4_dev` branch.  Splink 3 is in maintenance mode and we are no longer accepting new features. We welcome contributions to Splink 4. Read more on our latest [blog](https://moj-analytical-services.github.io/splink/blog/2024/03/19/splink4.html).
+> Development has begun on Splink 4 on the `splink4_dev` branch.  Splink 3 is in maintenance mode and we are no longer accepting new features. We welcome contributions to Splink 4. Read more on our latest [blog](https://moj-analytical-services.github.io/splink/blog/2024/04/02/splink-3-updates-and-splink-4-development-announcement---april-2024.html).
 
 # Fast, accurate and scalable probabilistic data linkage
 


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [X] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
No.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
The README notice that development has begun on Splink 4 included a link for more information (https://moj-analytical-services.github.io/splink/blog/2024/03/19/splink4.html), which returns a '404 - Not found' error.

I've updated the link to https://moj-analytical-services.github.io/splink/blog/2024/04/02/splink-3-updates-and-splink-4-development-announcement---april-2024.html.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


