### PR TITLE
Pin versino of griffe to prevent docs build failure

### DIFF
--- a/scripts/docs-requirements.txt
+++ b/scripts/docs-requirements.txt
@@ -16,3 +16,4 @@ mkdocs-charts-plugin==0.0.10
 neoteroi-mkdocs==1.0.5
 mkdocs-video==1.5.0
 mkdocs-rss-plugin==1.15.0
+griffe==0.49.0

--- a/splink/internals/linker_components/table_management.py
+++ b/splink/internals/linker_components/table_management.py
@@ -191,7 +191,7 @@ class LinkerTableManagement:
 
         This method allows you to register a term frequency table in the Splink
         cache for a specific column. This table will then be used during linkage
-        rather than computing the term frequency table anew.
+        rather than computing the term frequency table anew from your input data.
 
         Args:
             input_data (AcceptableInputTableType): The data representing the term
@@ -209,8 +209,8 @@ class LinkerTableManagement:
         Examples:
             ```py
             tf_table = [
-                {"first_name": "Theodore", "tf_first_name": 0.012},
-                {"first_name": "Alfie", "tf_first_name": 0.013},
+                {"first_name": "theodore", "tf_first_name": 0.012},
+                {"first_name": "alfie", "tf_first_name": 0.013},
             ]
             tf_df = pd.DataFrame(tf_table)
             linker.table_management.register_term_frequency_lookup(tf_df,


### PR DESCRIPTION
The issue was that `griffe` recently (16th Aug) [released a new major version](https://pypi.org/project/griffe/1.0.0/)

I've now pinned

Here's a manual run showing this PR should fix:
https://github.com/moj-analytical-services/splink/actions/runs/10449426954