### PR TITLE
Restore spark test mark

### DIFF
--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -163,6 +163,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
     Linker(df_spark, settings=path, database_api=spark_api)
 
 
+@mark_with_dialects_including("spark")
 def test_link_only(spark, df_spark, spark_api):
     settings = get_settings_dict()
     settings["link_type"] = "link_only"


### PR DESCRIPTION
Restores a spark test being marked with the `"spark"` backend marker.

This was added in #2161 and (presumably accidentally) reverted in #2187.

This ensures that spark tests only run as part of the spark tests CI, which in particular means they do not run on python 3.12 which is currently not compatible with spark (see #2164), and so the duckdb tests should pass in CI again (as they are not mistakenly trying to run this spark test).