### PR TITLE
Consistent `db_api` argument name

### DIFF
--- a/docs/demos/examples/athena/deduplicate_50k_synthetic.ipynb
+++ b/docs/demos/examples/athena/deduplicate_50k_synthetic.ipynb
@@ -331,7 +331,7 @@
         "    retain_intermediate_calculation_columns=True,\n",
         ")\n",
         "\n",
-        "linker = Linker(df, settings, database_api=db_api)"
+        "linker = Linker(df, settings, db_api=db_api)"
       ]
     },
     {

--- a/docs/demos/examples/duckdb/accuracy_analysis_from_labels_column.ipynb
+++ b/docs/demos/examples/duckdb/accuracy_analysis_from_labels_column.ipynb
@@ -184,7 +184,7 @@
    ],
    "source": [
     "db_api = DuckDBAPI()\n",
-    "linker = Linker(df, settings, database_api=db_api)\n",
+    "linker = Linker(df, settings, db_api=db_api)\n",
     "deterministic_rules = [\n",
     "    \"l.first_name = r.first_name and levenshtein(r.dob, l.dob) <= 1\",\n",
     "    \"l.surname = r.surname and levenshtein(r.dob, l.dob) <= 1\",\n",

--- a/docs/demos/examples/duckdb/deterministic_dedupe.ipynb
+++ b/docs/demos/examples/duckdb/deterministic_dedupe.ipynb
@@ -352,7 +352,7 @@
     "    retain_intermediate_calculation_columns=True,\n",
     ")\n",
     "\n",
-    "linker = Linker(df, settings, database_api=db_api)\n"
+    "linker = Linker(df, settings, db_api=db_api)\n"
    ]
   },
   {

--- a/docs/demos/examples/duckdb/febrl3.ipynb
+++ b/docs/demos/examples/duckdb/febrl3.ipynb
@@ -215,7 +215,7 @@
     "    link_type=\"dedupe_only\",\n",
     ")\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI())"
+    "linker = Linker(df, settings, db_api=DuckDBAPI())"
    ]
   },
   {
@@ -570,7 +570,7 @@
     "    retain_intermediate_calculation_columns=True,\n",
     ")\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI())"
+    "linker = Linker(df, settings, db_api=DuckDBAPI())"
    ]
   },
   {

--- a/docs/demos/examples/duckdb/febrl4.ipynb
+++ b/docs/demos/examples/duckdb/febrl4.ipynb
@@ -301,7 +301,7 @@
     "    # our estimation procedure returns something sensible\n",
     ")\n",
     "\n",
-    "linker = Linker(dfs, basic_settings, database_api=DuckDBAPI())"
+    "linker = Linker(dfs, basic_settings, db_api=DuckDBAPI())"
    ]
   },
   {
@@ -715,8 +715,8 @@
     ")\n",
     "\n",
     "\n",
-    "linker_simple = Linker(dfs, simple_model_settings, database_api=DuckDBAPI())\n",
-    "linker_detailed = Linker(dfs, detailed_model_settings, database_api=DuckDBAPI())"
+    "linker_simple = Linker(dfs, simple_model_settings, db_api=DuckDBAPI())\n",
+    "linker_detailed = Linker(dfs, detailed_model_settings, db_api=DuckDBAPI())"
    ]
   },
   {
@@ -2786,7 +2786,7 @@
    ],
    "source": [
     "# train\n",
-    "linker_advanced = Linker(dfs, extended_model_settings, database_api=DuckDBAPI())\n",
+    "linker_advanced = Linker(dfs, extended_model_settings, db_api=DuckDBAPI())\n",
     "linker_advanced.training.estimate_probability_two_random_records_match(\n",
     "    deterministic_rules, recall=0.8\n",
     ")\n",

--- a/docs/demos/examples/duckdb/link_only.ipynb
+++ b/docs/demos/examples/duckdb/link_only.ipynb
@@ -176,7 +176,7 @@
     "linker = Linker(\n",
     "    [df_l, df_r],\n",
     "    settings,\n",
-    "    database_api=DuckDBAPI(),\n",
+    "    db_api=DuckDBAPI(),\n",
     "    input_table_aliases=[\"df_left\", \"df_right\"],\n",
     ")"
    ]

--- a/docs/demos/examples/duckdb/pairwise_labels.ipynb
+++ b/docs/demos/examples/duckdb/pairwise_labels.ipynb
@@ -377,7 +377,7 @@
    },
    "outputs": [],
    "source": [
-    "linker = Linker(df, settings, database_api=DuckDBAPI(), set_up_basic_logging=False)\n",
+    "linker = Linker(df, settings, db_api=DuckDBAPI(), set_up_basic_logging=False)\n",
     "deterministic_rules = [\n",
     "    \"l.first_name = r.first_name and levenshtein(r.dob, l.dob) <= 1\",\n",
     "    \"l.surname = r.surname and levenshtein(r.dob, l.dob) <= 1\",\n",

--- a/docs/demos/examples/duckdb/quick_and_dirty_persons.ipynb
+++ b/docs/demos/examples/duckdb/quick_and_dirty_persons.ipynb
@@ -257,7 +257,7 @@
     "from splink import Linker, DuckDBAPI\n",
     "\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI(), set_up_basic_logging=False)\n",
+    "linker = Linker(df, settings, db_api=DuckDBAPI(), set_up_basic_logging=False)\n",
     "deterministic_rules = [\n",
     "    \"l.full_name = r.full_name\",\n",
     "    \"l.postcode_fake = r.postcode_fake and l.dob = r.dob\",\n",

--- a/docs/demos/examples/duckdb/real_time_record_linkage.ipynb
+++ b/docs/demos/examples/duckdb/real_time_record_linkage.ipynb
@@ -81,7 +81,7 @@
         "    settings = json.loads(u.read().decode())\n",
         "\n",
         "\n",
-        "linker = Linker(df, settings, database_api=DuckDBAPI())"
+        "linker = Linker(df, settings, db_api=DuckDBAPI())"
       ]
     },
     {

--- a/docs/demos/examples/duckdb/transactions.ipynb
+++ b/docs/demos/examples/duckdb/transactions.ipynb
@@ -546,7 +546,7 @@
     "    [df_origin, df_destination],\n",
     "    settings,\n",
     "    input_table_aliases=[\"__ori\", \"_dest\"],\n",
-    "    database_api=db_api,\n",
+    "    db_api=db_api,\n",
     ")"
    ]
   },

