### PR TITLE
`InputColumn` always dialected

### DIFF
--- a/splink/internals/input_column.py
+++ b/splink/internals/input_column.py
@@ -231,12 +231,6 @@ class InputColumn:
         return self_copy
 
     @property
-    def as_base_dialect(self) -> InputColumn:
-        input_column_copy = copy(self)
-        input_column_copy.sql_dialect = None
-        return input_column_copy
-
-    @property
     def name(self) -> str:
         return self.col_builder.sql
 

--- a/splink/internals/input_column.py
+++ b/splink/internals/input_column.py
@@ -174,6 +174,8 @@ class InputColumn:
         column_info_settings: ColumnInfoSettings = None,
         sql_dialect: str,
     ):
+        # TODO: the sql_dialect is the sqlglot name.
+        # Might need to be more careful with this
         self.column_info_settings = copy(column_info_settings)
 
         self.register_dialect(sql_dialect)
@@ -190,7 +192,7 @@ class InputColumn:
             )
         )
 
-    def register_dialect(self, sql_dialect: str | None) -> None:
+    def register_dialect(self, sql_dialect: str) -> None:
         if self.column_info_settings is not None:
             column_info_sql_dialect = self.column_info_settings.sql_dialect
             if sql_dialect is not None:

--- a/splink/internals/input_column.py
+++ b/splink/internals/input_column.py
@@ -170,8 +170,9 @@ class InputColumn:
     def __init__(
         self,
         raw_column_name_or_column_reference: str,
+        *,
         column_info_settings: ColumnInfoSettings = None,
-        sql_dialect: str = None,
+        sql_dialect: str,
     ):
         self.column_info_settings = copy(column_info_settings)
 

--- a/splink/internals/settings.py
+++ b/splink/internals/settings.py
@@ -300,11 +300,16 @@ class Settings:
                     get_columns_used_from_sql(br.blocking_rule_sql, br.sql_dialect)
                 )
 
-            used_by_brs = [InputColumn(c) for c in used_by_brs]
+            used_by_brs = [
+                InputColumn(c, sql_dialect=self._sql_dialect) for c in used_by_brs
+            ]
 
             used_by_brs = [c.unquote().name for c in used_by_brs]
             already_used_names = self._columns_used_by_comparisons
-            already_used = [InputColumn(c) for c in already_used_names]
+            already_used = [
+                InputColumn(c, sql_dialect=self._sql_dialect)
+                for c in already_used_names
+            ]
             already_used_names = [c.unquote().name for c in already_used]
 
             new_cols = list(set(used_by_brs) - set(already_used_names))

--- a/splink/internals/settings_validation/settings_column_cleaner.py
+++ b/splink/internals/settings_validation/settings_column_cleaner.py
@@ -140,7 +140,8 @@ class SettingsColumnCleaner:
     @property
     def uid(self):
         uid_as_tree = InputColumn(
-            self._settings_obj.column_info_settings.unique_id_column_name
+            self._settings_obj.column_info_settings.unique_id_column_name,
+            sql_dialect=self.sql_dialect,
         )
         return clean_list_of_column_names([uid_as_tree])
 

--- a/tests/test_input_column.py
+++ b/tests/test_input_column.py
@@ -20,7 +20,7 @@ class ColumnTestCase:
     input_column: str
     name_out: str
     alias: str
-    sql_dialect: str  # Assuming sql_dialect is passed as an argument
+    sql_dialect: str
 
     def __post_init__(self):
         # Retrieve dialect quotes
@@ -45,7 +45,7 @@ class ColumnTestCase:
 
 
 def test_input_column():
-    c = InputColumn("my_col")
+    c = InputColumn("my_col", sql_dialect="duckdb")
     assert c.name == '"my_col"'
     # Check we only unquote for a given column building instance
     assert c.unquote().name == "my_col"
@@ -56,12 +56,12 @@ def test_input_column():
     # Removes quotes for table name, column name and the alias
     assert c.unquote().l_tf_name_as_l == "l.tf_my_col AS tf_my_col_l"
 
