### PR TITLE
Support duckdbpyrelation as input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- When using DuckDB, you can now pass `duckdb.DuckDBPyRelation`s as input tables to the `Linker` ([#2375](https://github.com/moj-analytical-services/splink/pull/2375))
+
 ### Fixed
 
 - Completeness chart now works correctly with indexed columns in spark ([#2309](https://github.com/moj-analytical-services/splink/pull/2309))

--- a/splink/internals/athena/database_api.py
+++ b/splink/internals/athena/database_api.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Sequence
+from typing import Any
 
 import awswrangler as wr
 import boto3
 import pandas as pd
 
-from ..database_api import AcceptableInputTableType, DatabaseAPI
+from ..database_api import DatabaseAPI
 from ..dialects import AthenaDialect
 from ..sql_transform import sqlglot_transform_sql
 from .athena_helpers.athena_transforms import cast_concat_as_varchar
@@ -250,17 +250,3 @@ class AthenaAPI(DatabaseAPI[dict[str, Any]]):
         except ImportError:
             pass
         return accepted_df_dtypes
-
-    def load_from_file(self, file_path: str) -> str:
-        raise NotImplementedError(
-            "Loading from file is not supported for Athena. "
-            "Please use the `table` method to load data."
-        )
-
-    def process_input_tables(
-        self, input_tables: Sequence[AcceptableInputTableType]
-    ) -> Sequence[AcceptableInputTableType]:
-        input_tables = super().process_input_tables(input_tables)
-        return [
-            self.load_from_file(t) if isinstance(t, str) else t for t in input_tables
-        ]

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Sequence, Union
+from typing import Union
 
 import duckdb
 import pandas as pd
@@ -14,7 +14,6 @@ from splink.internals.dialects import (
 from .dataframe import DuckDBDataFrame
 from .duckdb_helpers.duckdb_helpers import (
     create_temporary_duckdb_connection,
-    duckdb_load_from_file,
     validate_duckdb_connection,
 )
 
@@ -30,7 +29,7 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
 
     def __init__(
         self,
-        connection: Union[str, ddb_con] = ":memory:",
+        connection: Union[str, ddb_con] = ":default:",
         output_schema: str = None,
     ):
         super().__init__()
@@ -93,9 +92,6 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
             return False
         return True
 
-    def load_from_file(self, file_path: str) -> str:
-        return duckdb_load_from_file(file_path)
-
     def _execute_sql_against_backend(self, final_sql: str) -> duckdb.DuckDBPyRelation:
         return self._con.sql(final_sql)
 
@@ -110,11 +106,3 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         except ImportError:
             pass
         return accepted_df_dtypes
-
-    def process_input_tables(
-        self, input_tables: Sequence[AcceptableInputTableType]
-    ) -> Sequence[AcceptableInputTableType]:
-        input_tables = super().process_input_tables(input_tables)
-        return [
-            self.load_from_file(t) if isinstance(t, str) else t for t in input_tables
-        ]

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -29,7 +29,7 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
 
     def __init__(
         self,
-        connection: Union[str, ddb_con] = ":default:",
+        connection: Union[str, ddb_con] = ":memory:",
         output_schema: str = None,
     ):
         super().__init__()

--- a/splink/internals/duckdb/dataframe.py
+++ b/splink/internals/duckdb/dataframe.py
@@ -4,6 +4,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
+from duckdb import DuckDBPyRelation
 from pandas import DataFrame as pd_DataFrame
 
 from splink.internals.input_column import InputColumn
@@ -49,6 +50,13 @@ class DuckDBDataFrame(SplinkDataFrame):
             sql += f" limit {limit}"
 
         return self.db_api._execute_sql_against_backend(sql).to_df()
+
+    def as_duckdbpyrelation(self, limit: int = None) -> DuckDBPyRelation:
+        sql = f"select * from {self.physical_name}"
+        if limit:
+            sql += f" limit {limit}"
+
+        return self.db_api._execute_sql_against_backend(sql)
 
     def to_parquet(self, filepath, overwrite=False):
         if not overwrite:

--- a/splink/internals/duckdb/duckdb_helpers/duckdb_helpers.py
+++ b/splink/internals/duckdb/duckdb_helpers/duckdb_helpers.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import uuid
-from pathlib import Path
 
 import duckdb
 
@@ -26,7 +25,7 @@ def validate_duckdb_connection(connection, logger):
 
     connection = connection.lower()
 
-    if connection in [":memory:", ":temporary:"]:
+    if connection in [":memory:", ":temporary:", ":default:"]:
         return
 
     suffixes = (".duckdb", ".db")
@@ -49,15 +48,3 @@ def create_temporary_duckdb_connection(self):
     path = os.path.join(self._temp_dir.name, f"{fname}.duckdb")
     con = duckdb.connect(database=path, read_only=False)
     return con
-
-
-def duckdb_load_from_file(path: str) -> str:
-    file_functions = {
-        ".csv": f"read_csv_auto('{path}')",
-        ".parquet": f"read_parquet('{path}')",
-    }
-    file_ext = Path(path).suffix
-    if file_ext in file_functions.keys():
-        return file_functions[file_ext]
-    else:
-        return path

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -306,9 +306,11 @@ class Linker:
         input_tables: Sequence[AcceptableInputTableType],
         input_aliases: Optional[str | List[str]],
     ) -> Dict[str, SplinkDataFrame]:
+        input_tables_list = ensure_is_list(input_tables)
+
         if input_aliases is None:
             input_table_aliases = [
-                f"__splink__input_table_{i}" for i, _ in enumerate(input_tables)
+                f"__splink__input_table_{i}" for i, _ in enumerate(input_tables_list)
             ]
             overwrite = True
         else:

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -198,8 +198,8 @@ def test_link_only(input, source_l, source_r):
             id="DuckDB link from pandas df",
         ),
         pytest.param(
-            "./tests/datasets/fake_1000_from_splink_demos.csv",
-            id="DuckDB load from file",
+            duckdb.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv"),
+            id="DuckDB link from duckdbpyrelation",
         ),
         pytest.param(
             pa.Table.from_pandas(
@@ -219,7 +219,7 @@ def test_link_only(input, source_l, source_r):
     ],
 )
 @mark_with_dialects_including("duckdb")
-def test_duckdb_load_from_file(df):
+def test_duckdb_load_different_tablish_types(df):
     settings = get_settings_dict()
 
     db_api = DuckDBAPI()
@@ -323,19 +323,4 @@ def test_small_example_duckdb(tmp_path):
     blocking_rule = "l.dob = r.dob"
     linker.training.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
-    linker.inference.predict()
-
-
-@mark_with_dialects_including("duckdb")
-def test_duckdb_input_is_duckdbpyrelation():
-    df1 = duckdb.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df2 = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-
-    settings = SettingsCreator(
-        link_type="link_and_dedupe",
-        comparisons=[cl.ExactMatch("first_name")],
-        blocking_rules_to_generate_predictions=[block_on("first_name", "surname")],
-    )
-    db_api = DuckDBAPI(":default:")
-    linker = Linker([df1, df2], settings, db_api)
     linker.inference.predict()

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -1,5 +1,6 @@
 import os
 
+import duckdb
 import pandas as pd
 import pyarrow as pa
 import pyarrow.csv as pa_csv
@@ -8,10 +9,9 @@ import pytest
 
 import splink.internals.comparison_level_library as cll
 import splink.internals.comparison_library as cl
+from splink import DuckDBAPI, Linker, SettingsCreator, block_on
 from splink.blocking_analysis import count_comparisons_from_blocking_rule
 from splink.exploratory import completeness_chart, profile_columns
-from splink.internals.duckdb.database_api import DuckDBAPI
-from splink.internals.linker import Linker
 
 from .basic_settings import get_settings_dict, name_comparison
 from .decorator import mark_with_dialects_including
@@ -323,4 +323,19 @@ def test_small_example_duckdb(tmp_path):
     blocking_rule = "l.dob = r.dob"
     linker.training.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
+    linker.inference.predict()
+
+
+@mark_with_dialects_including("duckdb")
+def test_duckdb_input_is_duckdbpyrelation():
+    df1 = duckdb.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df2 = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    settings = SettingsCreator(
+        link_type="link_and_dedupe",
+        comparisons=[cl.ExactMatch("first_name")],
+        blocking_rules_to_generate_predictions=[block_on("first_name", "surname")],
+    )
+    db_api = DuckDBAPI()
+    linker = Linker([df1, df2], settings, db_api)
     linker.inference.predict()

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -332,6 +332,6 @@ def test_duckdb_input_is_duckdbpyrelation():
         comparisons=[cl.ExactMatch("first_name")],
         blocking_rules_to_generate_predictions=[block_on("first_name", "surname")],
     )
-    db_api = DuckDBAPI()
+    db_api = DuckDBAPI(connection=":default:")
     linker = Linker([df1, df2], settings, db_api)
     linker.inference.predict()

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -198,10 +198,6 @@ def test_link_only(input, source_l, source_r):
             id="DuckDB link from pandas df",
         ),
         pytest.param(
-            duckdb.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv"),
-            id="DuckDB link from duckdbpyrelation",
-        ),
-        pytest.param(
             pa.Table.from_pandas(
                 pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
             ),
@@ -323,4 +319,19 @@ def test_small_example_duckdb(tmp_path):
     blocking_rule = "l.dob = r.dob"
     linker.training.estimate_parameters_using_expectation_maximisation(blocking_rule)
 
+    linker.inference.predict()
+
+
+@mark_with_dialects_including("duckdb")
+def test_duckdb_input_is_duckdbpyrelation():
+    df1 = duckdb.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df2 = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    settings = SettingsCreator(
+        link_type="link_and_dedupe",
+        comparisons=[cl.ExactMatch("first_name")],
+        blocking_rules_to_generate_predictions=[block_on("first_name", "surname")],
+    )
+    db_api = DuckDBAPI()
+    linker = Linker([df1, df2], settings, db_api)
     linker.inference.predict()

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -336,6 +336,6 @@ def test_duckdb_input_is_duckdbpyrelation():
         comparisons=[cl.ExactMatch("first_name")],
         blocking_rules_to_generate_predictions=[block_on("first_name", "surname")],
     )
-    db_api = DuckDBAPI()
+    db_api = DuckDBAPI(":default:")
     linker = Linker([df1, df2], settings, db_api)
     linker.inference.predict()


### PR DESCRIPTION
Currently we don't support passing a `DuckDBPyRelation` (the object that most closely resembles a dataframe in the duckdb python API) into the linker.

That is, you can't do:


```python
in_df = con.read_parquet("mydf.parquet")
linker = Linker(in_df, settings, db_api)
```


This is bad because many users will go through pandas e.g. `df = pd.read_csv()` and pass df to `Linker`), which in inefficient and risks data typing issues

