### PR TITLE
Completeness - handle existing source dataset column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Completeness chart now works correectly with indexed columns in spark ([#2309](https://github.com/moj-analytical-services/splink/pull/2309))
+- Completeness chart now works correctly with indexed columns in spark ([#2309](https://github.com/moj-analytical-services/splink/pull/2309))
+- Completeness chart works even if you have a `source_dataset` column ([#2323](https://github.com/moj-analytical-services/splink/pull/2323))
+
 
 ## [4.0.0] - 2024-07-24
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -44,6 +44,10 @@ class TestHelper(ABC):
     def load_frame_from_parquet(self, path):
         return pd.read_parquet(path)
 
+    @property
+    def arrays_from(self) -> int:
+        return 1
+
 
 class DuckDBTestHelper(TestHelper):
     @property
@@ -84,6 +88,9 @@ class SparkTestHelper(TestHelper):
         df.persist()
         return df
 
+    @property
+    def arrays_from(self) -> int:
+        return 0
 
 class SQLiteTestHelper(TestHelper):
     _frame_counter = 0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -92,6 +92,7 @@ class SparkTestHelper(TestHelper):
     def arrays_from(self) -> int:
         return 0
 
+
 class SQLiteTestHelper(TestHelper):
     _frame_counter = 0
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -56,3 +56,13 @@ def test_completeness_chart_complex_columns(dialect, test_helpers):
     # check completeness when we have more complicated column constructs, such as
     # indexing into array columns
     completeness_chart(df, db_api, cols=["first_name", "surname", "city_arr[0]"])
+
+
+@mark_with_dialects_excluding("sqlite")
+def test_completeness_chart_source_dataset(dialect, test_helpers):
+    helper = test_helpers[dialect]
+    db_api = helper.DatabaseAPI(**helper.db_api_args())
+    df_pd = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df_pd["source_dataset"] = "fake_1000"
+    df = helper.convert_frame(df_pd)
+    completeness_chart(df, db_api)

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -53,9 +53,10 @@ def test_completeness_chart_complex_columns(dialect, test_helpers):
         }
     )
     df = helper.convert_frame(df)
+    first = helper.arrays_from
     # check completeness when we have more complicated column constructs, such as
     # indexing into array columns
-    completeness_chart(df, db_api, cols=["first_name", "surname", "city_arr[0]"])
+    completeness_chart(df, db_api, cols=["first_name", "surname", f"city_arr[{first}]"])
 
 
 @mark_with_dialects_excluding("sqlite")


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Closes #2317.


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
Use an internal column name when computing `completeness_data`, so that we do not clash if the data has a `source_dataset` column pre-existing, which is certainly possible.

Also add some fairly unrelated test machinery to easily deal with arrays, which have differing conventions on different backends - see #2310.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


