### PR TITLE
Comparison that has tf adjustments = True properly accounts for column expressions

### DIFF
--- a/splink/internals/comparison_creator.py
+++ b/splink/internals/comparison_creator.py
@@ -77,9 +77,11 @@ class ComparisonCreator(ABC):
 
         if self.term_frequency_adjustments:
             for cl in comparison_levels:
-                # TODO: Check that the column name a 'pure' column name and
-                # not a column expression with transforms applied
-                if cl.is_exact_match_level:
+                if (
+                    hasattr(cl, "col_expression")
+                    and cl.col_expression.is_pure_column_or_column_reference
+                    and cl.is_exact_match_level
+                ):
                     cl.term_frequency_adjustments = True
 
         if self.m_probabilities:


### PR DESCRIPTION
```
import splink.comparison_library as cl
from splink import SettingsCreator, block_on

cl.PostcodeComparison("postcode_1", km_thresholds=[1, 10, 100]).configure(
    term_frequency_adjustments=True
).get_comparison("duckdb").as_dict()

``` 
does not work without this since it has exact matches on substrings of the postcode 