### PR TITLE
Allow a specific m and u probabilities to be fixed during training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - When using DuckDB, you can now pass `duckdb.DuckDBPyRelation`s as input tables to the `Linker` ([#2375](https://github.com/moj-analytical-services/splink/pull/2375))
+- It's now possible to fix values for `m` and `u` probabilities in the settings such that they are not updated/changed during training.  ([#2379](https://github.com/moj-analytical-services/splink/pull/2379))
 
 ### Fixed
 

--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -139,8 +139,8 @@ class ComparisonLevel:
         m_probability: float = None,
         u_probability: float = None,
         disable_tf_exact_match_detection: bool = False,
-        m_is_fixed: bool = False,
-        u_is_fixed: bool = False,
+        fix_m_probability: bool = False,
+        fix_u_probability: bool = False,
     ):
         self._sqlglot_dialect_name = sqlglot_dialect_name
 
@@ -159,8 +159,8 @@ class ComparisonLevel:
         self.default_m_probability: float | None = None
         self.default_u_probability: float | None = None
 
-        self._m_is_fixed = m_is_fixed
-        self._u_is_fixed = u_is_fixed
+        self._fix_m_probability = fix_m_probability
+        self._fix_u_probability = fix_u_probability
 
         # TODO: control this in comparison getter setter ?
         # These will be set when the ComparisonLevel is passed into a Comparison

--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -139,6 +139,8 @@ class ComparisonLevel:
         m_probability: float = None,
         u_probability: float = None,
         disable_tf_exact_match_detection: bool = False,
+        m_is_fixed: bool = False,
+        u_is_fixed: bool = False,
     ):
         self._sqlglot_dialect_name = sqlglot_dialect_name
 
@@ -156,6 +158,9 @@ class ComparisonLevel:
         self._u_probability: float | None | str = u_probability
         self.default_m_probability: float | None = None
         self.default_u_probability: float | None = None
+
+        self._m_is_fixed = m_is_fixed
+        self._u_is_fixed = u_is_fixed
 
         # TODO: control this in comparison getter setter ?
         # These will be set when the ComparisonLevel is passed into a Comparison

--- a/splink/internals/comparison_level_creator.py
+++ b/splink/internals/comparison_level_creator.py
@@ -80,6 +80,8 @@ class ComparisonLevelCreator(ABC):
         is_null_level: UnsuppliedNoneOr[bool] = unsupplied_option,
         label_for_charts: UnsuppliedNoneOr[str] = unsupplied_option,
         disable_tf_exact_match_detection: UnsuppliedNoneOr[bool] = unsupplied_option,
