### PR TITLE
Fix examples in misc.py

### DIFF
--- a/splink/internals/linker_components/misc.py
+++ b/splink/internals/linker_components/misc.py
@@ -30,7 +30,7 @@ class LinkerMisc:
 
         Examples:
             ```py
-            linker.save_model_to_json("my_settings.json", overwrite=True)
+            linker.misc.save_model_to_json("my_settings.json", overwrite=True)
             ```
         Args:
             out_path (str, optional): File path for json file. If None, don't save to
@@ -60,7 +60,7 @@ class LinkerMisc:
             ```py
             linker = Linker(df, settings, db_api)
             df_predict = linker.predict()
-            linker.query_sql(f"select * from {df_predict.physical_name} limit 10")
+            linker.misc.query_sql(f"select * from {df_predict.physical_name} limit 10")
             ```
 
         Args:


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
no


### Give a brief description for the solution you have provided
Hi, I noticed that the examples in the misc.py file still use the old pre 4.0 API. 



### PR Checklist

- [ ] Added documentation for changes 
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


