### PR TITLE
Early return fixes #2332

### DIFF
--- a/splink/internals/sqlite/database_api.py
+++ b/splink/internals/sqlite/database_api.py
@@ -46,6 +46,8 @@ class SQLiteAPI(DatabaseAPI[sqlite3.Cursor]):
                     "See https://moj-analytical-services.github.io/splink/"
                     "topic_guides/backends.html#sqlite for more information"
                 ) from e
+        else:
+            return
 
         def wrap_func_with_str(func):
             def wrapped_func(str_l, str_r):


### PR DESCRIPTION
When register_udfs is set to False, add early return to avoid accessing unbounded local variables

### Type of PR

-  [x] BUG
-  [ ] FEAT
-  [ ] MAINT
-  [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->
Closes #2332 


### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
If `register_udfs` is set to False, returns early rather than attempt to register un-imported fuzzy match functions


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


