### PR TITLE
CVE related security updates for PySpark and PyArrow

### DIFF
--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -5,7 +5,7 @@ sqlglot==1.23.1
 pytest==7.0.1
 pytest-benchmark==3.4.1
 tabulate==0.8.9
-pyspark==3.1.2
+pyspark==3.2.2
 rapidfuzz==2.0.2
 # sha256: 6bfffc374e5bda33f8e39628702af52124ab4e5946727f7fda9bb05ffaf97c63
 lzstring==1.0.4

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,2 @@
 splink==3.9.8
-pyarrow==13.0.0
+pyarrow==14.0.1


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Give a brief description for the solution you have provided

Our SecOps team has identified four security alerts following a recent scan of `splink`, related to the versioning of two package dependencies (`pyspark`, `pyarrow`). I've outlined these alerts below, and linked CVE codes to pages in the National Security Database:

| CVE Name         | Severity | Package Name | Package Version | Fixed Version | CVE Published Date |
|------------------|----------|--------------|-----------------|---------------|---------------------|
| [CVE-2021-38296](https://nvd.nist.gov/vuln/detail/CVE-2021-38296)   | High     | pyspark       | 3.1.2           | 3.1.3         | 2022 Mar 10         |
| [CVE-2022-33891](https://nvd.nist.gov/vuln/detail/cve-2022-33891)   | High     | pyspark       | 3.1.2           | 3.2.2         | 2022 Jul 18         |
| [CVE-2023-32007](https://nvd.nist.gov/vuln/detail/CVE-2023-32007)   | High     | pyspark       | 3.1.2           | 3.2.2         | 2023 May 02         |
| [CVE-2023-47248](https://nvd.nist.gov/vuln/detail/CVE-2023-47248)   | Critical | pyarrow       | 13.0.0          | 14.0.1        | 2023 Nov 09         |

Unfortunately, these vulnerabilities currently prevent us from safely utilizing this package in our production environment. 

This pull request aims to resolve these issues to ensure compliance with our security standards and maintain the integrity of our systems. It updates two files `benchmarking/requirements.txt` and `binder/requirements.txt` with secure versions of `pyspark` (3.2.2) and `pyarrow` (14.0.1).