+        fix_m_probability: UnsuppliedNoneOr[bool] = unsupplied_option,
+        fix_u_probability: UnsuppliedNoneOr[bool] = unsupplied_option,
     ) -> "ComparisonLevelCreator":
         """
         Configure the comparison level with options which are common to all
@@ -127,6 +129,12 @@ class ComparisonLevelCreator(ABC):
                 frequency adjustments are set, the corresponding adjustment will be
                 made using the u-value for _this_ level, rather than the usual case
                 where it is the u-value of the exact match level in the same comparison.
+                Default is equivalent to False.
+            fix_m_probability (bool, optional): If true, the m probability for this
+                level will be fixed and not estimated during training.
+                Default is equivalent to False.
+            fix_u_probability (bool, optional): If true, the u probability for this
+                level will be fixed and not estimated during training.
                 Default is equivalent to False.
         Returns:
             ComparisonLevelCreator: The instance of the ComparisonLevelCreator class

--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -189,6 +189,8 @@ class CustomLevel(ComparisonLevelCreator):
                 "tf_minimum_u_value",
                 "label_for_charts",
                 "disable_tf_exact_match_detection",
+                "fix_m_probability",
+                "fix_u_probability",
             )
             # split dict in two depending whether or not entries are 'configurables'
             configurables = {

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -169,7 +169,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
 
-    if not cl._m_is_fixed and "m" not in training_fixed_probabilities:
+    if not cl._fix_m_probability and "m" not in training_fixed_probabilities:
         try:
             m_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -188,7 +188,7 @@ def populate_m_u_from_lookup(
                 cl._m_warning_sent = True
         cl.m_probability = m_probability
 
-    if not cl._u_is_fixed and "u" not in training_fixed_probabilities:
+    if not cl._fix_u_probability and "u" not in training_fixed_probabilities:
         try:
             u_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -169,7 +169,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
 
-    if "m" not in training_fixed_probabilities:
+    if not cl._fix_m_probability and "m" not in training_fixed_probabilities:
         try:
             m_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -188,7 +188,7 @@ def populate_m_u_from_lookup(
                 cl._m_warning_sent = True
         cl.m_probability = m_probability
 
-    if "u" not in training_fixed_probabilities:
+    if not cl._fix_u_probability and "u" not in training_fixed_probabilities:
         try:
             u_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -169,7 +169,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
 
-    if not cl._fix_m_probability and "m" not in training_fixed_probabilities:
+    if "m" not in training_fixed_probabilities:
         try:
             m_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -188,7 +188,7 @@ def populate_m_u_from_lookup(
                 cl._m_warning_sent = True
         cl.m_probability = m_probability
 
-    if not cl._fix_u_probability and "u" not in training_fixed_probabilities:
+    if "u" not in training_fixed_probabilities:
         try:
             u_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -169,7 +169,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
 
-    if "m" not in training_fixed_probabilities:
+    if not cl._m_is_fixed and "m" not in training_fixed_probabilities:
         try:
             m_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -188,7 +188,7 @@ def populate_m_u_from_lookup(
                 cl._m_warning_sent = True
         cl.m_probability = m_probability
 
-    if "u" not in training_fixed_probabilities:
+    if not cl._u_is_fixed and "u" not in training_fixed_probabilities:
         try:
             u_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -491,9 +491,9 @@ class Linker:
 
         for cc in ccs:
             for cl in cc._comparison_levels_excluding_null:
-                if cl._has_estimated_u_values:
+                if cl._has_estimated_u_values and not cl._fix_u_probability:
                     cl.u_probability = cl._trained_u_median
-                if cl._has_estimated_m_values:
+                if cl._has_estimated_m_values and not cl._fix_m_probability:
                     cl.m_probability = cl._trained_m_median
 
     def _raise_error_if_necessary_waterfall_columns_not_computed(self):

--- a/splink/internals/m_from_labels.py
+++ b/splink/internals/m_from_labels.py
@@ -62,11 +62,12 @@ def estimate_m_from_pairwise_labels(linker: "Linker", table_name: str) -> None:
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in linker._settings_obj.comparisons:
         for cl in cc._comparison_levels_excluding_null:
-            append_m_probability_to_comparison_level_trained_probabilities(
-                cl,
-                m_u_records_lookup,
-                cc.output_column_name,
-                "estimate m from pairwise labels",
-            )
+            if not cl._fix_m_probability:
+                append_m_probability_to_comparison_level_trained_probabilities(
+                    cl,
+                    m_u_records_lookup,
+                    cc.output_column_name,
+                    "estimate m from pairwise labels",
+                )
 
     linker._populate_m_u_from_trained_values()

--- a/splink/internals/m_u_records_to_parameters.py
+++ b/splink/internals/m_u_records_to_parameters.py
@@ -53,6 +53,9 @@ def append_u_probability_to_comparison_level_trained_probabilities(
 ) -> None:
     cl = comparison_level
 
+    if cl._fix_u_probability:
+        return
+
     try:
         u_probability = m_u_records_lookup[output_column_name][
             cl.comparison_vector_value

--- a/splink/internals/m_u_records_to_parameters.py
+++ b/splink/internals/m_u_records_to_parameters.py
@@ -53,9 +53,6 @@ def append_u_probability_to_comparison_level_trained_probabilities(
 ) -> None:
     cl = comparison_level
 
-    if cl._fix_u_probability:
-        return
-
     try:
         u_probability = m_u_records_lookup[output_column_name][
             cl.comparison_vector_value

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -1,8 +1,9 @@
 import pandas as pd
 import pytest
 
+import splink.comparison_level_library as cll
 import splink.internals.comparison_library as cl
-from splink.internals.duckdb.database_api import DuckDBAPI
+from splink import DuckDBAPI, SettingsCreator, block_on
 from splink.internals.exceptions import EMTrainingException
 from splink.internals.linker import Linker
 
@@ -105,3 +106,77 @@ def test_estimate_without_term_frequencies():
 
     for r in compare.to_dict(orient="records"):
         assert r["m_probability_e"] == pytest.approx(r["m_probability_a"])
+
+
+def test_fix_probabilities():
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+
+    first_name_comparison = cl.CustomComparison(
+        comparison_levels=[
+            cll.NullLevel("first_name"),
+            cll.ExactMatchLevel("first_name").configure(
+                m_probability=0.9999,
+                fix_m_probability=True,
+                u_probability=0.001,
+                fix_u_probability=True,
+            ),
+            {
+                "sql_condition": 'levenshtein("first_name_l", "first_name_r") <= 2',
+                "label_for_charts": "Levenshtein distance of first_name <= 2",
+                "m_probability": 0.88,
+                "is_null_level": False,
+                "fix_m_probability": True,
+            },
+            cll.ElseLevel().configure(
+                m_probability=0.001,
+                fix_m_probability=False,
+                u_probability=0.9,
+                fix_u_probability=False,
+            ),
+        ]
+    )
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            first_name_comparison,
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("first_name"),
+            block_on("dob"),
+        ],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    linker = Linker(df, settings, db_api=DuckDBAPI())
+
+    linker.training.estimate_u_using_random_sampling(max_pairs=1e4)
+
+    linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))
+
+    model = linker.misc.save_model_to_json()
+
+    first_name_comparison = model["comparisons"][0]
+    exact_match_level = first_name_comparison["comparison_levels"][1]
+    levenshtein_level = first_name_comparison["comparison_levels"][2]
+
+    assert (
+        exact_match_level["m_probability"] == 0.9999
+    ), "Exact match m_probability is not as expected"
+    assert (
+        exact_match_level["u_probability"] == 0.001
+    ), "Exact match u_probability is not as expected"
+    assert (
+        levenshtein_level["m_probability"] == 0.88
+    ), "Levenshtein m_probability is not as expected"
+
+    # Check that non-fixed probabilities on the else level have changed
+    else_level = first_name_comparison["comparison_levels"][3]
+
+    assert (
+        else_level["m_probability"] != 0.001
+    ), "Else level m_probability should have changed"
+    assert (
+        else_level["u_probability"] != 0.9
+    ), "Else level u_probability should have changed"


### PR DESCRIPTION
This PR allow the user to fix m and u probabilities when the model is created such that they aren't changed when training is run.

This is a fairly fairly common requirement e.g. [here](https://github.com/moj-analytical-services/splink/issues/2068) [here](https://github.com/moj-analytical-services/splink/discussions/2362) and [here](https://github.com/moj-analytical-services/splink/discussions/2275).  Because in some cases the user has prior knowledge of specific m and u values and wishes to fix them during training.





Suggested API:

```python
import splink.comparison_level_library as cll
import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets
from splink.datasets import splink_dataset_labels

labels = splink_dataset_labels.fake_1000_labels

db_api = DuckDBAPI()

first_name_comparison = cl.CustomComparison(
    comparison_levels=[
        cll.NullLevel("first_name"),
        cll.ExactMatchLevel("first_name").configure(
            m_probability=0.9999,
            fix_m_probability=True,
            u_probability=0.7,
            fix_u_probability=True,
        ),
        {
            "sql_condition": 'levenshtein("first_name_l", "first_name_r") <= 2',
            "label_for_charts": "Levenshtein distance of first_name <= 2",
            "m_probability": 0.88,
            "is_null_level": False,
            "fix_m_probability": True,
        },
        cll.ElseLevel()
    ]
)
settings = SettingsCreator(
    link_type="dedupe_only",
    comparisons=[
        first_name_comparison,
        cl.ExactMatch("surname"),
        cl.ExactMatch("dob"),
        cl.ExactMatch("city"),
        cl.ExactMatch("email"),
    ],
    blocking_rules_to_generate_predictions=[
        block_on("first_name"),
        block_on("dob"),
    ],
    additional_columns_to_retain=["cluster"],
)

linker = Linker(splink_datasets.fake_1000, settings, db_api)

linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))

labels_sdf = linker.table_management.register_labels_table(labels)
linker.training.estimate_m_from_pairwise_labels(labels_sdf)
linker.training.estimate_m_from_label_column("cluster")

linker.visualisations.m_u_parameters_chart()

```

Closes https://github.com/moj-analytical-services/splink/issues/2068