### PR TITLE
Docs colour scheme for v4

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,14 +27,14 @@ theme:
   favicon: "img/favicon.ico"
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: teal
+      accent: purple
       toggle:
         icon: material/toggle-switch
         name: Switch to dark mode
     - scheme: slate
-      primary: purple
-      accent: red
+      primary: teal
+      accent: purple
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to light mode


### PR DESCRIPTION
Updating the colour scheme for the docs site to help alert users to the switch to v4 and preserve a visual distinction between the v3 (old colours) and v4 docs (new colours)

https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/