### PR TITLE
Consolidate accuracy 2

### DIFF
--- a/docs/charts/accuracy_chart_from_labels_table.ipynb
+++ b/docs/charts/accuracy_chart_from_labels_table.ipynb
@@ -114,6 +114,7 @@
     "from splink.duckdb.blocking_rule_library import block_on\n",
     "from splink.datasets import splink_datasets, splink_dataset_labels\n",
     "import logging, sys\n",
+    "\n",
     "logging.disable(sys.maxsize)\n",
     "\n",
     "df = splink_datasets.fake_1000\n",
@@ -147,7 +148,9 @@
     "df_labels = splink_dataset_labels.fake_1000_labels\n",
     "labels_table = linker.register_labels_table(df_labels)\n",
     "\n",
-    "linker.accuracy_chart_from_labels_table(labels_table, add_metrics=['f1'])"
+    "linker.accuracy_analysis_from_labels_table(\n",
+    "    labels_table, output_type=\"accuracy\", add_metrics=[\"f1\"]\n",
+    ")"
    ]
   },
   {

--- a/docs/charts/threshold_selection_tool_from_labels_table.ipynb
+++ b/docs/charts/threshold_selection_tool_from_labels_table.ipynb
@@ -147,7 +147,7 @@
     "df_labels = splink_dataset_labels.fake_1000_labels\n",
     "labels_table = linker.register_labels_table(df_labels)\n",
     "\n",
-    "linker.threshold_selection_tool_from_labels_table(labels_table, add_metrics=['f1'])"
+    "linker.accuracy_analysis_from_labels_table(labels_table, add_metrics=['f1'])"
    ]
   },
   {

--- a/docs/demos/examples/duckdb/accuracy_analysis_from_labels_column.ipynb
+++ b/docs/demos/examples/duckdb/accuracy_analysis_from_labels_column.ipynb
@@ -766,8 +766,8 @@
     }
    ],
    "source": [
-    "linker.truth_space_table_from_labels_column(\n",
-    "    \"cluster\", match_weight_round_to_nearest=0.1\n",
+    "linker.accuracy_analysis_from_labels_column(\n",
+    "    \"cluster\", output_type=\"table\"\n",
     ").as_pandas_dataframe(limit=5)"
    ]
   },
@@ -863,8 +863,7 @@
     }
    ],
    "source": [
-    "linker.roc_chart_from_labels_column(\"cluster\")\n",
-    "# Can also do linker.precision_recall_chart_from_labels_column(\"cluster\")"
+    "linker.accuracy_analysis_from_labels_column(\"cluster\", output_type=\"roc\")"
    ]
   },
   {
@@ -959,7 +958,12 @@
     }
    ],
    "source": [
-    "linker.threshold_selection_tool_from_labels_column(\"cluster\", threshold_actual=0.5, add_metrics=['f1'])"
+    "linker.accuracy_analysis_from_labels_column(\n",
+    "    \"cluster\",\n",
+    "    output_type=\"threshold_selection\",\n",
+    "    threshold_actual=0.5,\n",
+    "    add_metrics=[\"f1\"],\n",
+    ")"
    ]
   },
   {

--- a/docs/demos/examples/duckdb/deduplicate_50k_synthetic.ipynb
+++ b/docs/demos/examples/duckdb/deduplicate_50k_synthetic.ipynb
@@ -1514,7 +1514,9 @@
     }
    ],
    "source": [
-    "linker.roc_chart_from_labels_column(\"cluster\", match_weight_round_to_nearest=0.02)"
+    "linker.accuracy_analysis_from_labels_column(\n",
+    "    \"cluster\", output_type=\"roc\", match_weight_round_to_nearest=0.02\n",
+    ")"
    ]
   },
   {

--- a/docs/demos/examples/duckdb/febrl3.ipynb
+++ b/docs/demos/examples/duckdb/febrl3.ipynb
@@ -1131,7 +1131,9 @@
     }
    ],
    "source": [
-    "linker.roc_chart_from_labels_column(\"cluster\", match_weight_round_to_nearest=0.1)"
+    "linker.accuracy_analysis_from_labels_column(\n",
+    "    \"cluster\", match_weight_round_to_nearest=0.1, output_type=\"roc\"\n",
+    ")"
    ]
   },
   {

--- a/docs/demos/examples/duckdb/febrl4.ipynb
+++ b/docs/demos/examples/duckdb/febrl4.ipynb
@@ -2809,9 +2809,8 @@
         }
       ],
       "source": [
-        "# linker_detailed.roc_chart_from_labels_column(\"cluster\")\n",
-        "linker_detailed.precision_recall_chart_from_labels_column(\n",
-        "    \"cluster\", match_weight_round_to_nearest=0.1\n",
+        "linker_detailed.accuracy_analysis_from_labels_column(\n",
+        "    \"cluster\", output_type=\"precision_recall\"\n",
         ")"
       ]
     },

--- a/docs/demos/examples/sqlite/deduplicate_50k_synthetic.ipynb
+++ b/docs/demos/examples/sqlite/deduplicate_50k_synthetic.ipynb
@@ -1303,7 +1303,9 @@
         }
       ],
       "source": [
-        "linker.roc_chart_from_labels_column(\"cluster\", match_weight_round_to_nearest=0.02)"
+        "linker.accuracy_analysis_from_labels_column(\n",
+        "    \"cluster\", output_type=\"roc\", match_weight_round_to_nearest=0.02\n",
+        ")"
       ]
     },
     {

--- a/docs/demos/tutorials/07_Evaluation.ipynb
+++ b/docs/demos/tutorials/07_Evaluation.ipynb
@@ -136,6 +136,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "030c4cde",
+   "metadata": {},
+   "source": [
+    "### Threshold Selection chart\n",
+    "\n",
+    "Splink includes an interactive dashboard that shows key accuracy statistics:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e83d9645",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linker.accuracy_analysis_from_labels_table(\n",
+    "    labels_table, output_type=\"threshold_selection\", add_metrics=[\"f1\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "81e4396d",
    "metadata": {},
    "source": [
@@ -237,7 +259,9 @@
     }
    ],
    "source": [
-    "linker.roc_chart_from_labels_table(labels_table)"
+    "linker.accuracy_analysis_from_labels_table(\n",
+    "    labels_table, output_type=\"roc\"\n",
+    ")"
    ]
   },
   {
@@ -345,7 +369,9 @@
     }
    ],
    "source": [
-    "linker.precision_recall_chart_from_labels_table(labels_table)"
+    "linker.accuracy_analysis_from_labels_table(\n",
+    "    labels_table, output_type=\"precision_recall\"\n",
+    ")"
    ]
   },
   {
@@ -600,7 +626,7 @@
     }
    ],
    "source": [
-    "roc_table = linker.truth_space_table_from_labels_table(labels_table)\n",
+    "roc_table = linker.accuracy_analysis_from_labels_table(labels_table, output_type=\"table\")\n",
     "roc_table.as_pandas_dataframe(limit=5)"
    ]
   },

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -1820,6 +1820,7 @@ class Linker:
                 "phi",
             ]
         ] = [],
