### PR TITLE
Does enabling arrow in spark speed the speed of tests?

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def _make_spark():
     conf.set("spark.driver.memory", "6g")
     conf.set("spark.sql.shuffle.partitions", "1")
     conf.set("spark.default.parallelism", "1")
+    conf.set("spark.sql.execution.arrow.enabled", "true")
     # Add custom similarity functions, which are bundled with Splink
     # documented here: https://github.com/moj-analytical-services/splink_scalaudfs
     path = similarity_jar_location()


### PR DESCRIPTION
Answer is no - it doesn't seem to!
Before:

![image](https://github.com/moj-analytical-services/splink/assets/2608005/367d4a4b-b688-4f27-9923-b8c9bc7c192a)

After:
![image](https://github.com/moj-analytical-services/splink/assets/2608005/2c2b2c9c-6174-4277-b915-8b8e5cd1e60e)
