### PR TITLE
Improve performance of SQL generation by using deepcopy less

### DIFF
--- a/splink/input_column.py
+++ b/splink/input_column.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from copy import deepcopy
+from copy import copy
 from dataclasses import dataclass, replace
 
 import sqlglot
@@ -216,20 +216,20 @@ class InputColumn:
         )
 
     def unquote(self) -> InputColumn:
-        self_copy = deepcopy(self)
+        self_copy = copy(self)
         b = replace(self_copy.col_builder, quoted=False)
         self_copy.col_builder = b
         return self_copy
 
     def quote(self) -> InputColumn:
-        self_copy = deepcopy(self)
+        self_copy = copy(self)
         b = replace(self_copy.col_builder, quoted=True)
         self_copy.col_builder = b
         return self_copy
 
     @property
     def as_base_dialect(self) -> InputColumn:
-        input_column_copy = deepcopy(self)
+        input_column_copy = copy(self)
         input_column_copy.sql_dialect = None
         return input_column_copy
 


### PR DESCRIPTION
Fixes #2210 

This takes 2 seconds before, 0.1 second after this PR 
<details>
<summary>
example
</summary>

```python
import time

from splink.blocking import block_using_rules_sqls
from splink.datasets import splink_datasets
from splink.duckdb.blocking_rule_library import block_on
from splink.duckdb.comparison_library import (
    exact_match,
    levenshtein_at_thresholds,
)
from splink.duckdb.linker import DuckDBLinker

df = splink_datasets.fake_1000

settings = {
    "probability_two_random_records_match": 0.01,
    "link_type": "dedupe_only",
    "blocking_rules_to_generate_predictions": [
        block_on(["first_name"]),
        block_on(["surname"]),
        block_on(["dob"]),
        block_on(["city"]),
        block_on(["email", "city", "first_name"]),
    ],
    "comparisons": [
        levenshtein_at_thresholds("first_name", 2),
        exact_match("surname"),
        exact_match("dob"),
        exact_match("city", term_frequency_adjustments=True),
        exact_match("email"),
    ],
    "retain_intermediate_calculation_columns": True,
    "additional_columns_to_retain": [
        "cluster",
        "surname",
        "email",
        "city",
        "dob",
        "first_name",
    ],
}


linker = DuckDBLinker(df, settings)

start_time = time.time()
block_using_rules_sqls(linker)
end_time = time.time()
print(f"Blocking took {end_time - start_time} seconds")

```

</details>

Deepcopy was resulting in the settings object being copied repeatedly I think - in any case, a shallow copy is sufficient becasue the only thing that is being copied is the column builder 