### PR TITLE
Turn off previously configured options

### DIFF
--- a/splink/internals/comparison_creator.py
+++ b/splink/internals/comparison_creator.py
@@ -7,7 +7,11 @@ from splink.internals.column_expression import ColumnExpression
 from splink.internals.exceptions import SplinkException
 
 from .comparison import Comparison
-from .comparison_level_creator import ComparisonLevelCreator, unsupplied_option
+from .comparison_level_creator import (
+    ComparisonLevelCreator,
+    UnsuppliedNoneOr,
+    unsupplied_option,
+)
 
 
 class ComparisonCreator(ABC):
@@ -147,9 +151,9 @@ class ComparisonCreator(ABC):
     def configure(
         self,
         *,
-        term_frequency_adjustments: bool = unsupplied_option,
-        m_probabilities: List[float] = unsupplied_option,
-        u_probabilities: List[float] = unsupplied_option,
+        term_frequency_adjustments: UnsuppliedNoneOr[bool] = unsupplied_option,
+        m_probabilities: UnsuppliedNoneOr[List[float]] = unsupplied_option,
+        u_probabilities: UnsuppliedNoneOr[List[float]] = unsupplied_option,
     ) -> "ComparisonCreator":
         """
         Configure the comparison creator with options that are common to all

--- a/splink/internals/comparison_creator.py
+++ b/splink/internals/comparison_creator.py
@@ -7,7 +7,7 @@ from splink.internals.column_expression import ColumnExpression
 from splink.internals.exceptions import SplinkException
 
 from .comparison import Comparison
-from .comparison_level_creator import ComparisonLevelCreator
+from .comparison_level_creator import ComparisonLevelCreator, unsupplied_option
 
 
 class ComparisonCreator(ABC):
@@ -147,9 +147,9 @@ class ComparisonCreator(ABC):
     def configure(
         self,
         *,
-        term_frequency_adjustments: bool = False,
-        m_probabilities: List[float] = None,
-        u_probabilities: List[float] = None,
+        term_frequency_adjustments: bool = unsupplied_option,
+        m_probabilities: List[float] = unsupplied_option,
+        u_probabilities: List[float] = unsupplied_option,
     ) -> "ComparisonCreator":
         """
         Configure the comparison creator with m and u probabilities. The first
@@ -177,9 +177,16 @@ class ComparisonCreator(ABC):
             ```
 
         """
-        self.term_frequency_adjustments = term_frequency_adjustments
-        self.m_probabilities = m_probabilities
-        self.u_probabilities = u_probabilities
+        configurables = {
+            "term_frequency_adjustments": term_frequency_adjustments,
+            "m_probabilities": m_probabilities,
+            "u_probabilities": u_probabilities,
+        }
+
+        for attribute_name, attribute_value in configurables.items():
+            if attribute_value is not unsupplied_option:
+                setattr(self, attribute_name, attribute_value)
+
         return self
 
     @property

--- a/splink/internals/comparison_creator.py
+++ b/splink/internals/comparison_creator.py
@@ -152,18 +152,32 @@ class ComparisonCreator(ABC):
         u_probabilities: List[float] = unsupplied_option,
     ) -> "ComparisonCreator":
         """
-        Configure the comparison creator with m and u probabilities. The first
+        Configure the comparison creator with options that are common to all
+        comparisons.
+
+        For m and u probabilities, the first
         element in the list corresponds to the first comparison level, usually
         an exact match level. Subsequent elements correspond comparison to
         levels in sequential order, through to the last element which is usually
         the 'ELSE' level.
 
+        All options have default options set initially. Any call to `.configure()`
+        will set any options that are supplied. Any subsequent calls to `.configure()`
+        will not override these values with defaults; to override values you must
+        explicitly provide a value corresponding to the default.
+
+        Generally speaking only a single call (at most) to `.configure()` should
+        be required.
+
         Args:
             term_frequency_adjustments (bool, optional): Whether term frequency
                 adjustments are switched on for this comparison. Only applied
-                to exact match levels. Default: False
+                to exact match levels.
+                Default corresponds to False.
             m_probabilities (list, optional): List of m probabilities
+                Default corresponds to None.
             u_probabilities (list, optional): List of u probabilities
+                Default corresponds to None.
 
         Example:
             ```py

--- a/splink/internals/comparison_level_creator.py
+++ b/splink/internals/comparison_level_creator.py
@@ -82,8 +82,8 @@ class ComparisonLevelCreator(ABC):
 
         All options have default options set initially. Any call to `.configure()`
         will set any options that are supplied. Any subsequent calls to `.configure()`
-        will not override these values with defaults; to override values you must
-        explicitly provide a value.
+        will not override these values with defaults; to override values you must must
+        explicitly provide a value corresponding to the default.
 
         Generally speaking only a single call (at most) to `.configure()` should
         be required.

--- a/splink/internals/comparison_level_creator.py
+++ b/splink/internals/comparison_level_creator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from inspect import signature
-from typing import Any, final
+from typing import Any, TypeVar, Union, final
 
 from splink.internals.column_expression import ColumnExpression
 from splink.internals.dialects import SplinkDialect
