### PR TITLE
Fix performance issue with exploding blocking rules

### DIFF
--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -448,7 +448,6 @@ class ExplodingBlockingRule(BlockingRule):
                 " called."
             )
 
-        unique_id_col = unique_id_input_column
         unique_id_input_columns = combine_unique_id_input_columns(
             source_dataset_input_column, unique_id_input_column
         )
@@ -463,10 +462,6 @@ class ExplodingBlockingRule(BlockingRule):
                 {uid_l_expr} as join_key_l,
                 {uid_r_expr} as join_key_r
             from {exploded_id_pair_table.physical_name} as pairs
-            left join {input_tablename_l} as l
-                on pairs.{unique_id_col.name_l}={uid_l_expr}
-            left join {input_tablename_r} as r
-                on pairs.{unique_id_col.name_r}={uid_r_expr}
         """
         return sql
 

--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -448,20 +448,13 @@ class ExplodingBlockingRule(BlockingRule):
                 " called."
             )
 
-        unique_id_input_columns = combine_unique_id_input_columns(
-            source_dataset_input_column, unique_id_input_column
-        )
-
-        uid_l_expr = _composite_unique_id_from_nodes_sql(unique_id_input_columns, "l")
-        uid_r_expr = _composite_unique_id_from_nodes_sql(unique_id_input_columns, "r")
-
         exploded_id_pair_table = self.exploded_id_pair_table
         sql = f"""
             select
                 '{self.match_key}' as match_key,
-                {uid_l_expr} as join_key_l,
-                {uid_r_expr} as join_key_r
-            from {exploded_id_pair_table.physical_name} as pairs
+                {unique_id_input_column.name_l} as join_key_l,
+                {unique_id_input_column.name_r} as join_key_r
+            from {exploded_id_pair_table.physical_name}
         """
         return sql
 


### PR DESCRIPTION
Closes https://github.com/moj-analytical-services/splink/issues/2384

@aymonwuolanne look ok to you?


```python

import pandas as pd

import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator

data_1 = [
    {"unique_id": 1, "first_name": "John", "surname": "Doe", "postcode": ["A", "B"]},
    {"unique_id": 2, "first_name": "John", "surname": "Doe", "postcode": ["B"]},
]

data_2 = [
    {"unique_id": 3, "first_name": "John", "surname": "Smith", "postcode": ["A"]},
    {"unique_id": 4, "first_name": "John", "surname": "Smith", "postcode": ["Z"]},
]

df_1 = pd.DataFrame(data_1)
df_2 = pd.DataFrame(data_2)


settings = SettingsCreator(
    link_type="link_only",
    blocking_rules_to_generate_predictions=[
        {
            "blocking_rule": "l.postcode = r.postcode and l.first_name = r.first_name",
            "arrays_to_explode": ["postcode"],
        },
        "l.surname = r.surname",
    ],
    comparisons=[
        cl.ExactMatch("first_name"),
        cl.ExactMatch("surname"),
        cl.ExactMatch("postcode"),
    ],
    retain_intermediate_calculation_columns=True,
)
db_api = DuckDBAPI()

linker = Linker(
    [df_1, df_2], settings, db_api=db_api, input_table_aliases=["l", "r"]
)

linker._debug_mode = True
linker.inference.predict().as_pandas_dataframe()

```

and a more complex example below