### PR TITLE
Add `is_in_level` and `compute_comparison_vector_value` testing functions to internals

### DIFF
--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -73,7 +73,15 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
         elif isinstance(input, list):
-            input = pd.DataFrame.from_records(input)
+            import pyarrow as pa
+
+            try:
+                # pyarrow preserves types better than pandas
+                import pyarrow as pa
+
+                input = pa.Table.from_pylist(input)
+            except ImportError:
+                input = pd.DataFrame.from_records(input)
 
         self._con.register(table_name, input)
 

--- a/splink/internals/settings.py
+++ b/splink/internals/settings.py
@@ -37,7 +37,7 @@ class ColumnInfoSettings:
     comparison_vector_value_column_prefix: str
     unique_id_column_name: str
     _source_dataset_column_name: str
-    _source_dataset_column_name_is_required: str
+    _source_dataset_column_name_is_required: bool
     sql_dialect: str
 
     @property
@@ -330,7 +330,7 @@ class Settings:
             for c in cols
         ]
 
-    def _get_source_dataset_column_name_is_required(self):
+    def _get_source_dataset_column_name_is_required(self) -> bool:
         return self._link_type not in ["dedupe_only"]
 
     @property

--- a/splink/internals/spark/database_api.py
+++ b/splink/internals/spark/database_api.py
@@ -67,7 +67,7 @@ class SparkAPI(DatabaseAPI[spark_df]):
         if isinstance(input, dict):
             input = pd.DataFrame(input)
         elif isinstance(input, list):