--- a/docs/demos/examples/spark/deduplicate_1k_synthetic.ipynb
+++ b/docs/demos/examples/spark/deduplicate_1k_synthetic.ipynb
@@ -186,7 +186,7 @@
         }
       ],
       "source": [
-        "linker = Linker(df, settings, database_api=SparkAPI(spark_session=spark))\n",
+        "linker = Linker(df, settings, db_api=SparkAPI(spark_session=spark))\n",
         "deterministic_rules = [\n",
         "    \"l.first_name = r.first_name and levenshtein(r.dob, l.dob) <= 1\",\n",
         "    \"l.surname = r.surname and levenshtein(r.dob, l.dob) <= 1\",\n",

--- a/docs/demos/examples/sqlite/deduplicate_50k_synthetic.ipynb
+++ b/docs/demos/examples/sqlite/deduplicate_50k_synthetic.ipynb
@@ -317,7 +317,7 @@
         "    \"em_convergence\": 0.01,\n",
         "}\n",
         "\n",
-        "linker = Linker(df, settings, database_api=db_api)"
+        "linker = Linker(df, settings, db_api=db_api)"
       ]
     },
     {

--- a/docs/demos/tutorials/04_Estimating_model_parameters.ipynb
+++ b/docs/demos/tutorials/04_Estimating_model_parameters.ipynb
@@ -278,7 +278,7 @@
     "    retain_intermediate_calculation_columns=True,\n",
     ")\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI())"
+    "linker = Linker(df, settings, db_api=DuckDBAPI())"
    ]
   },
   {

--- a/docs/demos/tutorials/05_Predicting_results.ipynb
+++ b/docs/demos/tutorials/05_Predicting_results.ipynb
@@ -94,7 +94,7 @@
     "    settings = json.loads(u.read().decode())\n",
     "\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI())"
+    "linker = Linker(df, settings, db_api=DuckDBAPI())"
    ]
   },
   {

--- a/docs/demos/tutorials/06_Visualising_predictions.ipynb
+++ b/docs/demos/tutorials/06_Visualising_predictions.ipynb
@@ -98,7 +98,7 @@
     "    settings = json.loads(u.read().decode())\n",
     "\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI())\n",
+    "linker = Linker(df, settings, db_api=DuckDBAPI())\n",
     "df_predictions = linker.inference.predict(threshold_match_probability=0.2)"
    ]
   },

--- a/docs/demos/tutorials/07_Evaluation.ipynb
+++ b/docs/demos/tutorials/07_Evaluation.ipynb
@@ -124,7 +124,7 @@
     "    block_on(\"dob\"),\n",
     "]\n",
     "\n",
-    "linker = Linker(df, settings, database_api=DuckDBAPI())\n",
+    "linker = Linker(df, settings, db_api=DuckDBAPI())\n",
     "df_predictions = linker.inference.predict(threshold_match_probability=0.01)"
    ]
   },

--- a/docs/topic_guides/splink_fundamentals/backends/postgres.md
+++ b/docs/topic_guides/splink_fundamentals/backends/postgres.md
@@ -33,7 +33,7 @@ dbapi = PostgresAPI(engine=engine)
 linker = Linker(
     "my_data_table,
     settings_dict,
-    database_api=db_api,
+    db_api=db_api,
 )
 ```
 
@@ -49,7 +49,7 @@ dbapi = PostgresAPI(engine=engine)
 linker = Linker(
     df,
     settings_dict,
-    database_api=db_api,
+    db_api=db_api,
 )
 ```
 

--- a/docs/topic_guides/splink_fundamentals/link_type.md
+++ b/docs/topic_guides/splink_fundamentals/link_type.md
@@ -26,7 +26,7 @@ settings = SettingsCreator(
     link_type= "dedupe_only",
 )
 
-linker = Linker(df, settings, database_api=dbapi, )
+linker = Linker(df, settings, db_api=dbapi, )
 ```
 
 ## Link only
@@ -43,7 +43,7 @@ settings = SettingsCreator(
 linker = Linker(
     [df_1, df_2, df_n],
     settings,
-    database_api=dbapi,
+    db_api=dbapi,
     input_table_aliases=["name1", "name2", "name3"],
 )
 ```
@@ -64,7 +64,7 @@ settings = SettingsCreator(
 linker = Linker(
     [df_1, df_2, df_n],
     settings,
-    database_api=dbapi,
+    db_api=dbapi,
     input_table_aliases=["name1", "name2", "name3"],
 )
 ```

--- a/docs/topic_guides/splink_fundamentals/querying_splink_results.md
+++ b/docs/topic_guides/splink_fundamentals/querying_splink_results.md
@@ -92,7 +92,7 @@ con.sql("CREATE TABLE number_table AS SELECT * FROM df_numbers")
 db_api = DuckDBAPI(connection=con)
 df = splink_datasets.fake_1000
 
-linker = Linker(df, settings=SettingsCreator(link_type="dedupe_only"), database_api=db_api)
+linker = Linker(df, settings=SettingsCreator(link_type="dedupe_only"), db_api=db_api)
 splink_df = linker.table_management.register_table("number_table", "a_templated_name")
 splink_df.as_pandas_dataframe()
 ```

--- a/docs/topic_guides/splink_fundamentals/settings.md
+++ b/docs/topic_guides/splink_fundamentals/settings.md
@@ -147,7 +147,7 @@ With our finalised settings object, we can train a Splink model using the follow
         ],
     )
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
 
     blocking_rule_for_training = block_on("first_name", "surname")
