### PR TITLE
Find biggest block

### DIFF
--- a/docs/api_docs/api_docs_index.md
+++ b/docs/api_docs/api_docs_index.md
@@ -24,6 +24,7 @@ This section contains reference material for the modules and functions within Sp
 
 #### Other
 - [Exploratory](./exploratory.md)
+- [Blocking Analysis](./blocking_analysis.md)
 - [Blocking](./blocking.md)
 - [SplinkDataFrame](./splink_dataframe.md)
 - [EM Training Session API](./em_training_session.md)

--- a/splink/blocking_analysis.py
+++ b/splink/blocking_analysis.py
@@ -2,10 +2,12 @@ from .internals.blocking_analysis import (
     count_comparisons_from_blocking_rule,
     cumulative_comparisons_to_be_scored_from_blocking_rules_chart,
     cumulative_comparisons_to_be_scored_from_blocking_rules_data,
+    n_largest_blocks,
 )
 
 __all__ = [
     "count_comparisons_from_blocking_rule",
     "cumulative_comparisons_to_be_scored_from_blocking_rules_chart",
     "cumulative_comparisons_to_be_scored_from_blocking_rules_data",
+    "n_largest_blocks",
 ]

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -666,7 +666,7 @@ def n_largest_blocks(
     link_type: user_input_link_type_options,
     db_api: DatabaseAPISubClass,
     n_largest: int = 5,
-):
+) -> "SplinkDataFrame":
     blocking_rule_as_br = to_blocking_rule_creator(blocking_rule).get_blocking_rule(
         db_api.sql_dialect.name
     )

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -543,7 +543,31 @@ def count_comparisons_from_blocking_rule(
     compute_post_filter_count: bool = True,
     max_rows_limit: int = int(1e9),
 ) -> dict[str, Union[int, str]]:
-    """TODO: Add docstring here"""
+    """Analyse a blocking rule to understand the number of comparisons it will generate.
+
+    Read more about the definition of pre and post filter conditions
+    [here]("https://moj-analytical-services.github.io/splink/topic_guides/blocking/performance.html?h=filter+cond#filter-conditions")
+
+    Args:
+        table_or_tables (dataframe, str): Input data
+        blocking_rule (Union[BlockingRuleCreator, str, Dict[str, Any]]): The blocking
+            rule to analyse
+        link_type (user_input_link_type_options): The link type - "link_only",
+            "dedupe_only" or "link_and_dedupe"
+        db_api (DatabaseAPISubClass): Database API
+        unique_id_column_name (str, optional):  Defaults to "unique_id".
+        source_dataset_column_name (Optional[str], optional):  Defaults to None.
+        compute_post_filter_count (bool, optional): Whether to use a slower methodology
+            to calculate how many comparisons will be generated post filter conditions.
+            Defaults to True.
+        max_rows_limit (int, optional): Calculation of post filter counts will only
+            proceed if the fast method returns a value below this limit. Defaults
+            to int(1e9).
+
+    Returns:
+        dict[str, Union[int, str]]: A dictionary containing the results
+    """
+
     # Ensure what's been passed in is a BlockingRuleCreator
     blocking_rule_creator = to_blocking_rule_creator(blocking_rule).get_blocking_rule(
         db_api.sql_dialect.name
@@ -667,6 +691,28 @@ def n_largest_blocks(
     db_api: DatabaseAPISubClass,
     n_largest: int = 5,
 ) -> "SplinkDataFrame":
+    """Find the values responsible for creating the largest blocks of records.
+
+    For example, when blocking on first name and surname, the 'John Smith' block
+    might be the largest block of records.  In cases where values are highly skewed
+    a few values may be resonsible for generating a large proportion of all comparisons.
+    This function helps you find the culprit values.
+
+    The analysis is performed pre filter conditions, read more about what this means
+    [here]("https://moj-analytical-services.github.io/splink/topic_guides/blocking/performance.html?h=filter+cond#filter-conditions")
+
+    Args:
+        table_or_tables (dataframe, str): Input data
+        blocking_rule (Union[BlockingRuleCreator, str, Dict[str, Any]]): The blocking
+            rule to analyse
+        link_type (user_input_link_type_options): The link type - "link_only",
+            "dedupe_only" or "link_and_dedupe"
+        db_api (DatabaseAPISubClass): Database API
+        n_largest (int, optional): How many rows to return. Defaults to 5.
+
+    Returns:
+        SplinkDataFrame: A dataframe containing the n_largest blocks
+    """
     blocking_rule_as_br = to_blocking_rule_creator(blocking_rule).get_blocking_rule(
         db_api.sql_dialect.name
     )

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -763,6 +763,7 @@ def n_largest_blocks(
     blocking_rule: Union[BlockingRuleCreator, str, Dict[str, Any]],
     link_type: user_input_link_type_options,
     db_api: DatabaseAPISubClass,
+    n_largest: int = 5,
 ):
     blocking_rule_as_br = to_blocking_rule_creator(blocking_rule).get_blocking_rule(
         db_api.sql_dialect.name
@@ -771,7 +772,7 @@ def n_largest_blocks(
     splink_df_dict = db_api.register_multiple_tables(table_or_tables)
 
     sqls = _count_comparisons_from_n_largest_blocks_pre_filter_conditions_sqls(
-        splink_df_dict, blocking_rule_as_br, link_type, db_api
+        splink_df_dict, blocking_rule_as_br, link_type, db_api, n_largest=n_largest
     )
     pipeline = CTEPipeline()
     pipeline.enqueue_list_of_sqls(sqls)

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -190,6 +190,107 @@ def _count_comparisons_from_blocking_rule_pre_filter_conditions_sqls(
     return sqls
 
 
+def _count_comparisons_from_n_largest_blocks_pre_filter_conditions_sqls(
+    input_data_dict: dict[str, "SplinkDataFrame"],
+    blocking_rule: "BlockingRule",
+    link_type: str,
+    db_api: DatabaseAPISubClass,
+    n_largest=5,
+) -> list[dict[str, str]]:
+    input_dataframes = list(input_data_dict.values())
+
+    join_conditions = blocking_rule._equi_join_conditions
+    two_dataset_link_only = link_type == "link_only" and len(input_dataframes) == 2
+
+    sqls = []
+
+    if two_dataset_link_only:
+        input_tablename_l = input_dataframes[0].physical_name
+        input_tablename_r = input_dataframes[1].physical_name
+    else:
+        sql = vertically_concatenate_sql(
+            input_data_dict, salting_required=False, source_dataset_input_column=None
+        )
+        sqls.append({"sql": sql, "output_table_name": "__splink__df_concat"})
+
+        input_tablename_l = "__splink__df_concat"
+        input_tablename_r = "__splink__df_concat"
+
+    l_cols_sel = []
+    r_cols_sel = []
+    l_cols_gb = []
+    r_cols_gb = []
+    using = []
+    for (
+        i,
+        (l_key, r_key),
+    ) in enumerate(join_conditions):
+        l_cols_sel.append(f"{l_key} as key_{i}")
+        r_cols_sel.append(f"{r_key} as key_{i}")
+        l_cols_gb.append(l_key)
+        r_cols_gb.append(r_key)
+        using.append(f"key_{i}")
+
+    l_cols_sel_str = ", ".join(l_cols_sel)
+    r_cols_sel_str = ", ".join(r_cols_sel)
+    l_cols_gb_str = ", ".join(l_cols_gb)
+    r_cols_gb_str = ", ".join(r_cols_gb)
+    using_str = ", ".join(using)
+
+    if not join_conditions:
+        if two_dataset_link_only:
+            sql = f"""
+            SELECT
+                (SELECT COUNT(*) FROM {input_tablename_l})
+                *
+                (SELECT COUNT(*) FROM {input_tablename_r})
+                    AS count_of_pairwise_comparisons_generated
+            """
+        else:
+            sql = """
+            select count(*) * count(*) as count_of_pairwise_comparisons_generated
+            from __splink__df_concat
+
+            """
+        sqls.append(
+            {"sql": sql, "output_table_name": "__splink__total_of_block_counts"}
+        )
+        return sqls
+
+    sql = f"""
+    select {l_cols_sel_str}, count(*) as count_l
+    from {input_tablename_l}
+    group by {l_cols_gb_str}
+    """
+
+    sqls.append(
+        {"sql": sql, "output_table_name": "__splink__count_comparisons_from_blocking_l"}
+    )
+
+    sql = f"""
+    select {r_cols_sel_str}, count(*) as count_r
+    from {input_tablename_r}
+    group by {r_cols_gb_str}
+    """
+
+    sqls.append(
+        {"sql": sql, "output_table_name": "__splink__count_comparisons_from_blocking_r"}
+    )
+
+    sql = f"""
+    select {using_str}, count_l, count_r,  count_l * count_r as block_count
+    from __splink__count_comparisons_from_blocking_l
+    inner join __splink__count_comparisons_from_blocking_r
+    using ({using_str})
+    order by count_l * count_r desc
+    limit {n_largest}
+    """
+
+    sqls.append({"sql": sql, "output_table_name": "__splink__block_counts"})
+
+    return sqls
+
+
 def _row_counts_per_input_table(
     *,
     splink_df_dict: dict[str, "SplinkDataFrame"],
@@ -654,3 +755,25 @@ def cumulative_comparisons_to_be_scored_from_blocking_rules_chart(
     return cumulative_blocking_rule_comparisons_generated(
         pd_df.to_dict(orient="records")
     )
+
+
+def n_largest_blocks(
+    *,
+    table_or_tables: Sequence[AcceptableInputTableType],
+    blocking_rule: Union[BlockingRuleCreator, str, Dict[str, Any]],
+    link_type: user_input_link_type_options,
+    db_api: DatabaseAPISubClass,
+):
+    blocking_rule_as_br = to_blocking_rule_creator(blocking_rule).get_blocking_rule(
+        db_api.sql_dialect.name
+    )
+
+    splink_df_dict = db_api.register_multiple_tables(table_or_tables)
+
+    sqls = _count_comparisons_from_n_largest_blocks_pre_filter_conditions_sqls(
+        splink_df_dict, blocking_rule_as_br, link_type, db_api
+    )
+    pipeline = CTEPipeline()
+    pipeline.enqueue_list_of_sqls(sqls)
+
+    return db_api.sql_pipeline_to_splink_dataframe(pipeline)

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -5,6 +5,7 @@ from splink.blocking_analysis import (
     count_comparisons_from_blocking_rule,
     cumulative_comparisons_to_be_scored_from_blocking_rules_chart,
     cumulative_comparisons_to_be_scored_from_blocking_rules_data,
+    n_largest_blocks,
 )
 from splink.internals.blocking import BlockingRule
 from splink.internals.blocking_rule_library import CustomRule, Or, block_on
@@ -623,4 +624,189 @@ def test_chart(test_helpers, dialect):
         link_type="dedupe_only",
         db_api=db_api,
         unique_id_column_name="unique_id",
+    )
+
+
+@mark_with_dialects_excluding()
+def test_n_largest_blocks(test_helpers, dialect):
+    helper = test_helpers[dialect]
+    db_api = helper.DatabaseAPI(**helper.db_api_args())
+
+    df_1 = pd.DataFrame(
+        [
+            {"unique_id": 1, "name1": "Mary", "name2": "Jones", "dob": "2024-07-02"},
+            {"unique_id": 2, "name1": "Mary", "name2": "Jones", "dob": "2024-07-02"},
+            {"unique_id": 3, "name1": "Mary", "name2": "Jones", "dob": "2024-11-28"},
+            {"unique_id": 4, "name1": "Maurice", "name2": "Jones", "dob": "2024-07-02"},
+            {"unique_id": 5, "name1": "Jones", "name2": "Maurice", "dob": "2024-07-02"},
+            {"unique_id": 6, "name1": "Jones", "name2": "Maurice", "dob": "2024-07-02"},
+        ]
+    )
+
+    df_2 = pd.DataFrame(
+        [
+            {"unique_id": 1, "name1": "Mary", "name2": "Jones", "dob": "2024-07-02"},
+            {"unique_id": 2, "name1": "Mary", "name2": "Jones", "dob": "2024-07-02"},
+            {"unique_id": 3, "name1": "Mary", "name2": "Jones", "dob": "2024-11-28"},
+            {"unique_id": 4, "name1": "Jones", "name2": "Maurice", "dob": "2024-07-02"},
+            {"unique_id": 5, "name1": "Maurice", "name2": "Jones", "dob": "2024-07-02"},
+        ]
+    )
+
+    df_3 = pd.DataFrame(
+        [
+            {"unique_id": 1, "name1": "John", "name2": "Smith", "dob": "2019-01-03"},
+        ]
+    )
+
+    db_api = DuckDBAPI()
+
+    n_largest_dedupe_only = n_largest_blocks(
+        table_or_tables=df_1,
+        blocking_rule=block_on("name1", "substr(name2,1,1)"),
+        link_type="dedupe_only",
+        db_api=db_api,
+    ).as_pandas_dataframe()
+
+    sql = """
+    with
+    a as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from df_1
+    group by key_0, key_1
+    ),
+
+    b as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from df_1
+    group by key_0, key_1)
+
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    from a inner join b
+    on a.key_0 = b.key_0 and a.key_1 = b.key_1
+    order by block_count desc
+    """
+    n_largest_manual_dedupe_only = duckdb.sql(sql).df()
+
+    pd.testing.assert_frame_equal(n_largest_dedupe_only, n_largest_manual_dedupe_only)
+
+    n_largest_link_and_dedupe = n_largest_blocks(
+        table_or_tables=[df_1, df_2],
+        blocking_rule=block_on("name1", "substr(name2,1,1)"),
+        link_type="link_and_dedupe",
+        db_api=db_api,
+    ).as_pandas_dataframe()
+
+    sql = """
+    with
+    a as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from (select * from df_1 union all select * from df_2)
+    group by key_0, key_1
+    ),
+
+    b as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from (select * from df_1 union all select * from df_2)
+    group by key_0, key_1)
+
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    from a inner join b
+    on a.key_0 = b.key_0 and a.key_1 = b.key_1
+    order by block_count desc
+    """
+    n_largest_manual_link_and_dedupe = duckdb.sql(sql).df()
+
+    pd.testing.assert_frame_equal(
+        n_largest_link_and_dedupe, n_largest_manual_link_and_dedupe
+    )
+
+    n_largest_link_only = n_largest_blocks(
+        table_or_tables=[df_1, df_2],
+        blocking_rule=block_on("name1", "substr(name2,1,1)"),
+        link_type="link_only",
+        db_api=db_api,
+    ).as_pandas_dataframe()
+
+    sql = """
+    with
+    a as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from df_1
+    group by key_0, key_1
+    ),
+
+    b as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from df_2
+    group by key_0, key_1)
+
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    from a inner join b
+    on a.key_0 = b.key_0 and a.key_1 = b.key_1
+    order by block_count desc
+    """
+    n_largest_manual_link_only = duckdb.sql(sql).df()
+
+    pd.testing.assert_frame_equal(n_largest_link_only, n_largest_manual_link_only)
+
+    n_largest_link_only_3 = n_largest_blocks(
+        table_or_tables=[df_1, df_2, df_3],
+        blocking_rule=block_on("name1", "substr(name2,1,1)"),
+        link_type="link_only",
+        db_api=db_api,
+    ).as_pandas_dataframe()
+
+    sql = """
+    with
+    a as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from (select * from df_1 union all select * from df_2 union all select * from df_3)
+    group by key_0, key_1
+    ),
+
+    b as (
+    select name1 as key_0, substr(name2,1,1) as key_1, count(*) as c
+    from (select * from df_1 union all select * from df_2 union all select * from df_3)
+    group by key_0, key_1)
+
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    from a inner join b
+    on a.key_0 = b.key_0 and a.key_1 = b.key_1
+    order by block_count desc
+    """
+    n_largest_manual_link_only_3 = duckdb.sql(sql).df()
+
+    pd.testing.assert_frame_equal(n_largest_link_only_3, n_largest_manual_link_only_3)
+
+    n_largest_link_and_dedupe_inverted = n_largest_blocks(
+        table_or_tables=[df_1, df_2],
+        blocking_rule="l.name1 = r.name2 and l.name2 = r.name1",
+        link_type="link_and_dedupe",
+        db_api=db_api,
+    ).as_pandas_dataframe()
+
+    sql = """
+    with
+    a as (
+    select name1 as key_0, name2 as key_1, count(*) as c
+    from (select * from df_1 union all select * from df_2)
+    group by key_0, key_1
+    ),
+
+    b as (
+    select name2 as key_0, name1 as key_1, count(*) as c
+    from (select * from df_1 union all select * from df_2)
+    group by key_0, key_1)
+
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    from a inner join b
+    on a.key_0 = b.key_0 and a.key_1 = b.key_1
+    order by block_count desc
+    """
+    n_largest_manual_link_and_dedupe_inverted = duckdb.sql(sql).df()
+
+    pd.testing.assert_frame_equal(
+        n_largest_link_and_dedupe_inverted.sort_values(["key_0", "key_1"]),
+        n_largest_manual_link_and_dedupe_inverted.sort_values(["key_0", "key_1"]),
     )

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -807,6 +807,10 @@ def test_n_largest_blocks(test_helpers, dialect):
     n_largest_manual_link_and_dedupe_inverted = duckdb.sql(sql).df()
 
     pd.testing.assert_frame_equal(
-        n_largest_link_and_dedupe_inverted.sort_values(["key_0", "key_1"]),
-        n_largest_manual_link_and_dedupe_inverted.sort_values(["key_0", "key_1"]),
+        n_largest_link_and_dedupe_inverted.sort_values(["key_0", "key_1"]).reset_index(
+            drop=True
+        ),
+        n_largest_manual_link_and_dedupe_inverted.sort_values(
+            ["key_0", "key_1"]
+        ).reset_index(drop=True),
     )


### PR DESCRIPTION
It's common to want to find the 'worst offender' block for a given rule.

For instance, `block_on("first_name", "surname")` may produce reasonable block sizes for most combinations of values but not John Smith

This new function reports the n largest blocks