-            input = pd.DataFrame.from_records(input)
+            input = self.spark.createDataFrame(input)
 
         if isinstance(input, pd.DataFrame):
             input = self._clean_pandas_df(input)

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -1,0 +1,117 @@
+from typing import Any, Dict
+
+import sqlglot
+import sqlglot.expressions
+
+from splink.internals.comparison_creator import ComparisonCreator
+from splink.internals.comparison_level_creator import ComparisonLevelCreator
+from splink.internals.database_api import DatabaseAPI
+from splink.internals.pipeline import CTEPipeline
+
+
+def _set_quoted(node):
+    if hasattr(node, "quoted"):
+        node.set("quoted", True)
+    return node
+
+
+def _replace_identifier(node, replacements: Dict[str, Any], dialect: str):
+    """Replace identifiers in a sqlglot node with literal values.
+
+    Args:
+        node: A sqlglot node
+        replacements: A dictionary mapping column names to their literal values
+        dialect: The SQL dialect to use for parsing
+
+    Returns:
+        A new sqlglot node with identifiers replaced by literal values
+    """
+    node_quoted = node.transform(lambda x: _set_quoted(x))
+    for key, replacement in replacements.items():
+        parsed_key = sqlglot.parse_one(key, dialect=dialect)
+
+        parsed_key_quoted = parsed_key.transform(lambda x: _set_quoted(x))
+
+        if node_quoted == parsed_key_quoted:
+            if replacement is None:
+                return sqlglot.exp.null()
+            elif isinstance(replacement, str):
+                return sqlglot.exp.Literal(this=replacement, is_string=True)
+            else:
+                return sqlglot.exp.Literal(this=f"{replacement}", is_string=False)
+
+    return node
+
+
+def is_in_level(
+    comparison_level: ComparisonLevelCreator,
+    literal_values: Dict[str, Any],
+    db_api: DatabaseAPI,
+) -> bool:
+    """Check if a set of literal values satisfies a comparison level condition.
+
+    Args:
+        comparison_level: A ComparisonLevelCreator object
+        literal_values: A dictionary mapping column names to their literal values
+        db_api: A DatabaseAPI object for executing SQL queries
+
+    Returns:
+        Whether the literal values satisfy the comparison level condition
+    """
+    sqlglot_dialect = db_api.sql_dialect.sqlglot_name
+    sql_cond = comparison_level.get_comparison_level(sqlglot_dialect).sql_condition
+    if sql_cond == "ELSE":
+        return True
+
+    tree = sqlglot.parse_one(sql_cond, dialect=sqlglot_dialect)
+
+    new_tree = tree.transform(
+        lambda node: _replace_identifier(node, literal_values, sqlglot_dialect)
+    )
+    sql_to_evaluate = new_tree.sql(dialect=sqlglot_dialect)
+    sql_to_evaluate = f"SELECT {sql_to_evaluate} as result"
+
+    pipeline = CTEPipeline()
+    pipeline.enqueue_sql(sql_to_evaluate, "__splink__is_in_level")
+    res = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+    res = res.as_record_dict()[0]["result"]
+    return res
+
+
+def compute_comparison_vector_value(
+    comparison: ComparisonCreator, literal_values: Dict[str, Any], db_api: DatabaseAPI
+) -> Dict[str, Any]:
+    """Compute the comparison vector value for a set of literal values.
+
+    Args:
+        comparison: A ComparisonCreator object
+        literal_values: A dictionary mapping column names to their literal values
+        db_api: A DatabaseAPI object for executing SQL queries
+
+    Returns:
+        A dictionary containing the comparison vector value and label for charts
+    """
+    sqlglot_dialect = db_api.sql_dialect.sqlglot_name
+
+    creator_levels = comparison.create_comparison_levels()
+
+    instantiated_levels = comparison.get_comparison(sqlglot_dialect).comparison_levels
+
+    levels = [
+        {
+            "creator": c,
+            "comparison_vector_value": inst.comparison_vector_value,
+            "label_for_charts": inst.label_for_charts,
+        }
+        for c, inst in zip(creator_levels, instantiated_levels)
+    ]
+
+    for d in levels:
+        in_level = is_in_level(d["creator"], literal_values, db_api)
+        if in_level:
+            return {
+                "comparison_vector_value": d["comparison_vector_value"],
+                "label_for_charts": d["label_for_charts"],
+            }
+
+    return {}

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -50,7 +50,7 @@ def comparison_vector_value(
         unique_id_column_name="unique_id",
         _source_dataset_column_name="dataset",
         _source_dataset_column_name_is_required=False,
-        sql_dialect=db_api.sql_dialect,
+        sql_dialect=db_api.sql_dialect.name,
     )
 
     comparison_internal = comparison.get_comparison(sqlglot_dialect)

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -12,11 +12,11 @@ def is_in_level(
     comparison_level: ComparisonLevelCreator,
     literal_values: Dict[str, Any] | List[Dict[str, Any]],
     db_api: DatabaseAPISubClass,
-) -> List[bool]:
+) -> bool | List[bool]:
     sqlglot_dialect = db_api.sql_dialect.sqlglot_name
     sql_cond = comparison_level.get_comparison_level(sqlglot_dialect).sql_condition
     if sql_cond == "ELSE":
-        return [True] * len(ensure_is_list(literal_values))
+        sql_cond = "TRUE"
 
     table_name = f"__splink__temp_table_{ascii_uid(8)}"
     literal_values_list = ensure_is_list(literal_values)

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -2,14 +2,17 @@ from typing import Any, Dict
 
 import sqlglot
 import sqlglot.expressions
+from sqlglot.expressions import Expression
 
 from splink.internals.comparison_creator import ComparisonCreator
 from splink.internals.comparison_level_creator import ComparisonLevelCreator
-from splink.internals.database_api import DatabaseAPI
+from splink.internals.database_api import (
+    DatabaseAPISubClass,
+)
 from splink.internals.pipeline import CTEPipeline
 
 
-def _set_quoted(node):
+def _set_quoted(node: Expression) -> Expression:
     if hasattr(node, "quoted"):
         node.set("quoted", True)
     return node