@@ -418,7 +418,7 @@ When using a pre-trained model, you can read in the model from a json and recrea
 ```py
 linker = DuckDBLinker(new_df,
     settings="./path/to/model.json",
-    database_api=db_api
+    db_api=db_api
 )
 
 ```

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -74,7 +74,7 @@ class Linker:
         self,
         input_table_or_tables: str | list[str],
         settings: SettingsCreator | dict[str, Any] | Path | str,
-        database_api: DatabaseAPISubClass,
+        db_api: DatabaseAPISubClass,
         set_up_basic_logging: bool = True,
         input_table_aliases: str | list[str] | None = None,
         validate_settings: bool = True,
@@ -133,7 +133,7 @@ class Linker:
             splink_logger = logging.getLogger("splink")
             splink_logger.setLevel(logging.INFO)
 
-        self._db_api = database_api
+        self._db_api = db_api
 
         # TODO: temp hack for compat
         self._intermediate_table_cache: CacheDictWithLogging = (
@@ -155,7 +155,7 @@ class Linker:
         # Maybe overwrite it here and incompatibilities have to be dealt with
         # by comparisons/ blocking rules etc??
         self._settings_obj = settings_creator.get_settings(
-            database_api.sql_dialect.name
+            db_api.sql_dialect.name
         )
 
         # TODO: Add test of what happens if the db_api is for a different backend

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -73,7 +73,7 @@ class LinkerInference:
                 ],
             )
 
-            linker = Linker(df, settings, database_api=db_api)
+            linker = Linker(df, settings, db_api=db_api)
             splink_df = linker.inference.deterministic_link()
             ```
 
@@ -181,7 +181,7 @@ class LinkerInference:
 
         Examples:
             ```py
-            linker = linker(df, "saved_settings.json", database_api=db_api)
+            linker = linker(df, "saved_settings.json", db_api=db_api)
             splink_df = linker.inference.predict(threshold_match_probability=0.95)
             splink_df.as_pandas_dataframe(limit=5)
             ```
@@ -317,7 +317,7 @@ class LinkerInference:
 
         Examples:
             ```py
-            linker = Linker(df, "saved_settings.json", database_api=db_api)
+            linker = Linker(df, "saved_settings.json", db_api=db_api)
 
             # You should load or pre-compute tf tables for any tables with
             # term frequency adjustments
