### PR TITLE
Fix completeness Spark bug - array indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Completeness chart now works correectly with indexed columns in spark ([#2309](https://github.com/moj-analytical-services/splink/pull/2309))
+
 ## [4.0.0] - 2024-07-24
 
 Major release - see our [blog](https://moj-analytical-services.github.io/splink/blog/2024/07/24/splink-400-released.html) for what's changed

--- a/splink/internals/completeness.py
+++ b/splink/internals/completeness.py
@@ -46,7 +46,8 @@ def completeness_data(
     if cols is None:
         cols_as_input_col = first_df.columns
     else:
-        cols_as_input_col = [InputColumn(c) for c in cols]
+        sqlglot_dialect = db_api.sql_dialect.sqlglot_name
+        cols_as_input_col = [InputColumn(c, sql_dialect=sqlglot_dialect) for c in cols]
 
     sqls = []
     for col in cols_as_input_col:

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -32,3 +32,27 @@ def test_completeness_chart_mismatched_columns(dialect, test_helpers):
 
     with raises(SplinkException):
         completeness_chart([df_l, df_r], db_api)
+
+
+@mark_with_dialects_excluding("sqlite")
+def test_completeness_chart_complex_columns(dialect, test_helpers):
+    helper = test_helpers[dialect]
+    db_api = helper.DatabaseAPI(**helper.db_api_args())
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "first_name": ["Arnie", None, "Carla", "Debbie", None],
+            "surname": [None, None, None, None, "Everett"],
+            "city_arr": [
+                ["London", "Leeds"],
+                ["Birmingham"],
+                None,
+                ["Leeds", "Manchester"],
+                None,
+            ],
+        }
+    )
+    df = helper.convert_frame(df)
+    # check completeness when we have more complicated column constructs, such as
+    # indexing into array columns
+    completeness_chart(df, db_api, cols=["first_name", "surname", "city_arr[0]"])


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Using `completeness_chart` with column such as `some_arr[0]` failed in Spark. See test in this PR.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
This gives `InputColumn` the required dialect info so expression is parsed as a column expression, rather than a string literal.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


