### PR TITLE
Update Splink 4 docs

### DIFF
--- a/docs/api_docs/datasets.md
+++ b/docs/api_docs/datasets.md
@@ -17,8 +17,9 @@ df = splink_datasets.fake_1000
 which you can then use to set up a linker:
 ```py
 from splink splink_datasets, Linker, DuckDBAPI, SettingsCreator
+
 df = splink_datasets.fake_1000
-linker = DuckDBLinker(
+linker = Linker(
     df,
     SettingsCreator(
         link_type="dedupe_only",
@@ -26,7 +27,8 @@ linker = DuckDBLinker(
             cl.exact_match("first_name"),
             cl.exact_match("surname"),
         ],
-    )
+    ),
+    db_api=DuckDBAPI()
 )
 ```
 

--- a/docs/dev_guides/debug_modes.md
+++ b/docs/dev_guides/debug_modes.md
@@ -44,7 +44,7 @@ Note that by default Splink sets the [logging level to `INFO` on initialisation]
 
 ```python
 import logging
-linker = DuckDBLinker(df, settings, set_up_basic_logging=False)
+linker = Linker(df, settings, db_api, set_up_basic_logging=False)
 
 # This must come AFTER the linker is intialised, because the logging level
 # will be set to INFO
@@ -61,5 +61,5 @@ logging.basicConfig(format="%(message)s")
 splink_logger = logging.getLogger("splink")
 splink_logger.setLevel(logging.INFO)
 
-linker = DuckDBLinker(df, settings, set_up_basic_logging=False)
+linker = Linker(df, settings, db_api, set_up_basic_logging=False)
 ```