@@ -46,7 +49,7 @@ def _replace_identifier(node, replacements: Dict[str, Any], dialect: str):
 def is_in_level(
     comparison_level: ComparisonLevelCreator,
     literal_values: Dict[str, Any],
-    db_api: DatabaseAPI,
+    db_api: DatabaseAPISubClass,
 ) -> bool:
     """Check if a set of literal values satisfies a comparison level condition.
 
@@ -74,12 +77,13 @@ def is_in_level(
     pipeline = CTEPipeline()
     pipeline.enqueue_sql(sql_to_evaluate, "__splink__is_in_level")
     res = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-    res = res.as_record_dict()[0]["result"]
-    return res
+    return bool(res.as_record_dict()[0]["result"])
 
 
 def compute_comparison_vector_value(
-    comparison: ComparisonCreator, literal_values: Dict[str, Any], db_api: DatabaseAPI
+    comparison: ComparisonCreator,
+    literal_values: Dict[str, Any],
+    db_api: DatabaseAPISubClass,
 ) -> Dict[str, Any]:
     """Compute the comparison vector value for a set of literal values.
 

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List
 
 from splink.internals.comparison_creator import ComparisonCreator

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -1,10 +1,9 @@
 from typing import Any, Dict
 
-import pyarrow as pa
-
 from splink.internals.comparison_creator import ComparisonCreator
 from splink.internals.comparison_level_creator import ComparisonLevelCreator
 from splink.internals.database_api import DatabaseAPISubClass
+from splink.internals.misc import ascii_uid
 from splink.internals.pipeline import CTEPipeline
 
 