Users currently can do this, but it's not documented:


```python
linker = Linker("mydf.parquet", settings, db_api)
```

which under the hood uses duckdb natively to load in the parquet.  

This is also not completely desirable because it doesn't give the user any control over how `mydf.parquet` is read by duckdb.  This is particularly important for csv reads (e.g. passing `mydf.csv`) where the user may which to [specify types](https://duckdb.org/2024/08/19/duckdb-tricks-part-1#specifying-types-in-the-csv-loader)

This PR adds support for passing in a `DuckDBPyRelation`.

Note that, since the existing code was treating a `DuckDBPyRelation` the same as a pandas DataFrame, and both support being passed to `con.register`, the existing code actually worked already.

The only thing that was broken was that there was a seprate/independent bug where we weren't ensuring the input of tables was a list.

I have also added support for retrieving a  `DuckDBPyRelation` from SplinkDataFrame outputs from the duckdb linker with `as_duckdbpyrelation`

Finally, I have allowed the duckdb connection to be specified as `:default:`
It's used when the user doesn't bother to specify a connection, so for example when you run:
```
duckdb.read_parquet()
```
as opposed to
```
con.read_parquet()
```
the default connection is used.



This solves the problem that if you used `duckdb.read_parquet()` to load in a dataframe, and then passed it to a linker, you'd get an error:
```
InvalidInputException: Invalid Input Error: The relation you are attempting to register was not made from this connection
```

The solution is either:

```
con = duckdb.connect()
db_api = DuckdbAPI(connection=con)
df = con.read_parquet("myfile.parquet")
linker = Linker(df,settings,db_api)
```

or 

```
df = duckdb.read_parquet("myfile.parquet")
db_api = DuckDBAPI(":default:")
linker = Linker(df,settings,db_api)
```