@@ -12,12 +12,19 @@ from .comparison_level import ComparisonLevel
 
 class _UnsuppliedOption:
     _instance: "_UnsuppliedOption" | None = None
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(_UnsuppliedOption, cls).__new__(cls)
         return cls._instance
 
+
 unsupplied_option = _UnsuppliedOption()
+
+T = TypeVar("T")
+# type alias - either the specified type, _UnsuppliedOption, or None
+UnsuppliedNoneOr = Union[T, _UnsuppliedOption, None]
+
 
 class ComparisonLevelCreator(ABC):
     # off by default - only a small subset should have tf adjustments
@@ -65,14 +72,14 @@ class ComparisonLevelCreator(ABC):
     def configure(
         self,
         *,
-        m_probability: float = unsupplied_option,
-        u_probability: float = unsupplied_option,
-        tf_adjustment_column: str = unsupplied_option,
-        tf_adjustment_weight: float = unsupplied_option,
-        tf_minimum_u_value: float = unsupplied_option,
-        is_null_level: bool = unsupplied_option,
-        label_for_charts: str = unsupplied_option,
-        disable_tf_exact_match_detection: bool = unsupplied_option,
+        m_probability: UnsuppliedNoneOr[float] = unsupplied_option,
+        u_probability: UnsuppliedNoneOr[float] = unsupplied_option,
+        tf_adjustment_column: UnsuppliedNoneOr[str] = unsupplied_option,
+        tf_adjustment_weight: UnsuppliedNoneOr[float] = unsupplied_option,
+        tf_minimum_u_value: UnsuppliedNoneOr[float] = unsupplied_option,
+        is_null_level: UnsuppliedNoneOr[bool] = unsupplied_option,
+        label_for_charts: UnsuppliedNoneOr[str] = unsupplied_option,
+        disable_tf_exact_match_detection: UnsuppliedNoneOr[bool] = unsupplied_option,
     ) -> "ComparisonLevelCreator":
         """
         Configure the comparison level with options which are common to all

--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -256,8 +256,11 @@ class ExactMatchLevel(ComparisonLevelCreator):
                 tf_adjustment_column=self.col_expression.raw_sql_expression,
                 tf_adjustment_weight=1.0,
             )
-
-        # TODO: how to 'turn off'?? configure doesn't currently allow
+        else:
+            self.configure(
+                tf_adjustment_column=None,
+                tf_adjustment_weight=None,
+            )
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         self.col_expression.sql_dialect = sql_dialect

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -430,3 +430,18 @@ def test_comparison_level_reconfigure():
     # turn tf adjustments off again
     exact_match_without_tf = exact_match_with_tf.configure(tf_adjustment_column=None)
     assert_tf_adjustments_on_off(exact_match_without_tf, tf_adjustments_on=False)
+
+
+def test_sequential_configurations():
+    # want to check that configurations don't forget about previously-set options
+    em_with_m = cl.ExactMatch("col").configure(m_probabilities=[0.8, 0.2])
+    assert em_with_m.m_probabilities == [0.8, 0.2]
+    assert not em_with_m.term_frequency_adjustments
+
+    em_with_m.configure(term_frequency_adjustments=True)
+    assert em_with_m.term_frequency_adjustments
+    assert em_with_m.m_probabilities == [0.8, 0.2]
+
+    em_with_m.configure(m_probabilities=[0.9, 0.1])
+    assert em_with_m.m_probabilities == [0.9, 0.1]
+    assert em_with_m.term_frequency_adjustments


### PR DESCRIPTION
Currently, if you have a `ComparisonLevelCreator` that you `.configure()`, you cannot undo configurations to return to default values.

For example:
```py
import splink.comparison_level_library as cll

level = cll.ExactMatchLevel("name")
# turn tf adjustments on
level.configure(tf_adjustment_column="name")
# no way to turn them off!
level.configure(tf_adjustment_column=None)  # this is a noöp
```

While uncommon, this sort of thing might be used if you wanted to build two closely related models from common `SettingsCreator` or `ComparisonCreator` objects - for example comparing models with and without term frequencies.

A related (but sort-of opposite) point I noticed is an inconsistency between this behaviour and the current behaviour of `ComparisonCreator.configure()`. This _will_ allow you to undo values, but also automatically undoes any values not supplied:
```py
import splink.comparison_library as cl

comp = cl.ExactMatch("name")
# turn tf adjustments on:
comp.configure(term_frequency_adjustments=True)
# supply m probabilities
comp.configure(m_probabilities=[0.9, 0.1])  # this now turns off term frequency adjustments! 😢 
```

I have changed things to be consistent across both `ComparisonCreator` and `ComparisonLevelCreator`. In both cases:
* the true default is a new singleton type, whose instance is `unsupplied_option`
* if the value of an option is `unsupplied_option` then we do nothing
* if the value of an option is any other value, we set the corresponding attribute to that option

This means in particular that we can manually set values as `None`, and the underlying attribute _will_ change. It also means that any values we do not supply to `.configure()` will not overwrite any previously-set values, and so both of the above snippets should work properly now.