@@ -483,7 +483,7 @@ class LinkerInference:
 
         Examples:
             ```py
-            linker = Linker(df, "saved_settings.json", database_api=db_api)
+            linker = Linker(df, "saved_settings.json", db_api=db_api)
 
             # You should load or pre-compute tf tables for any tables with
             # term frequency adjustments

--- a/splink/internals/splink_dataframe.py
+++ b/splink/internals/splink_dataframe.py
@@ -25,12 +25,12 @@ class SplinkDataFrame(ABC):
         self,
         templated_name: str,
         physical_name: str,
-        database_api: DatabaseAPI[Any],
+        db_api: DatabaseAPI[Any],
         metadata: dict[str, Any] = None,
     ):
         self.templated_name = templated_name
         self.physical_name = physical_name
-        self.db_api = database_api
+        self.db_api = db_api
         self._target_schema = "splink"
         self.created_by_splink = False
         self.sql_used_to_create: str | None = None

--- a/tests/cc_testing_utils.py
+++ b/tests/cc_testing_utils.py
@@ -38,7 +38,7 @@ def register_cc_df(G):
     db_api = DuckDBAPI()
 
     linker = Linker(
-        df_concat, settings_dict, input_table_aliases=table_name, database_api=db_api
+        df_concat, settings_dict, input_table_aliases=table_name, db_api=db_api
     )
 
     # re-register under our required name to run the CC function

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,7 +28,7 @@ class TestHelper(ABC):
 
     def extra_linker_args(self):
         # create fresh api each time
-        return {"database_api": self.DatabaseAPI(**self.db_api_args())}
+        return {"db_api": self.DatabaseAPI(**self.db_api_args())}
 
     @property
     def date_format(self):

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -50,7 +50,7 @@ def test_scored_labels_table():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     pipeline = CTEPipeline()
     concat_with_tf = compute_df_concat_with_tf(linker, pipeline)
@@ -112,7 +112,7 @@ def test_truth_space_table():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     labels_with_predictions = [
         {
@@ -195,7 +195,7 @@ def test_roc_chart_dedupe_only():
     settings_dict = get_settings_dict()
     db_api = DuckDBAPI(connection=":memory:")
 
-    linker = Linker(df, settings_dict, database_api=db_api)
+    linker = Linker(df, settings_dict, db_api=db_api)
 
     labels_sdf = linker.table_management.register_table(df_labels, "labels")
 
@@ -227,7 +227,7 @@ def test_roc_chart_link_and_dedupe():
     db_api = DuckDBAPI(connection=":memory:")
 
     linker = Linker(
-        df, settings_dict, input_table_aliases="fake_data_1", database_api=db_api
+        df, settings_dict, input_table_aliases="fake_data_1", db_api=db_api
     )
 
     labels_sdf = linker.table_management.register_table(df_labels, "labels")
@@ -290,7 +290,7 @@ def test_prediction_errors_from_labels_table():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     linker.table_management.register_table(df_labels, "labels")
 
@@ -311,7 +311,7 @@ def test_prediction_errors_from_labels_table():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     linker.table_management.register_table(df_labels, "labels")
 
@@ -332,7 +332,7 @@ def test_prediction_errors_from_labels_table():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker.table_management.register_table(df_labels, "labels")
 
     pipeline = CTEPipeline()
@@ -395,7 +395,7 @@ def test_prediction_errors_from_labels_column():
     #
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     df_res = linker.evaluation.prediction_errors_from_labels_column(
         "cluster"
@@ -412,7 +412,7 @@ def test_prediction_errors_from_labels_column():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     df_res = linker.evaluation.prediction_errors_from_labels_column(
         "cluster", include_false_positives=False
@@ -429,7 +429,7 @@ def test_prediction_errors_from_labels_column():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     df_res = linker.evaluation.prediction_errors_from_labels_column(
         "cluster", include_false_negatives=False
@@ -491,7 +491,7 @@ def test_truth_space_table_from_labels_column_dedupe_only():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     tt = linker.evaluation.accuracy_analysis_from_labels_column(
         "cluster", output_type="table"
@@ -562,7 +562,7 @@ def test_truth_space_table_from_labels_column_link_only():
 
     db_api = DuckDBAPI()
 
-    linker = Linker([df_left, df_right], settings, database_api=db_api)
+    linker = Linker([df_left, df_right], settings, db_api=db_api)
 
     tt = linker.evaluation.accuracy_analysis_from_labels_column(
         "ground_truth", output_type="table"
@@ -612,7 +612,7 @@ def test_truth_space_table_from_column_vs_pandas_implementaiton_inc_unblocked():
         additional_columns_to_retain=["cluster"],
     )
 
-    linker_for_predictions = Linker(df, settings, database_api=DuckDBAPI())
+    linker_for_predictions = Linker(df, settings, db_api=DuckDBAPI())
     df_predictions_raw = linker_for_predictions.inference.predict()
 
     # Score all of the positive labels even if not captured by the blocking rules
@@ -647,7 +647,7 @@ def test_truth_space_table_from_column_vs_pandas_implementaiton_inc_unblocked():
         additional_columns_to_retain=["cluster"],
     )
 
-    linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
+    linker_for_splink_answer = Linker(df, settings, db_api=DuckDBAPI())
     df_from_splink = (
         linker_for_splink_answer.evaluation.accuracy_analysis_from_labels_column(
             "cluster",
@@ -688,7 +688,7 @@ def test_truth_space_table_from_column_vs_pandas_implementaiton_ex_unblocked():
         additional_columns_to_retain=["cluster"],
     )
 
-    linker_for_predictions = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
+    linker_for_predictions = Linker([df_1, df_2], settings, db_api=DuckDBAPI())
     df_predictions_raw = linker_for_predictions.inference.predict()
 
     # When match_key = 1, the record is not really recovered by the blocking rules
@@ -717,7 +717,7 @@ def test_truth_space_table_from_column_vs_pandas_implementaiton_ex_unblocked():
         blocking_rules_to_generate_predictions=[block_on("first_name")],
         additional_columns_to_retain=["cluster"],
     )
-    linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
+    linker_for_splink_answer = Linker([df_1, df_2], settings, db_api=DuckDBAPI())
 
     df_from_splink = (
         linker_for_splink_answer.evaluation.accuracy_analysis_from_labels_column(
@@ -766,10 +766,10 @@ def test_truth_space_table_from_table_vs_pandas_cartesian():
         additional_columns_to_retain=["cluster"],
     )
 
-    linker_for_predictions = Linker(df_first_50, settings, database_api=DuckDBAPI())
+    linker_for_predictions = Linker(df_first_50, settings, db_api=DuckDBAPI())
     df_predictions = linker_for_predictions.inference.predict().as_pandas_dataframe()
 
-    linker_for_splink_answer = Linker(df, settings, database_api=DuckDBAPI())
+    linker_for_splink_answer = Linker(df, settings, db_api=DuckDBAPI())
     labels_input = linker_for_splink_answer.table_management.register_labels_table(
         labels_table
     )
@@ -826,7 +826,7 @@ def test_truth_space_table_from_table_vs_pandas_with_blocking():
     )
 
     linker_for_predictions = Linker(
-        [df_1_first_50, df_2_first_50], settings, database_api=DuckDBAPI()
+        [df_1_first_50, df_2_first_50], settings, db_api=DuckDBAPI()
     )
     df_predictions_raw = linker_for_predictions.inference.predict()
     df_predictions_raw.as_pandas_dataframe()
@@ -855,7 +855,7 @@ def test_truth_space_table_from_table_vs_pandas_with_blocking():
         additional_columns_to_retain=["cluster"],
     )
 
-    linker_for_splink_answer = Linker([df_1, df_2], settings, database_api=DuckDBAPI())
+    linker_for_splink_answer = Linker([df_1, df_2], settings, db_api=DuckDBAPI())
     labels_input = linker_for_splink_answer.table_management.register_labels_table(
         labels_table
     )

--- a/tests/test_array_columns.py
+++ b/tests/test_array_columns.py
@@ -13,7 +13,7 @@ from tests.literal_utils import (
 @mark_with_dialects_excluding("sqlite", "spark")
 def test_array_comparison_1(test_helpers, dialect):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     test_spec = ComparisonTestSpec(
         cl.ArrayIntersectAtSizes("arr", [4, 3, 2, 1]),

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -33,7 +33,7 @@ def test_cache_id(tmp_path):
     # Test saving and loading a model
     db_api = DuckDBAPI()
 
-    linker = Linker(df, get_settings_dict(), database_api=db_api)
+    linker = Linker(df, get_settings_dict(), db_api=db_api)
 
     prior = linker._settings_obj._cache_uid
 
@@ -42,7 +42,7 @@ def test_cache_id(tmp_path):
 
     db_api = DuckDBAPI()
 
-    linker_2 = Linker(df, path, database_api=db_api)
+    linker_2 = Linker(df, path, db_api=db_api)
 
     assert linker_2._settings_obj._cache_uid == prior
 
@@ -52,7 +52,7 @@ def test_cache_id(tmp_path):
     settings["linker_uid"] = random_uid
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker_uid = linker._cache_uid
     assert linker_uid == random_uid
 
@@ -62,7 +62,7 @@ def test_cache_only_splink_dataframes():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._intermediate_table_cache["new_table"] = DuckDBDataFrame(
         "template", "__splink__dummy_frame", linker
     )
@@ -82,7 +82,7 @@ def test_cache_access_df_concat(debug_mode):
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = debug_mode
     with patch.object(
         db_api, "_sql_to_splink_dataframe", new=make_mock_execute(db_api)
@@ -114,7 +114,7 @@ def test_cache_access_compute_tf_table(debug_mode):
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = debug_mode
     with patch.object(
         db_api, "_sql_to_splink_dataframe", new=make_mock_execute(db_api)
@@ -134,7 +134,7 @@ def test_invalidate_cache(debug_mode):
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = debug_mode
 
     with patch.object(
@@ -184,7 +184,7 @@ def test_cache_invalidates_with_new_linker(debug_mode):
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = debug_mode
     with patch.object(
         db_api, "_sql_to_splink_dataframe", new=make_mock_execute(db_api)
@@ -201,7 +201,7 @@ def test_cache_invalidates_with_new_linker(debug_mode):
 
     db_api = DuckDBAPI()
 
-    new_linker = Linker(df, settings, database_api=db_api)
+    new_linker = Linker(df, settings, db_api=db_api)
     new_linker._debug_mode = debug_mode
     with patch.object(
         db_api, "_sql_to_splink_dataframe", new=make_mock_execute(db_api)
@@ -232,7 +232,7 @@ def test_cache_register_compute_concat_with_tf_table(debug_mode):
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = debug_mode
 
     with patch.object(
@@ -253,7 +253,7 @@ def test_cache_register_compute_tf_table(debug_mode):
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = debug_mode
 
     with patch.object(

--- a/tests/test_caching_tables.py
+++ b/tests/test_caching_tables.py
@@ -28,7 +28,7 @@ def test_cache_tracking_works():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
 
     assert cache.is_in_executed_queries("__splink__df_concat_with_tf") is False
@@ -93,7 +93,7 @@ def test_cache_used_when_registering_nodes_table():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
     linker.table_management.register_table_input_nodes_concat_with_tf(
         splink__df_concat_with_tf
@@ -146,7 +146,7 @@ def test_cache_used_when_registering_tf_tables():
     # First test do not register any tf tables
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
 
     linker.inference.predict()
@@ -157,7 +157,7 @@ def test_cache_used_when_registering_tf_tables():
     # Then try the same after registering surname tf table
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
     linker.table_management.register_term_frequency_lookup(surname_tf_table, "surname")
     linker.inference.predict()
@@ -168,7 +168,7 @@ def test_cache_used_when_registering_tf_tables():
     # Then try the same after registering both
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
     linker.table_management.register_term_frequency_lookup(surname_tf_table, "surname")
     linker.table_management.register_term_frequency_lookup(
@@ -196,7 +196,7 @@ def test_cache_invalidation():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
 
     linker.table_management.compute_tf_table("name")
@@ -210,7 +210,7 @@ def test_cache_invalidation():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
 
     linker.table_management.compute_tf_table("name")
@@ -243,7 +243,7 @@ def test_table_deletions():
 
     db_api = DuckDBAPI(connection=con)
 
-    linker = Linker("my_table", settings, database_api=db_api)
+    linker = Linker("my_table", settings, db_api=db_api)
 
     table_names_before = set(get_duckdb_table_names_as_list(db_api._con))
 
@@ -293,7 +293,7 @@ def test_table_deletions_with_preregistered():
 
     db_api = DuckDBAPI(connection=con)
 
-    linker = Linker("my_data_table", settings, database_api=db_api)
+    linker = Linker("my_data_table", settings, db_api=db_api)
     linker.table_management.register_table_input_nodes_concat_with_tf(
         "my_nodes_with_tf_table"
     )
@@ -330,7 +330,7 @@ def test_single_deletion():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     cache = linker._intermediate_table_cache
 
     tf_table = linker.table_management.compute_tf_table("name")

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -130,7 +130,7 @@ def test_m_u_charts():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     linker.training.estimate_probability_two_random_records_match(
         ["l.true_match_id = r.true_match_id"], recall=1.0
@@ -158,7 +158,7 @@ def test_parameter_estimate_charts():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     linker.training.estimate_probability_two_random_records_match(
         ["l.true_match_id = r.true_match_id"], recall=1.0
@@ -195,7 +195,7 @@ def test_parameter_estimate_charts():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker.training.estimate_u_using_random_sampling(1e6)
 
     linker.visualisations.parameter_estimate_comparisons_chart()
@@ -214,7 +214,7 @@ def test_tf_adjustment_chart():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker.visualisations.tf_adjustment_chart("gender")
     linker.visualisations.tf_adjustment_chart("first_name")
 

--- a/tests/test_cluster_studio.py
+++ b/tests/test_cluster_studio.py
@@ -14,7 +14,7 @@ def test_density_sample():
         "link_type": "dedupe_only",
         "unique_id_column_name": "person_id",
     }
-    linker = Linker(df, settings, database_api=DuckDBAPI())
+    linker = Linker(df, settings, db_api=DuckDBAPI())
 
     # Dummy cluster metrics table
     cluster = ["A", "B", "C", "D", "E", "F"]

--- a/tests/test_columns_selected.py
+++ b/tests/test_columns_selected.py
@@ -62,7 +62,7 @@ def test_regression(tmp_path):
                 output_schema="splink_in_duckdb",
             )
 
-            linker = Linker(df.copy(), settings_dict, database_api=db_api)
+            linker = Linker(df.copy(), settings_dict, db_api=db_api)
 
             linker.inference.predict()
 
@@ -123,6 +123,6 @@ def test_discussion_example(tmp_path):
 
             db_api = DuckDBAPI()
 
-            linker = Linker(df.copy(), settings_dict, database_api=db_api)
+            linker = Linker(df.copy(), settings_dict, db_api=db_api)
 
             linker.inference.predict()

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -15,7 +15,7 @@ def test_splink_2_predict():
     settings_dict = get_settings_dict()
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings_dict, database_api=db_api)
+    linker = Linker(df, settings_dict, db_api=db_api)
 
     expected_record = pd.read_csv("tests/datasets/splink2_479_vs_481.csv")
 
@@ -62,7 +62,7 @@ def test_splink_2_predict_sqlite():
     settings_dict = get_settings_dict()
 
     db_api = SQLiteAPI(con)
-    linker = Linker("fake_data_1", settings_dict, database_api=db_api)
+    linker = Linker("fake_data_1", settings_dict, db_api=db_api)
 
     df_e = linker.inference.predict().as_pandas_dataframe()
 
@@ -84,7 +84,7 @@ def test_splink_2_em_fixed_u():
     settings_dict = get_settings_dict()
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings_dict, database_api=db_api)
+    linker = Linker(df, settings_dict, db_api=db_api)
 
     # Check lambda history is the same
     expected_prop_history = pd.read_csv(
@@ -132,7 +132,7 @@ def test_splink_2_em_no_fix():
     settings_dict = get_settings_dict()
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings_dict, database_api=db_api)
+    linker = Linker(df, settings_dict, db_api=db_api)
 
     # Check lambda history is the same
     expected_prop_history = pd.read_csv(
@@ -190,7 +190,7 @@ def test_lambda():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings_dict, database_api=db_api)
+    linker = Linker(df, settings_dict, db_api=db_api)
 
     ma = linker.inference.predict().as_pandas_dataframe()
     f1 = ma["unique_id_l"] == 924

--- a/tests/test_comparison_lib.py
+++ b/tests/test_comparison_lib.py
@@ -31,7 +31,7 @@ def test_distance_function_comparison():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     df_pred = linker.inference.predict().as_pandas_dataframe()
 
@@ -84,7 +84,7 @@ def test_set_to_lowercase():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     df_e = linker.inference.predict().as_pandas_dataframe()
 
     row = dict(df_e.query("id_l == 1 and id_r == 2").iloc[0])

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -13,7 +13,7 @@ from tests.literal_utils import (
 @mark_with_dialects_excluding("postgres", "sqlite")
 def test_email_comparison(dialect, test_helpers, test_gamma_assert):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
     test_spec = ComparisonTestSpec(
         cl.EmailComparison("email"),
         tests=[
@@ -45,7 +45,7 @@ def test_email_comparison(dialect, test_helpers, test_gamma_assert):
 @mark_with_dialects_excluding("sqlite")
 def test_date_of_birth_comparison_levels(dialect, test_helpers, test_gamma_assert):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
     test_spec = ComparisonTestSpec(
         cl.DateOfBirthComparison(
             "date_of_birth",
@@ -246,7 +246,7 @@ def test_date_comparison_error_logger(dialect):
 @mark_with_dialects_excluding("postgres", "sqlite")
 def test_postcode_comparison(dialect, test_helpers, test_gamma_assert):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     test_spec = ComparisonTestSpec(
         cl.PostcodeComparison("postcode"),
@@ -346,7 +346,7 @@ def test_postcode_comparison(dialect, test_helpers, test_gamma_assert):
 @mark_with_dialects_excluding("postgres", "sqlite")
 def test_name_comparison(dialect, test_helpers, test_gamma_assert):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
     test_spec = ComparisonTestSpec(
         cl.NameComparison("name"),
         tests=[
@@ -439,7 +439,7 @@ def test_name_comparison(dialect, test_helpers, test_gamma_assert):
 @mark_with_dialects_excluding("postgres", "sqlite")
 def test_forename_surname_comparison(dialect, test_helpers, test_gamma_assert):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     test_spec = ComparisonTestSpec(
         cl.ForenameSurnameComparison("forename", "surname"),

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -120,7 +120,7 @@ def test_compound_comparison_level():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     all_cols_match_level = linker._settings_obj.comparisons[1].comparison_levels[1]
     assert all_cols_match_level._is_exact_match
     assert set(all_cols_match_level._exact_match_colnames) == {
@@ -218,6 +218,6 @@ def test_complex_compound_comparison_level():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     linker.training.estimate_parameters_using_expectation_maximisation("1=1")

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -76,7 +76,7 @@ def test_splink_converges_to_known_params():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(in_df, settings, database_api=db_api)
+    linker = Linker(in_df, settings, db_api=db_api)
 
     settings_obj = linker._settings_obj
 

--- a/tests/test_date_levels_and_comparisons.py
+++ b/tests/test_date_levels_and_comparisons.py
@@ -17,7 +17,7 @@ from tests.literal_utils import (
 @mark_with_dialects_excluding("sqlite")
 def test_absolute_date_difference_level(test_helpers, dialect):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     col_exp = ColumnExpression("dob").try_parse_date()
     test_spec = ComparisonLevelTestSpec(
@@ -68,7 +68,7 @@ def test_absolute_date_difference_level(test_helpers, dialect):
 @mark_with_dialects_excluding("sqlite")
 def test_absolute_time_difference_levels(test_helpers, dialect):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     test_spec = ComparisonLevelTestSpec(
         cll.AbsoluteTimeDifferenceLevel,
@@ -129,7 +129,7 @@ def test_absolute_time_difference_levels(test_helpers, dialect):
 @mark_with_dialects_excluding("sqlite")
 def test_absolute_date_difference_at_thresholds(test_helpers, dialect):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     test_spec = ComparisonTestSpec(
         cl.AbsoluteDateDifferenceAtThresholds(
@@ -160,7 +160,7 @@ def test_absolute_date_difference_at_thresholds(test_helpers, dialect):
 @mark_with_dialects_including("duckdb", pass_dialect=True)
 def test_alternative_date_format(test_helpers, dialect):
     helper = test_helpers[dialect]
-    db_api = helper.extra_linker_args()["database_api"]
+    db_api = helper.extra_linker_args()["db_api"]
 
     test_spec = ComparisonTestSpec(
         cl.AbsoluteDateDifferenceAtThresholds(

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -29,7 +29,7 @@ def test_clear_error_when_empty_block():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
     linker._debug_mode = True
     linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
     linker.training.estimate_parameters_using_expectation_maximisation(
@@ -56,11 +56,11 @@ def test_estimate_without_term_frequencies():
 
     db_api = DuckDBAPI()
 
-    linker_0 = Linker(df, settings, database_api=db_api)
+    linker_0 = Linker(df, settings, db_api=db_api)
 
     db_api = DuckDBAPI()
 
-    linker_1 = Linker(df, settings, database_api=db_api)
+    linker_1 = Linker(df, settings, db_api=db_api)
 
     session_fast = linker_0.training.estimate_parameters_using_expectation_maximisation(
         blocking_rule="l.email = r.email",

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -53,7 +53,7 @@ def test_full_example_duckdb(tmp_path):
     linker = Linker(
         df,
         settings=settings_dict,
-        database_api=db_api,
+        db_api=db_api,
         # output_schema="splink_in_duckdb",
     )
 
@@ -131,9 +131,9 @@ def test_full_example_duckdb(tmp_path):
     linker.misc.save_model_to_json(path)
 
     db_api = DuckDBAPI()
-    linker_2 = Linker(df, settings=simple_settings, database_api=db_api)
+    linker_2 = Linker(df, settings=simple_settings, db_api=db_api)
 
-    linker_2 = Linker(df, database_api=db_api, settings=path)
+    linker_2 = Linker(df, db_api=db_api, settings=path)
 
     # Test that writing to files works as expected
     _test_write_functionality(linker_2, pd.read_csv)
@@ -182,7 +182,7 @@ def test_link_only(input, source_l, source_r):
     settings["source_dataset_column_name"] = "source_dataset"
 
     db_api = DuckDBAPI()
-    linker = Linker(input, settings, database_api=db_api)
+    linker = Linker(input, settings, db_api=db_api)
     df_predict = linker.inference.predict().as_pandas_dataframe()
 
     assert len(df_predict) == 7257
@@ -226,7 +226,7 @@ def test_duckdb_load_from_file(df):
     linker = Linker(
         df,
         settings,
-        database_api=db_api,
+        db_api=db_api,
     )
 
     assert len(linker.inference.predict().as_pandas_dataframe()) == 3167
@@ -237,7 +237,7 @@ def test_duckdb_load_from_file(df):
     linker = Linker(
         [df, df],
         settings,
-        database_api=db_api,
+        db_api=db_api,
         input_table_aliases=["testing1", "testing2"],
     )
 
@@ -269,7 +269,7 @@ def test_duckdb_arrow_array():
             "comparisons": [cl.ExactMatch("b")],
             "blocking_rules_to_generate_predictions": ["l.a[1] = r.a[1]"],
         },
-        database_api=db_api,
+        db_api=db_api,
     )
     df = linker.inference.deterministic_link().as_pandas_dataframe()
     assert len(df) == 2
@@ -314,7 +314,7 @@ def test_small_example_duckdb(tmp_path):
     }
 
     db_api = DuckDBAPI()
-    linker = Linker(df, settings_dict, database_api=db_api)
+    linker = Linker(df, settings_dict, db_api=db_api)
 
     linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
     blocking_rule = "l.full_name = r.full_name"

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -24,7 +24,7 @@ def test_full_example_postgres(tmp_path, pg_engine):
     linker = Linker(
         df,
         settings_dict,
-        database_api=db_api,
+        db_api=db_api,
     )
 
     count_comparisons_from_blocking_rule(
@@ -121,7 +121,7 @@ def test_full_example_postgres(tmp_path, pg_engine):
     path = os.path.join(tmp_path, "model.json")
     linker.misc.save_model_to_json(path)
 
-    Linker(df, path, database_api=db_api)
+    Linker(df, path, db_api=db_api)
 
 
 @mark_with_dialects_including("postgres")
@@ -136,7 +136,7 @@ def test_postgres_use_existing_table(tmp_path, pg_engine):
     db_api = PostgresAPI(engine=pg_engine)
     linker = Linker(
         table_name,
-        database_api=db_api,
+        db_api=db_api,
         settings=settings_dict,
     )
     linker.inference.predict()

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -160,7 +160,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
     path = os.path.join(tmp_path, "model.json")
     linker.misc.save_model_to_json(path)
 
-    Linker(df_spark, settings=path, database_api=spark_api)
+    Linker(df_spark, settings=path, db_api=spark_api)
 
 
 @mark_with_dialects_including("spark")

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -27,7 +27,7 @@ def test_full_example_sqlite(tmp_path):
     linker = Linker(
         "input_df_tablename",
         settings_dict,
-        database_api=db_api,
+        db_api=db_api,
         input_table_aliases="fake_data_1",
     )
 

--- a/tests/test_graph_metrics.py
+++ b/tests/test_graph_metrics.py
@@ -37,7 +37,7 @@ def test_size_density_dedupe():
     }
     db_api = DuckDBAPI()
 
-    linker = Linker(df_1, settings, database_api=db_api)
+    linker = Linker(df_1, settings, db_api=db_api)
 
     df_predict = linker.inference.predict()
     df_clustered = linker.clustering.cluster_pairwise_predictions_at_threshold(
@@ -75,7 +75,7 @@ def test_size_density_link():
         [df_1, df_2],
         settings,
         input_table_aliases=["df_left", "df_right"],
-        database_api=db_api,
+        db_api=db_api,
     )
 
     df_predict = linker.inference.predict()

--- a/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
+++ b/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
@@ -117,7 +117,7 @@ def test_dedupe_only():
     linker = Linker(
         df_one,
         settings,
-        database_api=db_api,
+        db_api=db_api,
         set_up_basic_logging=False,
     )
     logging.getLogger("splink").setLevel(1)
@@ -170,7 +170,7 @@ def test_link_and_dedupe():
     linker = Linker(
         [df_one, df_two],
         settings,
-        database_api=db_api,
+        db_api=db_api,
         input_table_aliases=["df_one", "df_two"],
         set_up_basic_logging=False,
     )
@@ -226,7 +226,7 @@ def test_link_only_two():
     linker = Linker(
         [df_one, df_two],
         settings,
-        database_api=db_api,
+        db_api=db_api,
         input_table_aliases=["df_one", "df_two"],
         set_up_basic_logging=False,
     )
@@ -283,7 +283,7 @@ def test_link_only_three():
     linker = Linker(
         [df_one, df_two, df_three],
         settings,
-        database_api=db_api,
+        db_api=db_api,
         input_table_aliases=["df_one", "df_two", "df_three"],
         set_up_basic_logging=False,
     )

--- a/tests/test_km_distance_level.py
+++ b/tests/test_km_distance_level.py
@@ -226,7 +226,7 @@ def test_haversine_level():
 
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, input_table_aliases="test", database_api=db_api)
+    linker = Linker(df, settings, input_table_aliases="test", db_api=db_api)
     df_e = linker.inference.predict().as_pandas_dataframe()
 
     row = dict(df_e.query("id_l == 1 and id_r == 2").iloc[0])

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -68,7 +68,7 @@ def test_dedupe_only_join_condition():
     for s in [settings, settings_salt]:
         db_api = DuckDBAPI()
 
-        linker = Linker(df.copy(), s, database_api=db_api)
+        linker = Linker(df.copy(), s, db_api=db_api)
 
         df_predict = linker.inference.predict().as_pandas_dataframe()
 
@@ -93,7 +93,7 @@ def test_link_only_two_join_condition():
     for s in [settings, settings_salt]:
         db_api = DuckDBAPI()
 
-        linker = Linker([sds_d_only, sds_b_only], s, database_api=db_api)
+        linker = Linker([sds_d_only, sds_b_only], s, db_api=db_api)
 
         df_predict = linker.inference.predict().as_pandas_dataframe()
 
@@ -122,7 +122,7 @@ def test_link_only_three_join_condition():
     for s in [settings, settings_salt]:
         db_api = DuckDBAPI()
 
-        linker = Linker([sds_d_only, sds_b_only, sds_c_only], s, database_api=db_api)
+        linker = Linker([sds_d_only, sds_b_only, sds_c_only], s, db_api=db_api)
 
         df_predict = linker.inference.predict().as_pandas_dataframe()
 
@@ -151,7 +151,7 @@ def test_link_and_dedupe_two_join_condition():
     for s in [settings, settings_salt]:
         db_api = DuckDBAPI()
 
-        linker = Linker([sds_d_only, sds_b_only], s, database_api=db_api)
+        linker = Linker([sds_d_only, sds_b_only], s, db_api=db_api)
 
         df_predict = linker.inference.predict().as_pandas_dataframe()
 
@@ -180,7 +180,7 @@ def test_link_and_dedupe_three_join_condition():
     for s in [settings, settings_salt]:
         db_api = DuckDBAPI()
 
-        linker = Linker([sds_d_only, sds_b_only, sds_c_only], s, database_api=db_api)
+        linker = Linker([sds_d_only, sds_b_only, sds_c_only], s, db_api=db_api)
 
         df_predict = linker.inference.predict().as_pandas_dataframe()
 

--- a/tests/test_m_train.py
+++ b/tests/test_m_train.py
@@ -24,7 +24,7 @@ def test_m_train():
     # Train from label column
     db_api = DuckDBAPI()
 
-    linker = Linker(df, settings, database_api=db_api)
+    linker = Linker(df, settings, db_api=db_api)
 
     linker.training.estimate_m_from_label_column("cluster")
     cc_name = linker._settings_obj.comparisons[0]
@@ -55,7 +55,7 @@ def test_m_train():
 
     db_api = DuckDBAPI()
 
-    linker_pairwise = Linker(df, settings, database_api=db_api)
+    linker_pairwise = Linker(df, settings, db_api=db_api)
 
     linker_pairwise.table_management.register_table(df_labels, "labels")
     linker_pairwise.training.estimate_m_from_pairwise_labels("labels")

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -244,7 +244,7 @@ def test_settings_validation_logs(caplog):
     with caplog.at_level(logging.WARNING):
         db_api = DuckDBAPI()
 
-        Linker(DF, settings, validate_settings=True, database_api=db_api)
+        Linker(DF, settings, validate_settings=True, db_api=db_api)
 
         # Define expected log segments
         expected_log_segments = [

--- a/tests/test_term_frequencies.py
+++ b/tests/test_term_frequencies.py
@@ -81,7 +81,7 @@ def test_tf_basic():
     }
 
     db_api = DuckDBAPI(connection=":memory:")
-    linker = Linker(data, settings, database_api=db_api)
+    linker = Linker(data, settings, db_api=db_api)
     df_predict = linker.inference.predict()
     results = filter_results(df_predict)
 
@@ -118,7 +118,7 @@ def test_tf_clamp():
     }
 
     db_api = DuckDBAPI(connection=":memory:")
-    linker = Linker(data, settings, database_api=db_api)
+    linker = Linker(data, settings, db_api=db_api)
     df_predict = linker.inference.predict()
     results = filter_results(df_predict)
 
@@ -156,7 +156,7 @@ def test_weight():
 
     db_api = DuckDBAPI(connection=":memory:")
 
-    linker = Linker(data, settings, database_api=db_api)
+    linker = Linker(data, settings, db_api=db_api)
     df_predict = linker.inference.predict()
     results = filter_results(df_predict)
 
@@ -207,7 +207,7 @@ def test_weightand_clamp():
 
     db_api = DuckDBAPI(connection=":memory:")
 
-    linker = Linker(data, settings, database_api=db_api)
+    linker = Linker(data, settings, db_api=db_api)
     df_predict = linker.inference.predict()
     results = filter_results(df_predict)
 


### PR DESCRIPTION
`Linker` (and `SplinkDataFrame`) take arguments `database_api=`, whilst every other function we have that takes one calls the argument `db_api=`.

This changes the argument names for `Linker` and `SplinkDataFrame` to also be `db_api`, so that we are using that entirely throughout the codebase.
I have not changed any module (or class) names, as I do not think these really clash, and all the relevant stuff is in `splink.internals` anyway.

I think I have changed this everywhere in the code and the docs, but let me know if you think I've overlooked anything.