+        positives_not_captured_by_blocking_rules_scored_as_zero: bool = True,
     ) -> Union[ChartReturnType, SplinkDataFrame]:
         """Generate an accuracy chart or table from ground truth data, where the ground
         truth is in a column in the input dataset called `labels_column_name`
@@ -1872,6 +1873,7 @@ class Linker:
             labels_column_name,
             threshold_actual=threshold_actual,
             match_weight_round_to_nearest=match_weight_round_to_nearest,
+            positives_not_captured_by_blocking_rules_scored_as_zero=positives_not_captured_by_blocking_rules_scored_as_zero,
         )
         recs = df_truth_space.as_record_dict()
 

--- a/splink/linker.py
+++ b/splink/linker.py
@@ -6,7 +6,7 @@ import os
 from copy import copy, deepcopy
 from pathlib import Path
 from statistics import median
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
 from .accuracy import (
     prediction_errors_from_label_column,
@@ -1766,348 +1766,6 @@ class Linker:
         )
         estimate_m_from_pairwise_labels(self, labels_tablename)
 
-    def truth_space_table_from_labels_table(
-        self,
-        labels_splinkdataframe_or_table_name: SplinkDataFrame | str,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-    ) -> SplinkDataFrame:
-        """Generate truth statistics (false positive etc.) for each threshold value of
-        match_probability, suitable for plotting a ROC chart.
-
-        The table of labels should be in the following format, and should be registered
-        with your database:
-
-        |source_dataset_l|unique_id_l|source_dataset_r|unique_id_r|clerical_match_score|
-        |----------------|-----------|----------------|-----------|--------------------|
-        |df_1            |1          |df_2            |2          |0.99                |
-        |df_1            |1          |df_2            |3          |0.2                 |
-
-        Note that `source_dataset` and `unique_id` should correspond to the values
-        specified in the settings dict, and the `input_table_aliases` passed to the
-        `linker` object.
-
-        For `dedupe_only` links, the `source_dataset` columns can be ommitted.
-
-        Args:
-            labels_splinkdataframe_or_table_name (str | SplinkDataFrame): Name of table
-                containing labels in the database
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the ROC chart. Defaults to None.
-
-        Examples:
-            ```py
-            labels = pd.read_csv("my_labels.csv")
-            linker.register_table(labels, "labels")
-            linker.truth_space_table_from_labels_table("labels")
-            ```
-
-        Returns:
-            SplinkDataFrame:  Table of truth statistics
-        """
-        labels_tablename = self._get_labels_tablename_from_input(
-            labels_splinkdataframe_or_table_name
-        )
-
-        self._raise_error_if_necessary_accuracy_columns_not_computed()
-        return truth_space_table_from_labels_table(
-            self,
-            labels_tablename,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-
-    def roc_chart_from_labels_table(
-        self,
-        labels_splinkdataframe_or_table_name: str | SplinkDataFrame,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-    ) -> ChartReturnType:
-        """Generate a ROC chart from labelled (ground truth) data.
-
-        The table of labels should be in the following format, and should be registered
-        with your database:
-
-        |source_dataset_l|unique_id_l|source_dataset_r|unique_id_r|clerical_match_score|
-        |----------------|-----------|----------------|-----------|--------------------|
-        |df_1            |1          |df_2            |2          |0.99                |
-        |df_1            |1          |df_2            |3          |0.2                 |
-
-        Note that `source_dataset` and `unique_id` should correspond to the values
-        specified in the settings dict, and the `input_table_aliases` passed to the
-        `linker` object.
-
-        For `dedupe_only` links, the `source_dataset` columns can be ommitted.
-
-        Args:
-            labels_splinkdataframe_or_table_name (str | SplinkDataFrame): Name of table
-                containing labels in the database
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the ROC chart. Defaults to None.
-
-        Examples:
-            === ":simple-duckdb: DuckDB"
-                ```py
-                labels = pd.read_csv("my_labels.csv")
-                linker.register_table(labels, "labels")
-                linker.roc_chart_from_labels_table("labels")
-                ```
-            === ":simple-apachespark: Spark"
-                ```py
-                labels = spark.read.csv("my_labels.csv", header=True)
-                labels.createDataFrame("labels")
-                linker.roc_chart_from_labels_table("labels")
-                ```
-
-        Returns:
-            altair.Chart: An altair chart
-        """
-        labels_tablename = self._get_labels_tablename_from_input(
-            labels_splinkdataframe_or_table_name
-        )
-
-        self._raise_error_if_necessary_accuracy_columns_not_computed()
-        df_truth_space = truth_space_table_from_labels_table(
-            self,
-            labels_tablename,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-        recs = df_truth_space.as_record_dict()
-        return roc_chart(recs)
-
-    def precision_recall_chart_from_labels_table(
-        self,
-        labels_splinkdataframe_or_table_name: SplinkDataFrame | str,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-    ) -> ChartReturnType:
-        """Generate a precision-recall chart from labelled (ground truth) data.
-
-        The table of labels should be in the following format, and should be registered
-        as a table with your database:
-
-        |source_dataset_l|unique_id_l|source_dataset_r|unique_id_r|clerical_match_score|
-        |----------------|-----------|----------------|-----------|--------------------|
-        |df_1            |1          |df_2            |2          |0.99                |
-        |df_1            |1          |df_2            |3          |0.2                 |
-
-        Note that `source_dataset` and `unique_id` should correspond to the values
-        specified in the settings dict, and the `input_table_aliases` passed to the
-        `linker` object.
-
-        For `dedupe_only` links, the `source_dataset` columns can be ommitted.
-
-        Args:
-            labels_splinkdataframe_or_table_name (str | SplinkDataFrame): Name of table
-                containing labels in the database
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the ROC chart. Defaults to None.
-        Examples:
-            ```py
-            labels = pd.read_csv("my_labels.csv")
-            linker.register_table(labels, "labels")
-            linker.precision_recall_chart_from_labels_table("labels")
-            ```
-
-        Returns:
-            altair.Chart: An altair chart
-        """
-        labels_tablename = self._get_labels_tablename_from_input(
-            labels_splinkdataframe_or_table_name
-        )
-        self._raise_error_if_necessary_accuracy_columns_not_computed()
-        df_truth_space = truth_space_table_from_labels_table(
-            self,
-            labels_tablename,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-        recs = df_truth_space.as_record_dict()
-        return precision_recall_chart(recs)
-
-    def accuracy_chart_from_labels_table(
-        self,
-        labels_splinkdataframe_or_table_name: SplinkDataFrame | str,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-        add_metrics: list[str] = [],
-    ) -> ChartReturnType:
-        """Generate an accuracy measure chart from labelled (ground truth) data.
-
-        The table of labels should be in the following format, and should be registered
-        as a table with your database:
-
-        |source_dataset_l|unique_id_l|source_dataset_r|unique_id_r|clerical_match_score|
-        |----------------|-----------|----------------|-----------|--------------------|
-        |df_1            |1          |df_2            |2          |0.99                |
-        |df_1            |1          |df_2            |3          |0.2                 |
-
-        Note that `source_dataset` and `unique_id` should correspond to the values
-        specified in the settings dict, and the `input_table_aliases` passed to the
-        `linker` object.
-
-        For `dedupe_only` links, the `source_dataset` columns can be ommitted.
-
-        Args:
-            labels_splinkdataframe_or_table_name (str | SplinkDataFrame): Name of table
-                containing labels in the database
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the chart. Defaults to None.
-            add_metrics (list(str), optional): Precision and recall metrics are always
-                included. Where provided, `add_metrics` specifies additional metrics
-                to show, with the following options:
-
-                - `"specificity"`: specificity, selectivity, true negative rate (TNR)
-                - `"npv"`: negative predictive value (NPV)
-                - `"accuracy"`: overall accuracy (TP+TN)/(P+N)
-                - `"f1"`/`"f2"`/`"f0_5"`: F-scores for \u03b2=1 (balanced), \u03b2=2
-                (emphasis on recall) and \u03b2=0.5 (emphasis on precision)
-                - `"p4"` -  an extended F1 score with specificity and NPV included
-                - `"phi"` - \u03c6 coefficient or Matthews correlation coefficient (MCC)
-        Examples:
-            === ":simple-duckdb: DuckDB"
-                ```py
-                labels = pd.read_csv("my_labels.csv")
-                linker.register_table(labels, "labels")
-                linker.accuracy_chart_from_labels_table("labels", add_metrics=["f1"])
-                ```
-            === ":simple-apachespark: Spark"
-                ```py
-                labels = spark.read.csv("my_labels.csv", header=True)
-                labels.createDataFrame("labels")
-                linker.accuracy_chart_from_labels_table("labels", add_metrics=['f1'])
-                ```
-
-        Returns:
-            altair.Chart: An altair chart
-        """
-        allowed = ["specificity", "npv", "accuracy", "f1", "f2", "f0_5", "p4", "phi"]
-
-        if not isinstance(add_metrics, list):
-            raise Exception(
-                "add_metrics must be a list containing one or more of the following:",
-                allowed,
-            )
-
-        # Silently filter out invalid entries (except case errors - e.g. ["NPV", "F1"])
-        add_metrics = list(set(map(str.lower, add_metrics)).intersection(allowed))
-
-        labels_tablename = self._get_labels_tablename_from_input(
-            labels_splinkdataframe_or_table_name
-        )
-        self._raise_error_if_necessary_accuracy_columns_not_computed()
-        df_truth_space = truth_space_table_from_labels_table(
-            self,
-            labels_tablename,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-        recs = df_truth_space.as_record_dict()
-        return accuracy_chart(recs, add_metrics=add_metrics)
-
-    def threshold_selection_tool_from_labels_table(
-        self,
-        labels_splinkdataframe_or_table_name: str | SplinkDataFrame,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-        add_metrics: list[str] = [],
-    ) -> ChartReturnType:
-        """Generate an accuracy chart from labelled (ground truth) data.
-
-        The table of labels should be in the following format, and should be registered
-        as a table with your database:
-
-        |source_dataset_l|unique_id_l|source_dataset_r|unique_id_r|clerical_match_score|
-        |----------------|-----------|----------------|-----------|--------------------|
-        |df_1            |1          |df_2            |2          |0.99                |
-        |df_1            |1          |df_2            |3          |0.2                 |
-
-        Note that `source_dataset` and `unique_id` should correspond to the values
-        specified in the settings dict, and the `input_table_aliases` passed to the
-        `linker` object.
-
-        For `dedupe_only` links, the `source_dataset` columns can be ommitted.
-
-        Args:
-            labels_splinkdataframe_or_table_name (str | SplinkDataFrame): Name of table
-                containing labels in the database
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the chart. Defaults to None.
-            add_metrics (list(str), optional): Precision and recall metrics are always
-                included. Where provided, `add_metrics` specifies additional metrics
-                to show, with the following options:
-
-                - `"specificity"`: specificity, selectivity, true negative rate (TNR)
-                - `"npv"`: negative predictive value (NPV)
-                - `"accuracy"`: overall accuracy (TP+TN)/(P+N)
-                - `"f1"`/`"f2"`/`"f0_5"`: F-scores for \u03b2=1 (balanced), \u03b2=2
-                (emphasis on recall) and \u03b2=0.5 (emphasis on precision)
-                - `"p4"` -  an extended F1 score with specificity and NPV included
-                - `"phi"` - \u03c6 coefficient or Matthews correlation coefficient (MCC)
-        Examples:
-            ```py
-            linker.accuracy_chart_from_labels_column("ground_truth", add_metrics=["f1"])
-            ```
-
-        Returns:
-            altair.Chart: An altair chart
-        """
-
-        allowed = ["specificity", "npv", "accuracy", "f1", "f2", "f0_5", "p4", "phi"]
-
-        if not isinstance(add_metrics, list):
-            raise Exception(
-                "add_metrics must be a list containing one or more of the following:",
-                allowed,
-            )
-
-        # Silently filter out invalid entries (except case errors - e.g. ["NPV", "F1"])
-        add_metrics = list(set(map(str.lower, add_metrics)).intersection(allowed))
-
-        labels_tablename = self._get_labels_tablename_from_input(
-            labels_splinkdataframe_or_table_name
-        )
-        self._raise_error_if_necessary_accuracy_columns_not_computed()
-        df_truth_space = truth_space_table_from_labels_table(
-            self,
-            labels_tablename,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-        recs = df_truth_space.as_record_dict()
-        return threshold_selection_tool(recs, add_metrics=add_metrics)
-
     def prediction_errors_from_labels_table(
         self,
         labels_splinkdataframe_or_table_name,
@@ -2141,130 +1799,29 @@ class Linker:
             threshold,
         )
 
-    def truth_space_table_from_labels_column(
+    def accuracy_analysis_from_labels_column(
         self,
         labels_column_name: str,
+        *,
         threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-        positives_not_captured_by_blocking_rules_scored_as_zero: bool = True,
-    ) -> SplinkDataFrame:
-        """Generate truth statistics (false positive etc.) for each threshold value of
-        match_probability, suitable for plotting a ROC chart.
-
-        Your labels_column_name should include the ground truth cluster (unique
-        identifier) that groups entities which are the same
-
-        Args:
-            labels_tablename (str): Name of table containing labels in the database
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the ROC chart. Defaults to None.
-
-        Examples:
-            ```py
-            linker.truth_space_table_from_labels_column("cluster")
-            ```
-
-        Returns:
-            SplinkDataFrame:  Table of truth statistics
-        """
-
-        return truth_space_table_from_labels_column(
-            self,
-            labels_column_name,
-            threshold_actual,
-            match_weight_round_to_nearest,
-            positives_not_captured_by_blocking_rules_scored_as_zero,
-        )
-
-    def roc_chart_from_labels_column(
-        self,
-        labels_column_name: str,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-    ) -> ChartReturnType:
-        """Generate a ROC chart from ground truth data, whereby the ground truth
-        is in a column in the input dataset called `labels_column_name`
-
-        Args:
-            labels_column_name (str): Column name containing labels in the input table
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the ROC chart. Defaults to None.
-
-        Examples:
-            ```py
-            linker.roc_chart_from_labels_column("labels")
-            ```
-
-        Returns:
-            altair.Chart: An altair chart
-        """
-
-        df_truth_space = truth_space_table_from_labels_column(
-            self,
-            labels_column_name,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-        recs = df_truth_space.as_record_dict()
-        return roc_chart(recs)
-
-    def precision_recall_chart_from_labels_column(
-        self,
-        labels_column_name: str,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-    ) -> ChartReturnType:
-        """Generate a precision-recall chart from ground truth data, whereby the ground
-        truth is in a column in the input dataset called `labels_column_name`
-
-        Args:
-            labels_column_name (str): Column name containing labels in the input table
-            threshold_actual (float, optional): Where the `clerical_match_score`
-                provided by the user is a probability rather than binary, this value
-                is used as the threshold to classify `clerical_match_score`s as binary
-                matches or non matches. Defaults to 0.5.
-            match_weight_round_to_nearest (float, optional): When provided, thresholds
-                are rounded.  When large numbers of labels are provided, this is
-                sometimes necessary to reduce the size of the ROC table, and therefore
-                the number of points plotted on the ROC chart. Defaults to None.
-        Examples:
-            ```py
-            linker.precision_recall_chart_from_labels_column("ground_truth")
-            ```
-
-        Returns:
-            altair.Chart: An altair chart
-        """
-
-        df_truth_space = truth_space_table_from_labels_column(
-            self,
-            labels_column_name,
-            threshold_actual=threshold_actual,
-            match_weight_round_to_nearest=match_weight_round_to_nearest,
-        )
-        recs = df_truth_space.as_record_dict()
-        return precision_recall_chart(recs)
-
-    def accuracy_chart_from_labels_column(
-        self,
-        labels_column_name: str,
-        threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-        add_metrics: list[str] = [],
-    ) -> ChartReturnType:
-        """Generate an accuracy chart from ground truth data, whereby the ground
+        match_weight_round_to_nearest: float = 0.1,
+        output_type: Literal[
+            "threshold_selection", "roc", "precision_recall", "table", "accuracy"
+        ] = "threshold_selection",
+        add_metrics: List[
+            Literal[
+                "specificity",
+                "npv",
+                "accuracy",
+                "f1",
+                "f2",
+                "f0_5",
+                "p4",
+                "phi",
+            ]
+        ] = [],
+    ) -> Union[ChartReturnType, SplinkDataFrame]:
+        """Generate an accuracy chart or table from ground truth data, where the ground
         truth is in a column in the input dataset called `labels_column_name`
 
         Args:
@@ -2290,12 +1847,12 @@ class Linker:
                 - `"phi"` - \u03c6 coefficient or Matthews correlation coefficient (MCC)
         Examples:
             ```py
-            linker.accuracy_chart_from_labels_column("ground_truth", add_metrics=["f1"])
+            linker.accuracy_analysis_from_labels_column("ground_truth", add_metrics=["f1"])
             ```
 
         Returns:
             altair.Chart: An altair chart
-        """
+        """  # noqa: E501
 
         allowed = ["specificity", "npv", "accuracy", "f1", "f2", "f0_5", "p4", "phi"]
 
@@ -2305,8 +1862,10 @@ class Linker:
                 allowed,
             )
 
-        # Silently filter out invalid entries (except case errors - e.g. ["NPV", "F1"])
-        add_metrics = list(set(map(str.lower, add_metrics)).intersection(allowed))
+        if not all(metric in allowed for metric in add_metrics):
+            raise ValueError(
+                "Invalid metric. " f"Allowed metrics are: {', '.join(allowed)}."
+            )
 
         df_truth_space = truth_space_table_from_labels_column(
             self,
@@ -2315,20 +1874,65 @@ class Linker:
             match_weight_round_to_nearest=match_weight_round_to_nearest,
         )
         recs = df_truth_space.as_record_dict()
-        return accuracy_chart(recs, add_metrics=add_metrics)
 
-    def threshold_selection_tool_from_labels_column(
+        if output_type == "threshold_selection":
+            return threshold_selection_tool(recs, add_metrics=add_metrics)
+        elif output_type == "accuracy":
+            return accuracy_chart(recs, add_metrics=add_metrics)
+        elif output_type == "roc":
+            return roc_chart(recs)
+        elif output_type == "precision_recall":
+            return precision_recall_chart(recs)
+        elif output_type == "table":
+            return df_truth_space
+        else:
+            raise ValueError(
+                "Invalid chart_type. Allowed chart types are: "
+                "'threshold_selection', 'roc', 'precision_recall', 'accuracy."
+            )
+
+    def accuracy_analysis_from_labels_table(
         self,
-        labels_column_name: str,
+        labels_splinkdataframe_or_table_name: str | SplinkDataFrame,
+        *,
         threshold_actual: float = 0.5,
-        match_weight_round_to_nearest: float = None,
-        add_metrics: list[str] = [],
-    ) -> ChartReturnType:
-        """Generate an accuracy chart from ground truth data, whereby the ground
-        truth is in a column in the input dataset called `labels_column_name`
+        match_weight_round_to_nearest: float = 0.1,
+        output_type: Literal[
+            "threshold_selection", "roc", "precision_recall", "table", "accuracy"
+        ] = "threshold_selection",
+        add_metrics: List[
+            Literal[
+                "specificity",
+                "npv",
+                "accuracy",
+                "f1",
+                "f2",
+                "f0_5",
+                "p4",
+                "phi",
+            ]
+        ] = [],
+    ) -> Union[ChartReturnType, SplinkDataFrame]:
+        """Generate an accuracy chart or table from labelled (ground truth) data.
+
+        The table of labels should be in the following format, and should be registered
+        as a table with your database using
+        `labels_table = linker.register_labels_table(my_df)`
+
+        |source_dataset_l|unique_id_l|source_dataset_r|unique_id_r|clerical_match_score|
+        |----------------|-----------|----------------|-----------|--------------------|
+        |df_1            |1          |df_2            |2          |0.99                |
+        |df_1            |1          |df_2            |3          |0.2                 |
+
+        Note that `source_dataset` and `unique_id` should correspond to the values
+        specified in the settings dict, and the `input_table_aliases` passed to the
+        `linker` object.
+
+        For `dedupe_only` links, the `source_dataset` columns can be ommitted.
 
         Args:
-            labels_column_name (str): Column name containing labels in the input table
+            labels_splinkdataframe_or_table_name (str | SplinkDataFrame): Name of table
+                containing labels in the database
             threshold_actual (float, optional): Where the `clerical_match_score`
                 provided by the user is a probability rather than binary, this value
                 is used as the threshold to classify `clerical_match_score`s as binary
@@ -2350,12 +1954,12 @@ class Linker:
                 - `"phi"` - \u03c6 coefficient or Matthews correlation coefficient (MCC)
         Examples:
             ```py
-            linker.accuracy_chart_from_labels_column("ground_truth", add_metrics=["f1"])
+            linker.accuracy_analysis_from_labels_table("ground_truth", add_metrics=["f1"])
             ```
 
         Returns:
             altair.Chart: An altair chart
-        """
+        """  # noqa: E501
 
         allowed = ["specificity", "npv", "accuracy", "f1", "f2", "f0_5", "p4", "phi"]
 
@@ -2365,17 +1969,38 @@ class Linker:
                 allowed,
             )
 
-        # Silently filter out invalid entries (except case errors - e.g. ["NPV", "F1"])
-        add_metrics = list(set(map(str.lower, add_metrics)).intersection(allowed))
+        if not all(metric in allowed for metric in add_metrics):
+            raise ValueError(
+                f"Invalid metric. Allowed metrics are: {', '.join(allowed)}."
+            )
 
-        df_truth_space = truth_space_table_from_labels_column(
+        labels_tablename = self._get_labels_tablename_from_input(
+            labels_splinkdataframe_or_table_name
+        )
+        self._raise_error_if_necessary_accuracy_columns_not_computed()
+        df_truth_space = truth_space_table_from_labels_table(
             self,
-            labels_column_name,
+            labels_tablename,
             threshold_actual=threshold_actual,
             match_weight_round_to_nearest=match_weight_round_to_nearest,
         )
         recs = df_truth_space.as_record_dict()
-        return threshold_selection_tool(recs, add_metrics=add_metrics)
+
+        if output_type == "threshold_selection":
+            return threshold_selection_tool(recs, add_metrics=add_metrics)
+        elif output_type == "accuracy":
+            return accuracy_chart(recs, add_metrics=add_metrics)
+        elif output_type == "roc":
+            return roc_chart(recs)
+        elif output_type == "precision_recall":
+            return precision_recall_chart(recs)
+        elif output_type == "table":
+            return df_truth_space
+        else:
+            raise ValueError(
+                "Invalid chart_type. Allowed chart types are: "
+                "'threshold_selection', 'roc', 'precision_recall', 'accuracy."
+            )
 
     def prediction_errors_from_labels_column(
         self,

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -195,9 +195,9 @@ def test_roc_chart_dedupe_only():
 
     linker = Linker(df, settings_dict, database_api=db_api)
 
-    linker.register_table(df_labels, "labels")
+    labels_sdf = linker.register_table(df_labels, "labels")
 
-    linker.roc_chart_from_labels_table("labels")
+    linker.accuracy_analysis_from_labels_table(labels_sdf, output_type="roc")
 
 
 def test_roc_chart_link_and_dedupe():
@@ -228,9 +228,9 @@ def test_roc_chart_link_and_dedupe():
         df, settings_dict, input_table_aliases="fake_data_1", database_api=db_api
     )
 
-    linker.register_table(df_labels, "labels")
+    labels_sdf = linker.register_table(df_labels, "labels")
 
-    linker.roc_chart_from_labels_table("labels")
+    linker.accuracy_analysis_from_labels_table(labels_sdf, output_type="roc")
 
 
 def test_prediction_errors_from_labels_table():
@@ -489,7 +489,9 @@ def test_truth_space_table_from_labels_column_dedupe_only():
 
     linker = Linker(df, settings, database_api=db_api)
 
-    tt = linker.truth_space_table_from_labels_column("cluster").as_record_dict()
+    tt = linker.accuracy_analysis_from_labels_column(
+        "cluster", output_type="table"
+    ).as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
     assert truth_dict["tp"] == 4
@@ -558,7 +560,9 @@ def test_truth_space_table_from_labels_column_link_only():
 
     linker = Linker([df_left, df_right], settings, database_api=db_api)
 
-    tt = linker.truth_space_table_from_labels_column("ground_truth").as_record_dict()
+    tt = linker.accuracy_analysis_from_labels_column(
+        "ground_truth", output_type="table"
+    ).as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
     assert truth_dict["tp"] == 3

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -644,8 +644,10 @@ def test_truth_space_table_from_column_vs_pandas_implementaiton_inc_unblocked():
     )
 
     linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_column(
-        "cluster", positives_not_captured_by_blocking_rules_scored_as_zero=False
+    df_from_splink = linker_for_splink_answer.accuracy_analysis_from_labels_column(
+        "cluster",
+        output_type="table",
+        positives_not_captured_by_blocking_rules_scored_as_zero=False,
     ).as_pandas_dataframe()
 
     for _, splink_row in df_from_splink.iterrows():
@@ -711,8 +713,10 @@ def test_truth_space_table_from_column_vs_pandas_implementaiton_ex_unblocked():
     )
     linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
 
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_column(
-        "cluster", positives_not_captured_by_blocking_rules_scored_as_zero=True
+    df_from_splink = linker_for_splink_answer.accuracy_analysis_from_labels_column(
+        "cluster",
+        output_type="table",
+        positives_not_captured_by_blocking_rules_scored_as_zero=True,
     ).as_pandas_dataframe()
 
     for _, splink_row in df_from_splink.iterrows():
@@ -759,8 +763,8 @@ def test_truth_space_table_from_table_vs_pandas_cartesian():
 
     linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
     labels_input = linker_for_splink_answer.register_labels_table(labels_table)
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_table(
-        labels_input
+    df_from_splink = linker_for_splink_answer.accuracy_analysis_from_labels_table(
+        labels_input, output_type="table"
     ).as_pandas_dataframe()
 
     for _, splink_row in df_from_splink.iterrows():
@@ -841,8 +845,8 @@ def test_truth_space_table_from_table_vs_pandas_with_blocking():
 
     linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
     labels_input = linker_for_splink_answer.register_labels_table(labels_table)
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_table(
-        labels_input
+    df_from_splink = linker_for_splink_answer.accuracy_analysis_from_labels_table(
+        labels_input, output_type="table"
     ).as_pandas_dataframe()
 
     for _, splink_row in df_from_splink.iterrows():

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,8 +1,6 @@
-import duckdb
 import pandas as pd
 import pytest
 
-from splink import SettingsCreator
 from splink.accuracy import (
     predictions_from_sample_of_pairwise_labels_sql,
     truth_space_table_from_labels_with_predictions_sqls,
@@ -119,21 +117,21 @@ def test_truth_space_table():
             "person_id_l": 1,
             "person_id_r": 11,
             "match_weight": 0.0,
-            "found_by_blocking_rules": True,
+            "found_by_blocking_rules": False,
             "clerical_match_score": 0.1,
         },
         {
             "person_id_l": 2,
             "person_id_r": 12,
             "match_weight": 0.4,
-            "found_by_blocking_rules": True,
+            "found_by_blocking_rules": False,
             "clerical_match_score": 0.45,
         },
         {
             "person_id_l": 3,
             "person_id_r": 13,
             "match_weight": 1.0,
-            "found_by_blocking_rules": True,
+            "found_by_blocking_rules": False,
             "clerical_match_score": 0.01,
         },
     ]
@@ -195,9 +193,9 @@ def test_roc_chart_dedupe_only():
 
     linker = Linker(df, settings_dict, database_api=db_api)
 
-    linker.register_table(df_labels, "labels")
+    labels_sdf = linker.register_table(df_labels, "labels")
 
-    linker.roc_chart_from_labels_table("labels")
+    linker.accuracy_analysis_from_labels_table(labels_sdf, output_type="roc")
 
 
 def test_roc_chart_link_and_dedupe():
@@ -228,9 +226,9 @@ def test_roc_chart_link_and_dedupe():
         df, settings_dict, input_table_aliases="fake_data_1", database_api=db_api
     )
 
-    linker.register_table(df_labels, "labels")
+    labels_sdf = linker.register_table(df_labels, "labels")
 
-    linker.roc_chart_from_labels_table("labels")
+    linker.accuracy_analysis_from_labels_table(labels_sdf, output_type="roc")
 
 
 def test_prediction_errors_from_labels_table():
@@ -489,7 +487,9 @@ def test_truth_space_table_from_labels_column_dedupe_only():
 
     linker = Linker(df, settings, database_api=db_api)
 
-    tt = linker.truth_space_table_from_labels_column("cluster").as_record_dict()
+    tt = linker.accuracy_analysis_from_labels_column(
+        "cluster", output_type="table"
+    ).as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
     assert truth_dict["tp"] == 4
@@ -558,7 +558,9 @@ def test_truth_space_table_from_labels_column_link_only():
 
     linker = Linker([df_left, df_right], settings, database_api=db_api)
 
-    tt = linker.truth_space_table_from_labels_column("ground_truth").as_record_dict()
+    tt = linker.accuracy_analysis_from_labels_column(
+        "ground_truth", output_type="table"
+    ).as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
     assert truth_dict["tp"] == 3
@@ -573,279 +575,3 @@ def test_truth_space_table_from_labels_column_link_only():
     assert truth_dict["fp"] == 1
     assert truth_dict["tn"] == 5
     assert truth_dict["fn"] == 2
-
-
-def compute_tp_tn_fp_fn(predictions_pd_df, threshold):
-    # Note that in Splink, our critiera are great than or equal to
-    # meaning match prob of 0.40 is treated as a match at threshold 0.40
-    predicted_match = predictions_pd_df["match_weight"] >= threshold
-    actual_match = predictions_pd_df["cluster_l"] == predictions_pd_df["cluster_r"]
-
-    TP = (predicted_match & actual_match).sum()
-    TN = (~predicted_match & ~actual_match).sum()
-    FP = (predicted_match & ~actual_match).sum()
-    FN = (~predicted_match & actual_match).sum()
-
-    return TP, TN, FP, FN
-
-
-def test_truth_space_table_from_column_vs_pandas_implementaiton_inc_unblocked():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df = df.head(50)
-
-    settings = SettingsCreator(
-        link_type="dedupe_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        blocking_rules_to_generate_predictions=[block_on("surname"), "1=1"],
-        additional_columns_to_retain=["cluster"],
-    )
-
-    linker_for_predictions = Linker(df, settings, database_api=DuckDBAPI())
-    df_predictions_raw = linker_for_predictions.predict()
-
-    # Score all of the positive labels even if not captured by the blocking rules
-    # but not score any negative pairwise comaprisons not captured by the blocking rules
-    sql = f"""
-    SELECT
-        case when
-            cluster_l != cluster_r and match_key = 1 then -999.0
-            else match_weight
-        end as match_weight,
-        case when
-            cluster_l != cluster_r and match_key = 1 then 0
-            else match_probability
-        end as match_probability,
-        unique_id_l,
-        unique_id_r,
-        cluster_l,
-        cluster_r,
-        match_key
-    from {df_predictions_raw.physical_name}
-    """
-    df_predictions = linker_for_predictions.query_sql(sql)
-
-    settings = SettingsCreator(
-        link_type="dedupe_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        blocking_rules_to_generate_predictions=[block_on("surname")],
-        additional_columns_to_retain=["cluster"],
-    )
-
-    linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_column(
-        "cluster", positives_not_captured_by_blocking_rules_scored_as_zero=False
-    ).as_pandas_dataframe()
-
-    for _, splink_row in df_from_splink.iterrows():
-        threshold = splink_row["truth_threshold"]
-        # Compute stats using slow pandas methodology
-        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
-        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
-        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
-        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
-        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"
-
-
-def test_truth_space_table_from_column_vs_pandas_implementaiton_ex_unblocked():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df = df.head(100)
-
-    df_1 = df[df["unique_id"] % 2 == 0]
-    df_2 = df[df["unique_id"] % 2 == 1]
-
-    # Get a dataframe of predictions vs labels from splink
-    # Note we need to add the 1-1 blocking rule
-    settings = SettingsCreator(
-        link_type="link_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        # Add an additional blocking rule to ensure in our results we have
-        # all labels
-        blocking_rules_to_generate_predictions=[block_on("first_name"), "1=1"],
-        additional_columns_to_retain=["cluster"],
-    )
-
-    linker_for_predictions = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
-    df_predictions_raw = linker_for_predictions.predict()
-
-    # When match_key = 1, the record is not really recovered by the blocking rules
-    # so its score must be zero.  Want
-    sql = f"""
-    SELECT
-        case when match_key = 1 then -999.0 else match_weight end as match_weight,
-        case when match_key = 1 then 0 else match_probability end as match_probability,
-        unique_id_l,
-        unique_id_r,
-        cluster_l,
-        cluster_r,
-        match_key
-    from {df_predictions_raw.physical_name}
-    """
-    df_predictions = linker_for_predictions.query_sql(sql)
-
-    settings = SettingsCreator(
-        link_type="link_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        # Remove 1=1 blocking rule to get splink's verrsion of the truth space table
-        blocking_rules_to_generate_predictions=[block_on("first_name")],
-        additional_columns_to_retain=["cluster"],
-    )
-    linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
-
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_column(
-        "cluster", positives_not_captured_by_blocking_rules_scored_as_zero=True
-    ).as_pandas_dataframe()
-
-    for _, splink_row in df_from_splink.iterrows():
-        threshold = splink_row["truth_threshold"]
-        # Compute stats using slow pandas methodology
-        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
-        # Make sure you print the values and ueful message if assert fails
-        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
-        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
-        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
-        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"
-
-
-def test_truth_space_table_from_table_vs_pandas_cartesian():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df = df
-
-    df_first_50 = df.head(50).copy()
-    sql = """
-    SELECT
-        l.unique_id as unique_id_l,
-        r.unique_id as unique_id_r,
-        case when l.cluster = r.cluster then 1 else 0 end as clerical_match_score
-    from df_first_50 as l
-    inner join df_first_50 as r
-    on l.unique_id < r.unique_id
-    """
-    labels_table = duckdb.sql(sql).df()
-
-    # Predictions for this lael
-    settings = SettingsCreator(
-        link_type="dedupe_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        blocking_rules_to_generate_predictions=["1=1"],
-        additional_columns_to_retain=["cluster"],
-    )
-
-    linker_for_predictions = Linker(df_first_50, settings, database_api=DuckDBAPI())
-    df_predictions = linker_for_predictions.predict().as_pandas_dataframe()
-
-    linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
-    labels_input = linker_for_splink_answer.register_labels_table(labels_table)
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_table(
-        labels_input
-    ).as_pandas_dataframe()
-
-    for _, splink_row in df_from_splink.iterrows():
-        threshold = splink_row["truth_threshold"]
-        # Compute stats using slow pandas methodology
-        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
-        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
-        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
-        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
-        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"
-
-
-def test_truth_space_table_from_table_vs_pandas_with_blocking():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-
-    df_1 = df[df["unique_id"] % 2 == 0].copy()
-    df_1["source_dataset"] = "left"
-    df_2 = df[df["unique_id"] % 2 == 1].copy()
-    df_2["source_dataset"] = "right"
-
-    df_1_first_50 = df_1.head(50)
-    df_2_first_50 = df_2.head(50)
-
-    sql = """
-    SELECT
-        l.unique_id as unique_id_l,
-        r.unique_id as unique_id_r,
-        l.source_dataset as source_dataset_l,
-        r.source_dataset as source_dataset_r,
-        case when l.cluster = r.cluster then 1 else 0 end as clerical_match_score
-    from df_1_first_50 as l
-    inner join df_2_first_50 as r
-    on concat(l.source_dataset,l.unique_id) < concat(r.source_dataset,r.unique_id)
-    """
-    labels_table = duckdb.sql(sql).df()
-
-    # Predictions for this lael
-    settings = SettingsCreator(
-        link_type="link_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        blocking_rules_to_generate_predictions=[block_on("first_name"), "1=1"],
-        additional_columns_to_retain=["cluster"],
-    )
-
-    linker_for_predictions = Linker(
-        [df_1_first_50, df_2_first_50], settings, database_api=DuckDBAPI()
-    )
-    df_predictions_raw = linker_for_predictions.predict()
-    df_predictions_raw.as_pandas_dataframe()
-    sql = f"""
-    select
-        case when match_key = 1 then -999.0 else match_weight end as match_weight,
-        case when match_key = 1 then 0 else match_probability end as match_probability,
-        source_dataset_l,
-        source_dataset_r,
-        unique_id_l,
-        unique_id_r,
-        cluster_l,
-        cluster_r,
-    from {df_predictions_raw.physical_name}
-    """
-    df_predictions = linker_for_predictions.query_sql(sql)
-
-    settings = SettingsCreator(
-        link_type="link_only",
-        comparisons=[
-            ExactMatch("first_name"),
-            ExactMatch("surname"),
-            ExactMatch("dob"),
-        ],
-        blocking_rules_to_generate_predictions=[block_on("first_name")],
-        additional_columns_to_retain=["cluster"],
-    )
-
-    linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
-    labels_input = linker_for_splink_answer.register_labels_table(labels_table)
-    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_table(
-        labels_input
-    ).as_pandas_dataframe()
-
-    for _, splink_row in df_from_splink.iterrows():
-        threshold = splink_row["truth_threshold"]
-        # Compute stats using slow pandas methodology
-        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
-        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
-        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
-        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
-        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,6 +1,8 @@
+import duckdb
 import pandas as pd
 import pytest
 
+from splink import SettingsCreator
 from splink.accuracy import (
     predictions_from_sample_of_pairwise_labels_sql,
     truth_space_table_from_labels_with_predictions_sqls,
@@ -117,21 +119,21 @@ def test_truth_space_table():
             "person_id_l": 1,
             "person_id_r": 11,
             "match_weight": 0.0,
-            "found_by_blocking_rules": False,
+            "found_by_blocking_rules": True,
             "clerical_match_score": 0.1,
         },
         {
             "person_id_l": 2,
             "person_id_r": 12,
             "match_weight": 0.4,
-            "found_by_blocking_rules": False,
+            "found_by_blocking_rules": True,
             "clerical_match_score": 0.45,
         },
         {
             "person_id_l": 3,
             "person_id_r": 13,
             "match_weight": 1.0,
-            "found_by_blocking_rules": False,
+            "found_by_blocking_rules": True,
             "clerical_match_score": 0.01,
         },
     ]
@@ -193,9 +195,9 @@ def test_roc_chart_dedupe_only():
 
     linker = Linker(df, settings_dict, database_api=db_api)
 
-    labels_sdf = linker.register_table(df_labels, "labels")
+    linker.register_table(df_labels, "labels")
 
-    linker.accuracy_analysis_from_labels_table(labels_sdf, output_type="roc")
+    linker.roc_chart_from_labels_table("labels")
 
 
 def test_roc_chart_link_and_dedupe():
@@ -226,9 +228,9 @@ def test_roc_chart_link_and_dedupe():
         df, settings_dict, input_table_aliases="fake_data_1", database_api=db_api
     )
 
-    labels_sdf = linker.register_table(df_labels, "labels")
+    linker.register_table(df_labels, "labels")
 
-    linker.accuracy_analysis_from_labels_table(labels_sdf, output_type="roc")
+    linker.roc_chart_from_labels_table("labels")
 
 
 def test_prediction_errors_from_labels_table():
@@ -487,9 +489,7 @@ def test_truth_space_table_from_labels_column_dedupe_only():
 
     linker = Linker(df, settings, database_api=db_api)
 
-    tt = linker.accuracy_analysis_from_labels_column(
-        "cluster", output_type="table"
-    ).as_record_dict()
+    tt = linker.truth_space_table_from_labels_column("cluster").as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
     assert truth_dict["tp"] == 4
@@ -558,9 +558,7 @@ def test_truth_space_table_from_labels_column_link_only():
 
     linker = Linker([df_left, df_right], settings, database_api=db_api)
 
-    tt = linker.accuracy_analysis_from_labels_column(
-        "ground_truth", output_type="table"
-    ).as_record_dict()
+    tt = linker.truth_space_table_from_labels_column("ground_truth").as_record_dict()
     # Truth threshold -3.17, meaning all comparisons get classified as positive
     truth_dict = tt[0]
     assert truth_dict["tp"] == 3
@@ -575,3 +573,279 @@ def test_truth_space_table_from_labels_column_link_only():
     assert truth_dict["fp"] == 1
     assert truth_dict["tn"] == 5
     assert truth_dict["fn"] == 2
+
+
+def compute_tp_tn_fp_fn(predictions_pd_df, threshold):
+    # Note that in Splink, our critiera are great than or equal to
+    # meaning match prob of 0.40 is treated as a match at threshold 0.40
+    predicted_match = predictions_pd_df["match_weight"] >= threshold
+    actual_match = predictions_pd_df["cluster_l"] == predictions_pd_df["cluster_r"]
+
+    TP = (predicted_match & actual_match).sum()
+    TN = (~predicted_match & ~actual_match).sum()
+    FP = (predicted_match & ~actual_match).sum()
+    FN = (~predicted_match & actual_match).sum()
+
+    return TP, TN, FP, FN
+
+
+def test_truth_space_table_from_column_vs_pandas_implementaiton_inc_unblocked():
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df = df.head(50)
+
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=[block_on("surname"), "1=1"],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker_for_predictions = Linker(df, settings, database_api=DuckDBAPI())
+    df_predictions_raw = linker_for_predictions.predict()
+
+    # Score all of the positive labels even if not captured by the blocking rules
+    # but not score any negative pairwise comaprisons not captured by the blocking rules
+    sql = f"""
+    SELECT
+        case when
+            cluster_l != cluster_r and match_key = 1 then -999.0
+            else match_weight
+        end as match_weight,
+        case when
+            cluster_l != cluster_r and match_key = 1 then 0
+            else match_probability
+        end as match_probability,
+        unique_id_l,
+        unique_id_r,
+        cluster_l,
+        cluster_r,
+        match_key
+    from {df_predictions_raw.physical_name}
+    """
+    df_predictions = linker_for_predictions.query_sql(sql)
+
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=[block_on("surname")],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
+    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_column(
+        "cluster", positives_not_captured_by_blocking_rules_scored_as_zero=False
+    ).as_pandas_dataframe()
+
+    for _, splink_row in df_from_splink.iterrows():
+        threshold = splink_row["truth_threshold"]
+        # Compute stats using slow pandas methodology
+        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
+        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
+        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
+        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
+        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"
+
+
+def test_truth_space_table_from_column_vs_pandas_implementaiton_ex_unblocked():
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df = df.head(100)
+
+    df_1 = df[df["unique_id"] % 2 == 0]
+    df_2 = df[df["unique_id"] % 2 == 1]
+
+    # Get a dataframe of predictions vs labels from splink
+    # Note we need to add the 1-1 blocking rule
+    settings = SettingsCreator(
+        link_type="link_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        # Add an additional blocking rule to ensure in our results we have
+        # all labels
+        blocking_rules_to_generate_predictions=[block_on("first_name"), "1=1"],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker_for_predictions = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
+    df_predictions_raw = linker_for_predictions.predict()
+
+    # When match_key = 1, the record is not really recovered by the blocking rules
+    # so its score must be zero.  Want
+    sql = f"""
+    SELECT
+        case when match_key = 1 then -999.0 else match_weight end as match_weight,
+        case when match_key = 1 then 0 else match_probability end as match_probability,
+        unique_id_l,
+        unique_id_r,
+        cluster_l,
+        cluster_r,
+        match_key
+    from {df_predictions_raw.physical_name}
+    """
+    df_predictions = linker_for_predictions.query_sql(sql)
+
+    settings = SettingsCreator(
+        link_type="link_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        # Remove 1=1 blocking rule to get splink's verrsion of the truth space table
+        blocking_rules_to_generate_predictions=[block_on("first_name")],
+        additional_columns_to_retain=["cluster"],
+    )
+    linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
+
+    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_column(
+        "cluster", positives_not_captured_by_blocking_rules_scored_as_zero=True
+    ).as_pandas_dataframe()
+
+    for _, splink_row in df_from_splink.iterrows():
+        threshold = splink_row["truth_threshold"]
+        # Compute stats using slow pandas methodology
+        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
+        # Make sure you print the values and ueful message if assert fails
+        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
+        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
+        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
+        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"
+
+
+def test_truth_space_table_from_table_vs_pandas_cartesian():
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df = df
+
+    df_first_50 = df.head(50).copy()
+    sql = """
+    SELECT
+        l.unique_id as unique_id_l,
+        r.unique_id as unique_id_r,
+        case when l.cluster = r.cluster then 1 else 0 end as clerical_match_score
+    from df_first_50 as l
+    inner join df_first_50 as r
+    on l.unique_id < r.unique_id
+    """
+    labels_table = duckdb.sql(sql).df()
+
+    # Predictions for this lael
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=["1=1"],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker_for_predictions = Linker(df_first_50, settings, database_api=DuckDBAPI())
+    df_predictions = linker_for_predictions.predict().as_pandas_dataframe()
+
+    linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
+    labels_input = linker_for_splink_answer.register_labels_table(labels_table)
+    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_table(
+        labels_input
+    ).as_pandas_dataframe()
+
+    for _, splink_row in df_from_splink.iterrows():
+        threshold = splink_row["truth_threshold"]
+        # Compute stats using slow pandas methodology
+        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
+        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
+        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
+        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
+        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"
+
+
+def test_truth_space_table_from_table_vs_pandas_with_blocking():
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    df_1 = df[df["unique_id"] % 2 == 0].copy()
+    df_1["source_dataset"] = "left"
+    df_2 = df[df["unique_id"] % 2 == 1].copy()
+    df_2["source_dataset"] = "right"
+
+    df_1_first_50 = df_1.head(50)
+    df_2_first_50 = df_2.head(50)
+
+    sql = """
+    SELECT
+        l.unique_id as unique_id_l,
+        r.unique_id as unique_id_r,
+        l.source_dataset as source_dataset_l,
+        r.source_dataset as source_dataset_r,
+        case when l.cluster = r.cluster then 1 else 0 end as clerical_match_score
+    from df_1_first_50 as l
+    inner join df_2_first_50 as r
+    on concat(l.source_dataset,l.unique_id) < concat(r.source_dataset,r.unique_id)
+    """
+    labels_table = duckdb.sql(sql).df()
+
+    # Predictions for this lael
+    settings = SettingsCreator(
+        link_type="link_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=[block_on("first_name"), "1=1"],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker_for_predictions = Linker(
+        [df_1_first_50, df_2_first_50], settings, database_api=DuckDBAPI()
+    )
+    df_predictions_raw = linker_for_predictions.predict()
+    df_predictions_raw.as_pandas_dataframe()
+    sql = f"""
+    select
+        case when match_key = 1 then -999.0 else match_weight end as match_weight,
+        case when match_key = 1 then 0 else match_probability end as match_probability,
+        source_dataset_l,
+        source_dataset_r,
+        unique_id_l,
+        unique_id_r,
+        cluster_l,
+        cluster_r,
+    from {df_predictions_raw.physical_name}
+    """
+    df_predictions = linker_for_predictions.query_sql(sql)
+
+    settings = SettingsCreator(
+        link_type="link_only",
+        comparisons=[
+            ExactMatch("first_name"),
+            ExactMatch("surname"),
+            ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=[block_on("first_name")],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
+    labels_input = linker_for_splink_answer.register_labels_table(labels_table)
+    df_from_splink = linker_for_splink_answer.truth_space_table_from_labels_table(
+        labels_input
+    ).as_pandas_dataframe()
+
+    for _, splink_row in df_from_splink.iterrows():
+        threshold = splink_row["truth_threshold"]
+        # Compute stats using slow pandas methodology
+        TP, TN, FP, FN = compute_tp_tn_fp_fn(df_predictions, threshold)
+        assert TP == splink_row["tp"], f"TP: {TP} != {splink_row['tp']}"
+        assert TN == splink_row["tn"], f"TN: {TN} != {splink_row['tn']}"
+        assert FP == splink_row["fp"], f"FP: {FP} != {splink_row['fp']}"
+        assert FN == splink_row["fn"], f"FN: {FN} != {splink_row['fn']}"

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -8,9 +8,10 @@ import pytest
 
 import splink.comparison_level_library as cll
 import splink.comparison_library as cl
+from splink.blocking_analysis import count_comparisons_from_blocking_rule
 from splink.duckdb.database_api import DuckDBAPI
+from splink.exploratory import completeness_chart, profile_columns
 from splink.linker import Linker
-from splink.profile_data import profile_columns
 
 from .basic_settings import get_settings_dict, name_comparison
 from .decorator import mark_with_dialects_including
@@ -40,15 +41,20 @@ def test_full_example_duckdb(tmp_path):
     ]
 
     db_api = DuckDBAPI(connection=os.path.join(tmp_path, "duckdb.db"))
+
+    count_comparisons_from_blocking_rule(
+        table_or_tables=df,
+        blocking_rule='l.first_name = r.first_name and l."SUR name" = r."SUR name"',  # noqa: E501
+        link_type="dedupe_only",
+        db_api=db_api,
+        unique_id_column_name="unique_id",
+    )
+
     linker = Linker(
         df,
         settings=settings_dict,
         database_api=db_api,
         # output_schema="splink_in_duckdb",
-    )
-
-    linker.count_num_comparisons_from_blocking_rule(
-        'l.first_name = r.first_name and l."SUR name" = r."SUR name"'
     )
 
     profile_columns(
@@ -61,7 +67,8 @@ def test_full_example_duckdb(tmp_path):
             "concat(city, first_name)",
         ],
     )
-    linker.missingness_chart()
+    completeness_chart(df, db_api)
+
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -69,8 +76,6 @@ def test_full_example_duckdb(tmp_path):
     linker.estimate_probability_two_random_records_match(
         ["l.email = r.email"], recall=0.3
     )
-    # try missingness chart again now that concat_with_tf is precomputed
-    linker.missingness_chart()
 
     blocking_rule = 'l.first_name = r.first_name and l."SUR name" = r."SUR name"'
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
@@ -89,8 +94,8 @@ def test_full_example_duckdb(tmp_path):
     linker.waterfall_chart(records)
 
     register_roc_data(linker)
-
-    linker.accuracy_analysis_from_labels_table("labels")
+    linker.roc_chart_from_labels_table("labels")
+    linker.threshold_selection_tool_from_labels_table("labels")
 
     df_clusters = linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.1)
 
@@ -101,7 +106,7 @@ def test_full_example_duckdb(tmp_path):
         out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
     )
 
-    linker.unlinkables_chart(source_dataset="Testing")
+    linker.unlinkables_chart(name_of_data_in_title="Testing")
 
     _test_table_registration(linker)
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -94,8 +94,8 @@ def test_full_example_duckdb(tmp_path):
     linker.waterfall_chart(records)
 
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
     df_clusters = linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.1)
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -8,10 +8,9 @@ import pytest
 
 import splink.comparison_level_library as cll
 import splink.comparison_library as cl
-from splink.blocking_analysis import count_comparisons_from_blocking_rule
 from splink.duckdb.database_api import DuckDBAPI
-from splink.exploratory import completeness_chart, profile_columns
 from splink.linker import Linker
+from splink.profile_data import profile_columns
 
 from .basic_settings import get_settings_dict, name_comparison
 from .decorator import mark_with_dialects_including
@@ -41,20 +40,15 @@ def test_full_example_duckdb(tmp_path):
     ]
 
     db_api = DuckDBAPI(connection=os.path.join(tmp_path, "duckdb.db"))
-
-    count_comparisons_from_blocking_rule(
-        table_or_tables=df,
-        blocking_rule='l.first_name = r.first_name and l."SUR name" = r."SUR name"',  # noqa: E501
-        link_type="dedupe_only",
-        db_api=db_api,
-        unique_id_column_name="unique_id",
-    )
-
     linker = Linker(
         df,
         settings=settings_dict,
         database_api=db_api,
         # output_schema="splink_in_duckdb",
+    )
+
+    linker.count_num_comparisons_from_blocking_rule(
+        'l.first_name = r.first_name and l."SUR name" = r."SUR name"'
     )
 
     profile_columns(
@@ -67,8 +61,7 @@ def test_full_example_duckdb(tmp_path):
             "concat(city, first_name)",
         ],
     )
-    completeness_chart(df, db_api)
-
+    linker.missingness_chart()
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -76,6 +69,8 @@ def test_full_example_duckdb(tmp_path):
     linker.estimate_probability_two_random_records_match(
         ["l.email = r.email"], recall=0.3
     )
+    # try missingness chart again now that concat_with_tf is precomputed
+    linker.missingness_chart()
 
     blocking_rule = 'l.first_name = r.first_name and l."SUR name" = r."SUR name"'
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
@@ -94,8 +89,8 @@ def test_full_example_duckdb(tmp_path):
     linker.waterfall_chart(records)
 
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
     df_clusters = linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.1)
 
@@ -106,7 +101,7 @@ def test_full_example_duckdb(tmp_path):
         out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
     )
 
-    linker.unlinkables_chart(name_of_data_in_title="Testing")
+    linker.unlinkables_chart(source_dataset="Testing")
 
     _test_table_registration(linker)
 

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -85,8 +85,8 @@ def test_full_example_postgres(tmp_path, pg_engine):
     linker.waterfall_chart(records)
 
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
     df_clusters = linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.1)
 

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -2,6 +2,11 @@ import os
 
 import pandas as pd
 
+from splink.blocking_analysis import (
+    count_comparisons_from_blocking_rule,
+    cumulative_comparisons_to_be_scored_from_blocking_rules_chart,
+)
+from splink.exploratory import completeness_chart, profile_columns
 from splink.linker import Linker
 from splink.postgres.database_api import PostgresAPI
 
@@ -22,26 +27,39 @@ def test_full_example_postgres(tmp_path, pg_engine):
         database_api=db_api,
     )
 
-    linker.count_num_comparisons_from_blocking_rule(
-        'l.first_name = r.first_name and l."surname" = r."surname"'
+    count_comparisons_from_blocking_rule(
+        table_or_tables=df,
+        blocking_rule='l.first_name = r.first_name and l."surname" = r."surname"',  # noqa: E501
+        link_type="dedupe_only",
+        db_api=db_api,
+        unique_id_column_name="unique_id",
     )
-    linker.cumulative_num_comparisons_from_blocking_rules_chart(
-        [
+
+    cumulative_comparisons_to_be_scored_from_blocking_rules_chart(
+        table_or_tables=df,
+        blocking_rules=[
             "l.first_name = r.first_name",
             "l.surname = r.surname",
             "l.city = r.city",
-        ]
+        ],
+        link_type="dedupe_only",
+        db_api=db_api,
+        unique_id_column_name="unique_id",
     )
 
-    linker.profile_columns(
+    profile_columns(
+        df,
+        db_api,
         [
             "first_name",
             '"surname"',
             'first_name || "surname"',
             "concat(city, first_name)",
-        ]
+        ],
     )
-    linker.missingness_chart()
+
+    completeness_chart(df, db_api=db_api)
+
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -49,8 +67,6 @@ def test_full_example_postgres(tmp_path, pg_engine):
     linker.estimate_probability_two_random_records_match(
         ["l.email = r.email"], recall=0.3
     )
-    # try missingness chart again now that concat_with_tf is precomputed
-    linker.missingness_chart()
 
     blocking_rule = 'l.first_name = r.first_name and l."surname" = r."surname"'
     linker.estimate_parameters_using_expectation_maximisation(blocking_rule)
@@ -69,8 +85,8 @@ def test_full_example_postgres(tmp_path, pg_engine):
     linker.waterfall_chart(records)
 
     register_roc_data(linker)
-
-    linker.accuracy_analysis_from_labels_table("labels")
+    linker.roc_chart_from_labels_table("labels")
+    linker.threshold_selection_tool_from_labels_table("labels")
 
     df_clusters = linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.1)
 
@@ -81,7 +97,7 @@ def test_full_example_postgres(tmp_path, pg_engine):
         out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
     )
 
-    linker.unlinkables_chart(source_dataset="Testing")
+    linker.unlinkables_chart(name_of_data_in_title="Testing")
 
     _test_table_registration(linker)
 

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -7,8 +7,8 @@ from pyspark.sql.types import StringType, StructField, StructType
 
 import splink.comparison_level_library as cll
 import splink.comparison_library as cl
-from splink.exploratory import completeness_chart, profile_columns
 from splink.linker import Linker
+from splink.profile_data import profile_columns
 from splink.spark.database_api import SparkAPI
 
 from .basic_settings import get_settings_dict, name_comparison
@@ -62,14 +62,6 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         "max_iterations": 2,
     }
 
-    profile_columns(
-        df_spark,
-        spark_api,
-        ["first_name", "surname", "first_name || surname", "concat(city, first_name)"],
-    )
-
-    completeness_chart(df_spark, spark_api)
-
     linker = Linker(
         df_spark,
         settings,
@@ -81,6 +73,11 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         ),
     )
 
+    profile_columns(
+        df_spark,
+        spark_api,
+        ["first_name", "surname", "first_name || surname", "concat(city, first_name)"],
+    )
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -111,7 +108,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
     )
 
-    linker.unlinkables_chart(name_of_data_in_title="Testing")
+    linker.unlinkables_chart(source_dataset="Testing")
     # Test that writing to files works as expected
     # spark_csv_read = lambda x: linker.spark.read.csv(x, header=True).toPandas()
     # _test_write_functionality(linker, spark_csv_read)
@@ -124,8 +121,8 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         ]
     )
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
     record = {
         "unique_id": 1,
@@ -161,7 +158,6 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
     Linker(df_spark, settings=path, database_api=spark_api)
 
 
-@mark_with_dialects_including("spark")
 def test_link_only(spark, df_spark, spark_api):
     settings = get_settings_dict()
     settings["link_type"] = "link_only"

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -124,8 +124,8 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         ]
     )
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
     record = {
         "unique_id": 1,
@@ -161,7 +161,6 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
     Linker(df_spark, settings=path, database_api=spark_api)
 
 
-@mark_with_dialects_including("spark")
 def test_link_only(spark, df_spark, spark_api):
     settings = get_settings_dict()
     settings["link_type"] = "link_only"

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -7,8 +7,8 @@ from pyspark.sql.types import StringType, StructField, StructType
 
 import splink.comparison_level_library as cll
 import splink.comparison_library as cl
+from splink.exploratory import completeness_chart, profile_columns
 from splink.linker import Linker
-from splink.profile_data import profile_columns
 from splink.spark.database_api import SparkAPI
 
 from .basic_settings import get_settings_dict, name_comparison
@@ -62,6 +62,14 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         "max_iterations": 2,
     }
 
+    profile_columns(
+        df_spark,
+        spark_api,
+        ["first_name", "surname", "first_name || surname", "concat(city, first_name)"],
+    )
+
+    completeness_chart(df_spark, spark_api)
+
     linker = Linker(
         df_spark,
         settings,
@@ -73,11 +81,6 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         ),
     )
 
-    profile_columns(
-        df_spark,
-        spark_api,
-        ["first_name", "surname", "first_name || surname", "concat(city, first_name)"],
-    )
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -108,7 +111,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         out_path=os.path.join(tmp_path, "test_cluster_studio.html"),
     )
 
-    linker.unlinkables_chart(source_dataset="Testing")
+    linker.unlinkables_chart(name_of_data_in_title="Testing")
     # Test that writing to files works as expected
     # spark_csv_read = lambda x: linker.spark.read.csv(x, header=True).toPandas()
     # _test_write_functionality(linker, spark_csv_read)
@@ -121,8 +124,8 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
         ]
     )
     register_roc_data(linker)
-
-    linker.accuracy_analysis_from_labels_table("labels")
+    linker.roc_chart_from_labels_table("labels")
+    linker.threshold_selection_tool_from_labels_table("labels")
 
     record = {
         "unique_id": 1,
@@ -158,6 +161,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
     Linker(df_spark, settings=path, database_api=spark_api)
 
 
+@mark_with_dialects_including("spark")
 def test_link_only(spark, df_spark, spark_api):
     settings = get_settings_dict()
     settings["link_type"] = "link_only"

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -4,7 +4,6 @@ from math import sqrt
 
 import pandas as pd
 
-from splink.exploratory import profile_columns
 from splink.linker import Linker
 from splink.sqlite.database_api import SQLiteAPI
 
@@ -31,8 +30,7 @@ def test_full_example_sqlite(tmp_path):
         input_table_aliases="fake_data_1",
     )
 
-    profile_columns(df, db_api, ["first_name", "surname", "first_name || surname"])
-
+    linker.profile_columns(["first_name", "surname", "first_name || surname"])
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -56,13 +54,13 @@ def test_full_example_sqlite(tmp_path):
 
     linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.5)
 
-    linker.unlinkables_chart(name_of_data_in_title="Testing")
+    linker.unlinkables_chart(source_dataset="Testing")
 
     _test_table_registration(linker)
 
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
 
 @mark_with_dialects_including("sqlite")

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -4,6 +4,7 @@ from math import sqrt
 
 import pandas as pd
 
+from splink.exploratory import profile_columns
 from splink.linker import Linker
 from splink.sqlite.database_api import SQLiteAPI
 
@@ -30,7 +31,8 @@ def test_full_example_sqlite(tmp_path):
         input_table_aliases="fake_data_1",
     )
 
-    linker.profile_columns(["first_name", "surname", "first_name || surname"])
+    profile_columns(df, db_api, ["first_name", "surname", "first_name || surname"])
+
     linker.compute_tf_table("city")
     linker.compute_tf_table("first_name")
 
@@ -54,13 +56,13 @@ def test_full_example_sqlite(tmp_path):
 
     linker.cluster_pairwise_predictions_at_threshold(df_predict, 0.5)
 
-    linker.unlinkables_chart(source_dataset="Testing")
+    linker.unlinkables_chart(name_of_data_in_title="Testing")
 
     _test_table_registration(linker)
 
     register_roc_data(linker)
-
-    linker.accuracy_analysis_from_labels_table("labels")
+    linker.roc_chart_from_labels_table("labels")
+    linker.threshold_selection_tool_from_labels_table("labels")
 
 
 @mark_with_dialects_including("sqlite")

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -61,8 +61,8 @@ def test_full_example_sqlite(tmp_path):
     _test_table_registration(linker)
 
     register_roc_data(linker)
-    linker.roc_chart_from_labels_table("labels")
-    linker.threshold_selection_tool_from_labels_table("labels")
+
+    linker.accuracy_analysis_from_labels_table("labels")
 
 
 @mark_with_dialects_including("sqlite")


### PR DESCRIPTION
Supersedes #2147

Consolidates 

```
truth_space_table_from_labels_{type}
roc_chart_from_labels_{type}
precision_recall_chart_from_labels_{type}
accuracy_chart_from_labels_{type}
threshold_selection_tool_from_labels_{type}
```

to 

```
accuracy_analysis_from_labels_{type}
```

Where {type} is either 'table' or 'column

## Questions:

- Should `truth_space_table_from_labels_` be a separate function, since its return type is different?
- Should we bother retaining the `precision_recall` and `roc` options?

Closes https://github.com/moj-analytical-services/splink/issues/2010