### PR TITLE
Fixing issue with reaonly filesystems

### DIFF
--- a/splink/internals/datasets/__init__.py
+++ b/splink/internals/datasets/__init__.py
@@ -149,7 +149,6 @@ class _SplinkDataSetsMeta(type):
     cache_dir = _cache_dir
 
     def __new__(cls, clsname, bases, attrs, datasets):
-        cls.cache_dir.mkdir(exist_ok=True)
         attributes = {}
         repr_text = "splink_datasets object with datasets:"
         for dataset_meta in datasets:
@@ -185,6 +184,7 @@ class _SplinkDataSetsMeta(type):
         cls, dataset_name, url, rows, unique_entities, description, data_format
     ):
         def lazyload_data(self):
+            cls.cache_dir.mkdir(exist_ok=True)
             file_loc = cls.cache_dir / f"{dataset_name}.{data_format}"
             if not cls.datafile_exists(file_loc):
                 print(f"downloading: {url}")  # noqa: T201


### PR DESCRIPTION
### Type of PR

- [X] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
closes #2356
<!--
  Add links to related issues/prs. For Example "closes #111"
-->



### Give a brief description for the solution you have provided
I have moved creating the data cache to be when the data is requested rather than on import. This will allow anyone using this on a readonly filesystem to be able to import an use the package.



### PR Checklist

- [X] Added documentation for changes
- [X] Added feature to example notebooks or tutorial (if appropriate)
- [X] Added tests (if appropriate)
- [X] Updated CHANGELOG.md (if appropriate)
- [X] Made changes based off the latest version of Splink
- [X] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [X] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


