### PR TITLE
Adjust package top level imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ cython_debug/
 *.parquet
 *.csv
 
+# html files opt-in only
+*.html
+
 .DS_Store
 
 # vscode local settings

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -6,8 +6,8 @@ from splink.internals.datasets import splink_datasets
 from splink.internals.linker import Linker
 from splink.internals.settings_creator import SettingsCreator
 
-# The following is a workaround for the fact that dependencies of postgres, spark
-# and duckdb may not be installed, but we don't want this to prevent import
+# The following is a workaround for the fact that dependencies of particular backends
+# may not be installed, but we don't want this to prevent import
 # of the other backends.
 
 # This enables auto-complete to be used to import the various DBAPIs
@@ -15,7 +15,6 @@ from splink.internals.settings_creator import SettingsCreator
 # without importing them at runtime
 if TYPE_CHECKING:
     from splink.internals.duckdb.database_api import DuckDBAPI
-    from splink.internals.postgres.database_api import PostgresAPI
     from splink.internals.spark.database_api import SparkAPI
 
 
@@ -30,12 +29,8 @@ def __getattr__(name):
             from splink.internals.duckdb.database_api import DuckDBAPI
 
             return DuckDBAPI
-        elif name == "PostgresAPI":
-            from splink.internals.postgres.database_api import PostgresAPI
-
-            return PostgresAPI
     except ImportError as err:
-        if name in ["SparkAPI", "DuckDBAPI", "PostgresAPI"]:
+        if name in ["SparkAPI", "DuckDBAPI"]:
             raise ImportError(
                 f"{name} cannot be imported because its dependencies are not "
                 "installed. Please `pip install` the required package(s) as "
@@ -52,9 +47,7 @@ __all__ = [
     "ColumnExpression",
     "DuckDBAPI",
     "Linker",
-    "PostgresAPI",
     "SettingsCreator",
     "SparkAPI",
     "splink_datasets",
-    "SQLiteAPI",
 ]

--- a/splink/backends/duckdb.py
+++ b/splink/backends/duckdb.py
@@ -1,0 +1,3 @@
+from splink.internals.duckdb.database_api import DuckDBAPI
+
+__all__ = ["DuckDBAPI"]

--- a/splink/backends/postgres.py
+++ b/splink/backends/postgres.py
@@ -1,0 +1,3 @@
+from splink.internals.postgres.database_api import PostgresAPI
+
+__all__ = ["PostgresAPI"]

--- a/splink/backends/spark.py
+++ b/splink/backends/spark.py
@@ -1,3 +1,4 @@
+from splink.internals.spark.database_api import SparkAPI
 from splink.internals.spark.jar_location import similarity_jar_location
 
-__all__ = ["similarity_jar_location"]
+__all__ = ["similarity_jar_location", "SparkAPI"]


### PR DESCRIPTION
* Make all backend APIs available at `splink.backends.XXX.XXXAPI`
* Only `DuckDBAPI` and `SparkAPI` importable from top-level `splink`

Also:
* ignore `.html` files as default, particularly so I don't accidentally commit the one now generated in tests