### PR TITLE
prevent integer overflow

### DIFF
--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -448,7 +448,7 @@ def _count_comparisons_generated_from_blocking_rule(
     pipeline.enqueue_list_of_sqls(sqls)
 
     sql = """
-    select cast(sum(block_count) as integer) as count_of_pairwise_comparisons_generated
+    select cast(sum(block_count) as int128) as count_of_pairwise_comparisons_generated
     from __splink__block_counts
     """
 


### PR DESCRIPTION

<details>
<summary>
reprex
</summary>

```python
import numpy as np
import pandas as pd

from splink import DuckDBAPI, Linker, SettingsCreator, block_on
from splink.blocking_analysis import (
    count_comparisons_from_blocking_rule,
)

# Constant for number of records
NUM_RECORDS = 1_000_000

# Define probabilities for names and surnames
name_probs = [0.4, 0.4, 0.2]
surname_probs = [0.4, 0.4, 0.2]

# Generate random names and surnames
names = np.random.choice(["John", "Mary", "Jane"], size=NUM_RECORDS, p=name_probs)
surnames = np.random.choice(
    ["Jones", "Smith", "Williams"], size=NUM_RECORDS, p=surname_probs
)

# Generate random dates of birth
start_date = pd.to_datetime("1933-01-01")
end_date = pd.to_datetime("2006-12-31")
date_range = pd.date_range(start=start_date, end=end_date)
dob = np.random.choice(date_range, size=NUM_RECORDS)

# Create DataFrame
df = pd.DataFrame({"first_name": names, "surname": surnames, "dob": dob})


db_api = DuckDBAPI()

args = {
    "table_or_tables": df,
    "link_type": "dedupe_only",
    "db_api": db_api,
    "unique_id_column_name": "unique_id",
    "compute_post_filter_count": False,
}

args["blocking_rule"] = "1=1"

res_dict = count_comparisons_from_blocking_rule(
    table_or_tables=df,
    link_type="dedupe_only",
    db_api=db_api,
    unique_id_column_name="unique_id",
    blocking_rule=block_on("first_name"),
)
res_dict


settings = SettingsCreator(link_type="dedupe_only")
linker = Linker(df, settings, db_api)

linker._find_blocking_rules_below_threshold(1e11)

```

</details>