### PR TITLE
Remove jan 1st option from date of birth comparison

### DIFF
--- a/docs/topic_guides/comparisons/out_of_the_box_comparisons.ipynb
+++ b/docs/topic_guides/comparisons/out_of_the_box_comparisons.ipynb
@@ -33,15 +33,7 @@
         "date_of_birth_comparison = cl.DateOfBirthComparison(\n",
         "    \"date_of_birth\",\n",
         "    input_is_string=True,\n",
-        "    separate_1st_january=True,\n",
         ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The `separate_1st_january` argument is used where you have some dates that are set to 1st of January when only the year is known"
       ]
     },
     {
@@ -63,7 +55,6 @@
             "Comparison 'DateOfBirthComparison' of \"date_of_birth\".\n",
             "Similarity is assessed using the following ComparisonLevels:\n",
             "    - 'transformed date_of_birth is NULL' with SQL rule: try_strptime(\"date_of_birth_l\", '%Y-%m-%d') IS NULL OR try_strptime(\"date_of_birth_r\", '%Y-%m-%d') IS NULL\n",
-            "    - 'Exact match on year, 1st Jan only' with SQL rule: ((SUBSTRING(CAST(try_strptime(\"date_of_birth_l\", '%Y-%m-%d') AS TEXT), 6, 5) = '01-01') OR (SUBSTRING(CAST(try_strptime(\"date_of_birth_r\", '%Y-%m-%d') AS TEXT), 6, 5) = '01-01')) AND (SUBSTRING(CAST(try_strptime(\"date_of_birth_l\", '%Y-%m-%d') AS TEXT), 0, 4) = SUBSTRING(CAST(try_strptime(\"date_of_birth_r\", '%Y-%m-%d') AS TEXT), 0, 4))\n",
             "    - 'Exact match on date of birth' with SQL rule: \"date_of_birth_l\" = \"date_of_birth_r\"\n",
             "    - 'DamerauLevenshtein distance <= 1' with SQL rule: damerau_levenshtein(\"date_of_birth_l\", \"date_of_birth_r\") <= 1\n",
             "    - 'Abs date difference <= 1 month' with SQL rule: ABS(EPOCH(try_strptime(\"date_of_birth_l\", '%Y-%m-%d')) - EPOCH(try_strptime(\"date_of_birth_r\", '%Y-%m-%d'))) <= 2629800.0\n",
@@ -102,8 +93,6 @@
               " 'comparison_levels': [{'sql_condition': 'try_strptime(\"date_of_birth_l\", \\'%Y-%m-%d\\') IS NULL OR try_strptime(\"date_of_birth_r\", \\'%Y-%m-%d\\') IS NULL',\n",
               "   'label_for_charts': 'transformed date_of_birth is NULL',\n",
               "   'is_null_level': True},\n",
-              "  {'sql_condition': '((SUBSTRING(CAST(try_strptime(\"date_of_birth_l\", \\'%Y-%m-%d\\') AS TEXT), 6, 5) = \\'01-01\\') OR (SUBSTRING(CAST(try_strptime(\"date_of_birth_r\", \\'%Y-%m-%d\\') AS TEXT), 6, 5) = \\'01-01\\')) AND (SUBSTRING(CAST(try_strptime(\"date_of_birth_l\", \\'%Y-%m-%d\\') AS TEXT), 0, 4) = SUBSTRING(CAST(try_strptime(\"date_of_birth_r\", \\'%Y-%m-%d\\') AS TEXT), 0, 4))',\n",
-              "   'label_for_charts': 'Exact match on year, 1st Jan only'},\n",
               "  {'sql_condition': '\"date_of_birth_l\" = \"date_of_birth_r\"',\n",
               "   'label_for_charts': 'Exact match on date of birth'},\n",
               "  {'sql_condition': 'damerau_levenshtein(\"date_of_birth_l\", \"date_of_birth_r\") <= 1',\n",

--- a/tests/test_comparison_template_lib.py
+++ b/tests/test_comparison_template_lib.py
@@ -50,22 +50,9 @@ def test_date_of_birth_comparison_levels(dialect, test_helpers, test_gamma_asser
         cl.DateOfBirthComparison(
             "date_of_birth",
             input_is_string=True,
-            separate_1st_january=True,
             invalid_dates_as_null=True,
         ),
         tests=[
-            LiteralTestValues(
-                {"date_of_birth_l": "1990-01-01", "date_of_birth_r": "1990-01-01"},
-                expected_gamma_val=6,  # Exact match on year (1st of January only)
-            ),
-            LiteralTestValues(
-                {"date_of_birth_l": "2012-01-01", "date_of_birth_r": "2012-02-02"},
-                expected_gamma_val=6,  # Exact match on year (1st of January only)
-            ),
-            LiteralTestValues(
-                {"date_of_birth_l": "1985-03-11", "date_of_birth_r": "1985-01-01"},
-                expected_gamma_val=6,  # Exact match on year (1st of January only)
-            ),
             LiteralTestValues(
                 {"date_of_birth_l": "1990-05-20", "date_of_birth_r": "1990-05-20"},
                 expected_gamma_val=5,  # Exact match
@@ -98,21 +85,8 @@ def test_date_of_birth_comparison_levels(dialect, test_helpers, test_gamma_asser
         cl.DateOfBirthComparison(
             ColumnExpression("dob").try_parse_date(),
             input_is_string=False,
-            separate_1st_january=True,
         ),
         tests=[
-            LiteralTestValues(
-                {"dob_l": "1990-01-01", "dob_r": "1990-01-01"},
-                expected_gamma_val=6,  # Exact match on year (1st of January only)
-            ),
-            LiteralTestValues(
-                {"dob_l": "2012-01-01", "dob_r": "2012-02-02"},
-                expected_gamma_val=6,  # Exact match on year (1st of January only)
-            ),
-            LiteralTestValues(
-                {"dob_l": "1985-03-11", "dob_r": "1985-01-01"},
-                expected_gamma_val=6,  # Exact match on year (1st of January only)
-            ),
             LiteralTestValues(
                 {"dob_l": "1990-05-20", "dob_r": "1990-05-20"},
                 expected_gamma_val=5,  # Exact match
@@ -168,7 +142,6 @@ def test_date_of_birth_comparison_levels(dialect, test_helpers, test_gamma_asser
         cl.DateOfBirthComparison(
             "date_of_birth",
             input_is_string=True,
-            separate_1st_january=False,
             datetime_thresholds=[1, 2, 5],
             datetime_metrics=["day", "month", "year"],
         ),


### PR DESCRIPTION
We have decided to remove this option for the moment because:
- It adds a lot of complexity without any robust evidence it improves accuracy
- We're not sure whether it should be 'phrased' as a match of 1st jan vs. any other day/month, or only exact match on 1st jan on both sides of the match
- We're not sure of the extent to which you get similar results by just enabling term frequency adjustments