### PR TITLE
Remove clustering pairwise output format

### DIFF
--- a/splink/internals/linker_components/clustering.py
+++ b/splink/internals/linker_components/clustering.py
@@ -38,8 +38,6 @@ class LinkerClustering:
         self,
         df_predict: SplinkDataFrame,
         threshold_match_probability: Optional[float] = None,
-        pairwise_formatting: bool = False,
-        filter_pairwise_format_for_clusters: bool = True,
     ) -> SplinkDataFrame:
         """Clusters the pairwise match predictions that result from
         `linker.inference.predict()` into groups of connected record using the connected
@@ -53,11 +51,6 @@ class LinkerClustering:
             df_predict (SplinkDataFrame): The results of `linker.predict()`
             threshold_match_probability (float): Pairwise comparisons with a
                 `match_probability` at or above this threshold are matched
-            pairwise_formatting (bool): Whether to output the pairwise match predictions
-                from linker.predict() with cluster IDs.
-            filter_pairwise_format_for_clusters (bool): If pairwise formatting has been
-                selected, whether to output all pairs, or only those belonging to a
-                cluster of size 2 or greater.
 
         Returns:
             SplinkDataFrame: A SplinkDataFrame containing a list of all IDs, clustered
@@ -79,10 +72,7 @@ class LinkerClustering:
         cc = solve_connected_components(
             self._linker,
             edges_table,
-            df_predict,
             nodes_with_tf,
-            pairwise_formatting,
-            filter_pairwise_format_for_clusters,
         )
         cc.metadata["threshold_match_probability"] = threshold_match_probability
 

--- a/tests/cc_testing_utils.py
+++ b/tests/cc_testing_utils.py
@@ -61,7 +61,6 @@ def run_cc_implementation(linker, predict_df):
     cc = solve_connected_components(
         linker,
         predict_df,
-        df_predict=None,
         concat_with_tf=concat_with_tf,
         _generated_graph=True,
     ).as_pandas_dataframe()


### PR DESCRIPTION
This removes the options from `cluster_pairwise_predictions_at_threshold()` to allow for the output format to be in pairwise 'edge' format instead of as a list of nodes with cluster labels.

The rationale for this is that the feature does not seem to be used particularly, and its removal simplifies the code and the API. All the pairwise output did is essentially joining the clusters table to the edges table, which can easily be done manually if desired (or we could re-provide a method for doing so if there is a burning desire from users).