-    c = InputColumn("SUR name")
+    c = InputColumn("SUR name", sql_dialect="duckdb")
     assert c.name == '"SUR name"'
     assert c.name_r == '"SUR name_r"'
     assert c.r_name_as_r == '"r"."SUR name" AS "SUR name_r"'
 
-    c = InputColumn("col['lat']")
+    c = InputColumn("col['lat']", sql_dialect="duckdb")
 
     identifier = """
     "col"['lat']
@@ -183,16 +183,16 @@ def test_illegal_names_error():
         "my test column",
     )
     for name in odd_but_legal_names:
-        InputColumn(name).name_l  # noqa: B018
+        InputColumn(name, sql_dialect="duckdb").name_l  # noqa: B018
 
     # Check some illegal names we want to raise ParserErrors
     illegal_names = ('sur "name"', '"sur" name', '"sur" name[0]', "sur \"name\"['lat']")
     for name in illegal_names:
         with pytest.raises((ValueError)):
-            InputColumn(name)
+            InputColumn(name, sql_dialect="duckdb")
 
     # TokenError
     token_errors = ('"sur" name"', 'sur"name')
     for name in token_errors:
         with pytest.raises(ValueError):
-            InputColumn(name)
+            InputColumn(name, sql_dialect="duckdb")

--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -91,7 +91,7 @@ def test_set_numeric_as_double():
 
 
 def test_add_pref_and_suffix():
-    dull = InputColumn("dull")
+    dull = InputColumn("dull", sql_dialect="duckdb")
     dull_l_r = ['"l"."dull" AS "dull_l"', '"r"."dull" AS "dull_r"']
     assert dull.l_r_names_as_l_r == dull_l_r
 
@@ -100,7 +100,7 @@ def test_add_pref_and_suffix():
     tf_dull_l_r = ['"l"."tf_dull" AS "tf_dull_l"', '"r"."tf_dull" AS "tf_dull_r"']
     assert dull.l_r_tf_names_as_l_r == tf_dull_l_r
 
-    ll = InputColumn("lat['long']")
+    ll = InputColumn("lat['long']", sql_dialect="duckdb")
     assert ll.name_l == "\"lat_l\"['long']"
 
     ll_tf_l_r = [
@@ -110,7 +110,7 @@ def test_add_pref_and_suffix():
 
     assert ll.l_r_tf_names_as_l_r == ll_tf_l_r
 
-    group = InputColumn("cluster")
+    group = InputColumn("cluster", sql_dialect="duckdb")
     assert group.name_l == '"cluster_l"'
     assert group.bf_name == '"bf_cluster"'
     group_l_r_names = ['"l"."cluster" AS "cluster_l"', '"r"."cluster" AS "cluster_r"']
@@ -124,5 +124,5 @@ def test_add_pref_and_suffix():
 
     cols = ["unique_id", "SUR name", "cluster"]
     out_cols = ['"unique_id"', '"SUR name"', '"cluster"']
-    cols_class = [InputColumn(c) for c in cols]
+    cols_class = [InputColumn(c, sql_dialect="duckdb") for c in cols]
     assert [c.name for c in cols_class] == out_cols


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add link 
An idea following on from #2309, to avoid such issues in the future.

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
This makes `InputColumn`'s `sql_dialect` argument non-optional, so that such objects are always dialected, as I don't believe we ever need them in a context where there is no dialect.

This is somewhat reminiscent of what we did for `Settings`, `Comparison` and `ComparisonLevel` in Splink 4, separating the dialect-agnostic user-facing `XCreator` objects (except in this case we don't have a user-facing version).

A point to note is that there may be some muddying between whether we mean sqlglot dialects (as in `InputColumn`) or our backend names. But that issue is separate, and bigger than this, so for now have not been too careful with that.

Let me know @RobinL if you see any issues with doing this.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