@@ -18,10 +17,8 @@ def is_in_level(
     if sql_cond == "ELSE":
         return True
 
-    pa_table = pa.Table.from_pydict({k: [v] for k, v in literal_values.items()})
-
-    table_name = "__splink__temp_table"
-    db_api._table_registration(pa_table, table_name)
+    table_name = f"__splink__temp_table_{ascii_uid(8)}"
+    db_api._table_registration([literal_values], table_name)
 
     sql_to_evaluate = f"SELECT {sql_cond} as result FROM {table_name}"
 

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -1,49 +1,11 @@
 from typing import Any, Dict
 
-import sqlglot
-import sqlglot.expressions
-from sqlglot.expressions import Expression
+import pyarrow as pa
 
 from splink.internals.comparison_creator import ComparisonCreator
 from splink.internals.comparison_level_creator import ComparisonLevelCreator
-from splink.internals.database_api import (
-    DatabaseAPISubClass,
-)
+from splink.internals.database_api import DatabaseAPISubClass
 from splink.internals.pipeline import CTEPipeline
-
-
-def _set_quoted(node: Expression) -> Expression:
-    if hasattr(node, "quoted"):
-        node.set("quoted", True)
-    return node
-
-
-def _replace_identifier(node, replacements: Dict[str, Any], dialect: str):
-    """Replace identifiers in a sqlglot node with literal values.
-
-    Args:
-        node: A sqlglot node
-        replacements: A dictionary mapping column names to their literal values
-        dialect: The SQL dialect to use for parsing
-
-    Returns:
-        A new sqlglot node with identifiers replaced by literal values
-    """
-    node_quoted = node.transform(lambda x: _set_quoted(x))
-    for key, replacement in replacements.items():
-        parsed_key = sqlglot.parse_one(key, dialect=dialect)
-
-        parsed_key_quoted = parsed_key.transform(lambda x: _set_quoted(x))
-
-        if node_quoted == parsed_key_quoted:
-            if replacement is None:
-                return sqlglot.exp.null()
-            elif isinstance(replacement, str):
-                return sqlglot.exp.Literal(this=replacement, is_string=True)
-            else:
-                return sqlglot.exp.Literal(this=f"{replacement}", is_string=False)
-
-    return node
 
 
 def is_in_level(
@@ -51,32 +13,24 @@ def is_in_level(
     literal_values: Dict[str, Any],
     db_api: DatabaseAPISubClass,
 ) -> bool:
-    """Check if a set of literal values satisfies a comparison level condition.
-
-    Args:
-        comparison_level: A ComparisonLevelCreator object
-        literal_values: A dictionary mapping column names to their literal values
-        db_api: A DatabaseAPI object for executing SQL queries
-
-    Returns:
-        Whether the literal values satisfy the comparison level condition
-    """
     sqlglot_dialect = db_api.sql_dialect.sqlglot_name
     sql_cond = comparison_level.get_comparison_level(sqlglot_dialect).sql_condition
     if sql_cond == "ELSE":
         return True
 
-    tree = sqlglot.parse_one(sql_cond, dialect=sqlglot_dialect)
+    pa_table = pa.Table.from_pydict({k: [v] for k, v in literal_values.items()})
 
-    new_tree = tree.transform(
-        lambda node: _replace_identifier(node, literal_values, sqlglot_dialect)
-    )
-    sql_to_evaluate = new_tree.sql(dialect=sqlglot_dialect)
-    sql_to_evaluate = f"SELECT {sql_to_evaluate} as result"
+    table_name = "__splink__temp_table"
+    db_api._table_registration(pa_table, table_name)
+
+    sql_to_evaluate = f"SELECT {sql_cond} as result FROM {table_name}"
 
     pipeline = CTEPipeline()
     pipeline.enqueue_sql(sql_to_evaluate, "__splink__is_in_level")
     res = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+
+    db_api.delete_table_from_database(table_name)
+
     return bool(res.as_record_dict()[0]["result"])
 
 
@@ -85,20 +39,8 @@ def compute_comparison_vector_value(
     literal_values: Dict[str, Any],
     db_api: DatabaseAPISubClass,
 ) -> Dict[str, Any]:
-    """Compute the comparison vector value for a set of literal values.
-
-    Args:
-        comparison: A ComparisonCreator object
-        literal_values: A dictionary mapping column names to their literal values
-        db_api: A DatabaseAPI object for executing SQL queries
-
-    Returns:
-        A dictionary containing the comparison vector value and label for charts
-    """
     sqlglot_dialect = db_api.sql_dialect.sqlglot_name
-
     creator_levels = comparison.create_comparison_levels()
-
     instantiated_levels = comparison.get_comparison(sqlglot_dialect).comparison_levels
 
     levels = [

--- a/splink/internals/testing.py
+++ b/splink/internals/testing.py
@@ -5,6 +5,7 @@ from splink.internals.comparison_level_creator import ComparisonLevelCreator
 from splink.internals.database_api import DatabaseAPISubClass
 from splink.internals.misc import ascii_uid
 from splink.internals.pipeline import CTEPipeline
+from splink.internals.settings import ColumnInfoSettings
 
 
 def is_in_level(
@@ -37,24 +38,47 @@ def compute_comparison_vector_value(
     db_api: DatabaseAPISubClass,
 ) -> Dict[str, Any]:
     sqlglot_dialect = db_api.sql_dialect.sqlglot_name
-    creator_levels = comparison.create_comparison_levels()
-    instantiated_levels = comparison.get_comparison(sqlglot_dialect).comparison_levels
 
-    levels = [
-        {
-            "creator": c,
-            "comparison_vector_value": inst.comparison_vector_value,
-            "label_for_charts": inst.label_for_charts,
-        }
-        for c, inst in zip(creator_levels, instantiated_levels)
-    ]
+    mock_column_info_settings = ColumnInfoSettings(
+        bayes_factor_column_prefix="bm_",
+        term_frequency_adjustment_column_prefix="tf_",
+        comparison_vector_value_column_prefix="cv_",
+        unique_id_column_name="unique_id",
+        _source_dataset_column_name="dataset",
+        _source_dataset_column_name_is_required=False,
+        sql_dialect=db_api.sql_dialect,
+    )
 
-    for d in levels:
-        in_level = is_in_level(d["creator"], literal_values, db_api)
-        if in_level:
-            return {
-                "comparison_vector_value": d["comparison_vector_value"],
-                "label_for_charts": d["label_for_charts"],
-            }
+    comparison_internal = comparison.get_comparison(sqlglot_dialect)
 
-    return {}
+    comparison_internal.column_info_settings = mock_column_info_settings
+
+    case_statement = comparison_internal._case_statement
+
+    table_name = f"__splink__temp_table_{ascii_uid(8)}"
+    db_api._table_registration([literal_values], table_name)
+
+    sql_to_evaluate = f"SELECT {case_statement}  FROM {table_name}"
+
+    pipeline = CTEPipeline()
+    pipeline.enqueue_sql(sql_to_evaluate, "__splink__compute_cvv")
+    res = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+
+    db_api.delete_table_from_database(table_name)
+
+    result_dict = res.as_record_dict()[0]
+    first_column_name = next(iter(result_dict))
+
+    result = result_dict[first_column_name]
+
+    instantiated_levels = comparison_internal.comparison_levels
+
+    cvv_label_lookup = {
+        level.comparison_vector_value: level.label_for_charts
+        for level in instantiated_levels
+    }
+
+    return {
+        "comparison_vector_value": result,
+        "label_for_charts": cvv_label_lookup.get(result, ""),
+    }

--- a/tests/test_testing_fns.py
+++ b/tests/test_testing_fns.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+
+from splink import DuckDBAPI
+from splink.comparison_level_library import (
+    AbsoluteDateDifferenceLevel,
+    ArrayIntersectLevel,
+    ElseLevel,
+    ExactMatchLevel,
+    NullLevel,
+)
+from splink.comparison_library import ArrayIntersectAtSizes, ExactMatch
+from splink.internals.testing import comparison_vector_value, is_in_level
+
+db_api = DuckDBAPI()
+
+
+def test_is_in_level():
+    test_cases = [
+        {
+            "level": ExactMatchLevel("name"),
+            "inputs": [
+                {"name_l": "John", "name_r": "John", "expected": True},
+                {"name_l": "John", "name_r": "Jane", "expected": False},
+            ],
+        },
+        {
+            "level": NullLevel("name"),
+            "inputs": [
+                {"name_l": None, "name_r": "John", "expected": True},
+                {"name_l": "John", "name_r": None, "expected": True},
+                {"name_l": "John", "name_r": "Jane", "expected": False},
+            ],
+        },
+        {
+            "level": AbsoluteDateDifferenceLevel(
+                "date", input_is_string=False, threshold=3, metric="day"
+            ),
+            "inputs": [
+                {
+                    "date_l": datetime(2023, 1, 1),
+                    "date_r": datetime(2023, 1, 3),
+                    "expected": True,
+                },
+                {
+                    "date_l": datetime(2023, 1, 1),
+                    "date_r": datetime(2023, 1, 5),
+                    "expected": False,
+                },
+            ],
+        },
+        {
+            "level": ArrayIntersectLevel("tags", 2),
+            "inputs": [
+                {"tags_l": [1, 2, 3], "tags_r": [2, 3, 4], "expected": True},
+                {"tags_l": [1, 2, 3], "tags_r": [4, 5, 6], "expected": False},
+            ],
+        },
+        {
+            "level": ElseLevel(),
+            "inputs": [
+                {"name_l": "John", "name_r": "Jane", "expected": True},
+            ],
+        },
+    ]
+
+    for case in test_cases:
+        inputs = [
+            {k: v for k, v in input_data.items() if k != "expected"}
+            for input_data in case["inputs"]
+        ]
+        expected = [input_data["expected"] for input_data in case["inputs"]]
+        results = is_in_level(case["level"], inputs, db_api)
+        assert results == expected
+
+
+def test_comparison_vector_value():
+    test_cases = [
+        {
+            "comparison": ExactMatch("name"),
+            "inputs": [
+                {
+                    "name_l": "John",
+                    "name_r": "John",
+                    "expected_value": 1,
+                    "expected_label": "Exact match on name",
+                },
+                {
+                    "name_l": "John",
+                    "name_r": "Jane",
+                    "expected_value": 0,
+                    "expected_label": "All other comparisons",
+                },
+                {
+                    "name_l": None,
+                    "name_r": "John",
+                    "expected_value": -1,
+                    "expected_label": "name is NULL",
+                },
+            ],
+        },
+        {
+            "comparison": ArrayIntersectAtSizes("tags", [3, 2, 1]),
+            "inputs": [
+                {
+                    "tags_l": [1, 2, 3, 4],
+                    "tags_r": [2, 3, 4, 5],
+                    "expected_value": 3,
+                    "expected_label": "Array intersection size >= 3",
+                },
+                {
+                    "tags_l": [1, 2, 3],
+                    "tags_r": [2, 3],
+                    "expected_value": 2,
+                    "expected_label": "Array intersection size >= 2",
+                },
+                {
+                    "tags_l": [1],
+                    "tags_r": [1],
+                    "expected_value": 1,
+                    "expected_label": "Array intersection size >= 1",
+                },
+            ],
+        },
+    ]
+
+    for case in test_cases:
+        inputs = [
+            {
+                k: v
+                for k, v in input_data.items()
+                if k not in ["expected_value", "expected_label"]
+            }
+            for input_data in case["inputs"]
+        ]
+        expected_values = [
+            input_data["expected_value"] for input_data in case["inputs"]
+        ]
+        expected_labels = [
+            input_data["expected_label"] for input_data in case["inputs"]
+        ]
+
+        results = comparison_vector_value(case["comparison"], inputs, db_api)
+
+        for result, expected_value, expected_label in zip(
+            results, expected_values, expected_labels
+        ):
+            assert result["comparison_vector_value"] == expected_value
+            assert result["label_for_charts"] == expected_label


### PR DESCRIPTION
Adds two new functions `is_in_level` and `comparison_vector_value` which are useful if e.g. developing a new comparison level


```python
from datetime import datetime, timedelta

import splink.comparison_level_library as cll
import splink.comparison_library as cl
from splink import DuckDBAPI
from splink.comparison_library import ArrayIntersectAtSizes
from splink.internals.testing import comparison_vector_value, is_in_level

db_api = DuckDBAPI()

comparison = cl.ExactMatch("first_name")

# is_in_level, single input
is_in_level(
    cll.ArrayIntersectLevel("my_array_col", 3),
    {"my_array_col_l": [1, 2, 3], "my_array_col_r": [1, 2]},
    db_api,
)
```

> False

```python
# is_in_level, multiple inputs
is_in_level(
    cll.ArrayIntersectLevel("my_array_col", 3),
    [
        {"my_array_col_l": [1, 2, 3], "my_array_col_r": [1, 2]},
        {"my_array_col_l": [1, 2, 3], "my_array_col_r": [1, 2, 3]},
    ],
    db_api,
)
```

> [False, True]

```python
# comparison_vector_value, single input
comparison_vector_value(
    comparison,
    {"first_name_l": "John", "first_name_r": "John"},
    db_api,
)
```

> {'comparison_vector_value': 1, 'label_for_charts': 'Exact match on first_name'}

```python
# comparison_vector_value, multiple inputs
comparison_vector_value(
    comparison,
    [
        {"first_name_l": "John", "first_name_r": "John"},
        {"first_name_l": "Jane", "first_name_r": "Janet"},
        {"first_name_l": "Bob", "first_name_r": "Bob"},
    ],
    db_api,
)
```

> [{'comparison_vector_value': 1, 'label_for_charts': 'Exact match on first_name'}, {'comparison_vector_value': 0, 'label_for_charts': 'All other comparisons'}, {'comparison_vector_value': 1, 'label_for_charts': 'Exact match on first_name'}]

We could consider in future adding this into the public API at something like

`Comparison.comparison_vector_value`
and
`ComparisonLevel.is_in_level`

Another upshot of this approach is it makes tests run faster than the current approach in https://github.com/moj-analytical-services/splink/blob/d0f3c94f1f140914a4d1bdddaa2f80426138bd7a/tests/literal_utils.py#L10 
e.g.
https://github.com/moj-analytical-services/splink/blob/d0f3c94f1f140914a4d1bdddaa2f80426138bd7a/tests/test_array_columns.py#L1

Because it runs groups of tests as a single database query e.g. if you have multiple rows of values to compare and want to simultanously compute the comparison vector value for all of them