### PR TITLE
Misc tidying

### DIFF
--- a/splink/column_expression.py
+++ b/splink/column_expression.py
@@ -4,7 +4,7 @@ import re
 import string
 from copy import copy
 from functools import partial
-from typing import Callable, Union
+from typing import Protocol, Union
 
 import sqlglot
 
@@ -14,6 +14,10 @@ from .sql_transform import (
     add_suffix_to_all_column_identifiers,
     add_table_to_all_column_identifiers,
 )
+
+
+class ColumnExpressionOperation(Protocol):
+    def __call__(self, name: str, dialect: SplinkDialect) -> str: ...
 
 
 class ColumnExpression:
@@ -40,7 +44,7 @@ class ColumnExpression:
 
     def __init__(self, sql_expression: str, sql_dialect: SplinkDialect = None):
         self.raw_sql_expression = sql_expression
-        self.operations: list[Callable[..., str]] = []
+        self.operations: list[ColumnExpressionOperation] = []
         if sql_dialect is not None:
             self.sql_dialect: SplinkDialect = sql_dialect
 
@@ -113,7 +117,7 @@ class ColumnExpression:
 
     def lower(self) -> "ColumnExpression":
         """
-        Applies a lowercase transofrom to the input expression.
+        Applies a lowercase transform to the input expression.
         """
         clone = self._clone()
         clone.operations.append(clone._lower_dialected)

--- a/splink/dialects.py
+++ b/splink/dialects.py
@@ -497,12 +497,3 @@ class AthenaDialect(SplinkDialect):
     @property
     def _levenshtein_name(self):
         return "levenshtein_distance"
-
-
-_dialect_lookup = {
-    "duckdb": DuckDBDialect(),
-    "spark": SparkDialect(),
-    "sqlite": SQLiteDialect(),
-    "postgres": PostgresDialect(),
-    "athena": AthenaDialect(),
-}

--- a/splink/settings_creator.py
+++ b/splink/settings_creator.py
@@ -13,12 +13,6 @@ from .comparison_library import CustomComparison
 from .settings import Settings
 
 
-def to_comparison_creator(comparison_creator):
-    if isinstance(comparison_creator, dict):
-        return CustomComparison(**comparison_creator)
-    return comparison_creator
-
-
 @dataclass
 class SettingsCreator:
     """
@@ -68,7 +62,7 @@ class SettingsCreator:
         # we adjust dict to ensure that comparisons + blocking rules are
         # consistently of creatore types
         creator_dict["comparisons"] = [
-            to_comparison_creator(comparison_creator)
+            CustomComparison._convert_to_creator(comparison_creator)
             for comparison_creator in creator_dict["comparisons"]
         ]
         creator_dict["blocking_rules_to_generate_predictions"] = [


### PR DESCRIPTION
Three small unrelated changes that weren't quite worth putting separately:

* updated `ColumnExpression` typing to better clarify what allowed operations look like
* remove a dialect dict we don't use anymore
* move where we have functions for converting dicts to `ComparisonCreator`/`ComparisonLevelCreator`

On the last point I am not convinced if these are necessarily the best place to have these functions (maybe the base classes make more sense, but then more complicated as we need to make reference to the subclasses `CustomXXX` explicitly), but I think the current structure is a bit confusing (`ComparisonCreator._convert_to_creator()` makes a `ComparisonLevelCreator`), so now it is at least consistent across comparison + level.