### PR TITLE
Fix ColumnsReversedLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Match weight and m and u probabilities charts now have improved tooltips ([#2392](https://github.com/moj-analytical-services/splink/pull/2392))
 
+### Fixed
+
+- Fixed issue where `ColumnsReversedLevel` required equality on both columns ([#2395](https://github.com/moj-analytical-services/splink/pull/2395))
+
 ## [4.0.1] - 2024-09-06
 
 ### Added

--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -333,16 +333,23 @@ class ColumnsReversedLevel(ComparisonLevelCreator):
         self,
         col_name_1: Union[str, ColumnExpression],
         col_name_2: Union[str, ColumnExpression],
+        symmetrical: bool = False,
     ):
         """Represents a comparison level where the columns are reversed. For example,
         if surname is in the forename field and vice versa
 
+        By default, col_l = col_r.  If the symmetrical argument is True, then
+        col_l = col_r AND col_r = col_l.
+
         Args:
             col_name_1 (str): First column, e.g. forename
             col_name_2 (str): Second column, e.g. surname
+            symmetrical (bool): If True, equality is required in in both directions.
+                Default is False.
         """
         self.col_expression_1 = ColumnExpression.instantiate_if_str(col_name_1)
         self.col_expression_2 = ColumnExpression.instantiate_if_str(col_name_2)
+        self.symmetrical = symmetrical
 
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         self.col_expression_1.sql_dialect = sql_dialect
@@ -350,14 +357,18 @@ class ColumnsReversedLevel(ComparisonLevelCreator):
         col_1 = self.col_expression_1
         col_2 = self.col_expression_2
 
-        return (
-            f"{col_1.name_l} = {col_2.name_r} " f"AND {col_1.name_r} = {col_2.name_l}"
-        )
+        if self.symmetrical:
+            return (
+                f"{col_1.name_l} = {col_2.name_r} AND {col_1.name_r} = {col_2.name_l}"
+            )
+        else:
+            return f"{col_1.name_l} = {col_2.name_r}"
 
     def create_label_for_charts(self) -> str:
         col_1 = self.col_expression_1
         col_2 = self.col_expression_2
-        return f"Match on reversed cols: {col_1.label} and {col_2.label}"
+        direction = "both directions" if self.symmetrical else "one direction"
+        return f"Match on reversed cols: {col_1.label} and {col_2.label} ({direction})"
 
 
 class LevenshteinLevel(ComparisonLevelCreator):

--- a/splink/internals/comparison_library.py
+++ b/splink/internals/comparison_library.py
@@ -1052,7 +1052,9 @@ class ForenameSurnameComparison(ComparisonCreator):
             )
 
         levels.append(
-            cll.ColumnsReversedLevel(forename_col_expression, surname_col_expression)
+            cll.ColumnsReversedLevel(
+                forename_col_expression, surname_col_expression, symmetrical=True
+            )
         )
 
         for threshold in self.jaro_winkler_thresholds:


### PR DESCRIPTION
Fixing issue described in following discussino:

Question re: `cll.ColumnsReversedLevel`

At the moment `cll.ColumnsReversedLevel("first_name", "surname").get_comparison_level("duckdb").as_dict()` yields:

```{'sql_condition': '"first_name_l" = "surname_r" AND "first_name_r" = "surname_l"',
 'label_for_charts': 'Match on reversed cols: first_name and surname'}```

But one real-world application would be to set up:

* a first name comparison something like :
    * exact match first name
    * exact match first name to surname
    * fuzzy match first name
    * else
* a surname comparison somehting like:
    * exact match surname
    * exact match surname to first name
    * fuzzy match surname
    * else

with that in mind, in that example I think you’d want a ‘one way’ columns reversed level

i.e.

```{'sql_condition': '"first_name_l" = "surname_r"',
 'label_for_charts': 'Match on reversed cols: first_name and surname'}```

Have I got that right?  I think otherwise it’s effectively an ‘exact match full name with a reversal’, which can be used in a comparison that tries to encompass the full name (`cl.ForenameSurnameComparison`) but not if names are split out into multiple comparisons

My proposed solution would be to add a ‘symmetric’ argument to the `ColumnsReversedLevel` which by dfault is False.  If activated, it compares in both directions