--- a/docs/topic_guides/data_preparation/feature_engineering.md
+++ b/docs/topic_guides/data_preparation/feature_engineering.md
@@ -194,7 +194,7 @@ For a more detailed explanation on phonetic transformation algorithms, see the [
 
 ### Example
 
-There are a number of python packages which support phonetic transformations that can be applied to a pandas dataframe, which can then be loaded into the `DuckDBLinker`. For example, creating a [Double Metaphone](../comparisons/phonetic.md#double-metaphone) column with the [phonetics](https://pypi.org/project/phonetics/) python library:
+There are a number of python packages which support phonetic transformations that can be applied to a pandas dataframe, which can then be loaded into the `Linker`. For example, creating a [Double Metaphone](../comparisons/phonetic.md#double-metaphone) column with the [phonetics](https://pypi.org/project/phonetics/) python library:
 
 ```python
 import pandas as pd

--- a/docs/topic_guides/performance/optimising_duckdb.md
+++ b/docs/topic_guides/performance/optimising_duckdb.md
@@ -99,8 +99,8 @@ Use the special `:temporary:` connection built into Splink that creates a tempor
 
 ```python
 
-linker = DuckDBLinker(
-    df, settings, connection=":temporary:"
+linker = Linker(
+    df, settings, DuckDBAPI(connection=":temporary:")
 )
 ```
 
@@ -108,8 +108,8 @@ Use an on-disk database:
 
 ```python
 con = duckdb.connect(database='my-db.duckdb')
-linker = DuckDBLinker(
-    df, settings, connection=con
+linker = Linker(
+    df, settings, DuckDBAPI(connection=con)
 )
 ```
 
@@ -119,8 +119,8 @@ Use an in-memory database, but ensure it can spill to disk:
 con = duckdb.connect(":memory:")
 
 con.execute("SET temp_directory='/path/to/temp';")
-linker = DuckDBLinker(
-    df, settings, connection=con
+linker = Linker(
+    df, settings, DuckDBAPI(connection=con)
 )
 ```
 

--- a/docs/topic_guides/performance/optimising_spark.md
+++ b/docs/topic_guides/performance/optimising_spark.md
@@ -25,9 +25,10 @@ For a cluster with 10 CPUs, that outputs about 8GB of data in parquet format, th
 spark.conf.set("spark.default.parallelism", "50")
 spark.conf.set("spark.sql.shuffle.partitions", "50")
 
-linker = SparkLinker(
+linker = Linker(
     person_standardised_nodes,
     settings,
+    db_api=spark_api,
     break_lineage_method="parquet",
     num_partitions_on_repartition=80,
 )
@@ -45,9 +46,10 @@ Splink will automatically break lineage in sensible places. We have found in pra
 You can do this using the `break_lineage_method` parameter as follows:
 
 ```
-linker = SparkLinker(
+linker = Linker(
     person_standardised_nodes,
     settings,
+    db_api=db_api,
     break_lineage_method="parquet"
 )
 
@@ -78,7 +80,7 @@ In general, increasing parallelism will make Spark 'chunk' your job into a large
 
 ## Repartition after blocking
 
-For some jobs, setting `repartition_after_blocking=True` when you initialise the `SparkLinker` may improve performance.
+For some jobs, setting `repartition_after_blocking=True` when you initialise the `SparkAPI` may improve performance.
 
 ## Salting
 

--- a/docs/topic_guides/splink_fundamentals/settings.md
+++ b/docs/topic_guides/splink_fundamentals/settings.md
@@ -416,7 +416,8 @@ where the `m_probability` and `u_probability` values here are then used to gener
 When using a pre-trained model, you can read in the model from a json and recreate the linker object to make new pairwise predictions. For example:
 
 ```py
-linker = DuckDBLinker(new_df,
+linker = Linker(
+    new_df,
     settings="./path/to/model.json",
     db_api=db_api
 )

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -112,10 +112,12 @@ class Linker:
                 database) for link_only or link_and_dedupe.  For some linkers, such as
                 the DuckDBLinker and the SparkLinker, it's also possible to pass in
                 dataframes (Pandas and Spark respectively) rather than strings.
-            settings_dict (dict | Path, optional): A Splink settings dictionary, or a
-                path to a json defining a settingss dictionary or pre-trained model.
-                If not provided when the object is created, can later be added using
-                `linker.load_settings()` or `linker.load_model()` Defaults to None.
+            settings_dict (dict | Path | str): A Splink settings dictionary,
+                or a path (either as a pathlib.Path object, or a string) to a json file
+                defining a settings dictionary or pre-trained model.
+            db_api (DatabaseAPI): A `DatabaseAPI` object, which manages interactions
+                with the database. You can import these for use from
+                `splink.backends.{your_backend}`
             set_up_basic_logging (bool, optional): If true, sets ups up basic logging
                 so that Splink sends messages at INFO level to stdout. Defaults to True.
             input_table_aliases (Union[str, list], optional): Labels assigned to

--- a/splink/internals/linker_components/misc.py
+++ b/splink/internals/linker_components/misc.py
@@ -23,7 +23,9 @@ class LinkerMisc:
     ) -> dict[str, Any]:
         """Save the configuration and parameters of the linkage model to a `.json` file.
 
-        The model can later be loaded back in using `linker.load_model()`.
+        The model can later be loaded into a new linker using
+        `Linker(df, settings="path/to/model.json", db_api=db_api).
+
         The settings dict is also returned in case you want to save it a different way.
 
         Examples:

--- a/splink/internals/linker_components/table_management.py
+++ b/splink/internals/linker_components/table_management.py
@@ -43,8 +43,7 @@ class LinkerTableManagement:
 
             Real time linkage
             ```py
-            linker = Linker(df, db_api)
-            linker.load_settings("saved_settings.json")
+            linker = Linker(df, settings="saved_settings.json", db_api=db_api)
             linker.table_management.compute_tf_table("surname")
             linker.compare_two_records(record_left, record_right)
             ```


### PR DESCRIPTION
Removed references to `load_settings` + `load_model` + clarified a bit how to load settings into a fresh linker.

Also got rid of docs references to `DuckDBLinker` + `SparkLinker` + updated some code snippets to new API.