### PR TITLE
Add cosine similiarity comparison level and comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Match weight and m and u probabilities charts now have improved tooltips ([#2392](https://github.com/moj-analytical-services/splink/pull/2392))
 - Added new `AbsoluteDifferenceLevel` comparison level for numerical columns ([#2398](https://github.com/moj-analytical-services/splink/pull/2398))
+- Added new `CosineSimilarityLevel` and `CosineSimilarityAtThresholds` for comparing array columns using cosine similarity ([#2405](https://github.com/moj-analytical-services/splink/pull/2405))
 
 ### Fixed
 

--- a/splink/comparison_level_library.py
+++ b/splink/comparison_level_library.py
@@ -5,6 +5,7 @@ from splink.internals.comparison_level_library import (
     And,
     ArrayIntersectLevel,
     ColumnsReversedLevel,
+    CosineSimilarityLevel,
     CustomLevel,
     DamerauLevenshteinLevel,
     DistanceFunctionLevel,
@@ -44,4 +45,5 @@ __all__ = [
     "And",
     "Not",
     "Or",
+    "CosineSimilarityLevel",
 ]

--- a/splink/comparison_library.py
+++ b/splink/comparison_library.py
@@ -2,6 +2,7 @@ from splink.internals.comparison_library import (
     AbsoluteDateDifferenceAtThresholds,
     AbsoluteTimeDifferenceAtThresholds,
     ArrayIntersectAtSizes,
+    CosineSimilarityAtThresholds,
     CustomComparison,
     DamerauLevenshteinAtThresholds,
     DateOfBirthComparison,
@@ -36,4 +37,5 @@ __all__ = [
     "ForenameSurnameComparison",
     "NameComparison",
     "PostcodeComparison",
+    "CosineSimilarityAtThresholds",
 ]

--- a/splink/internals/dialects.py
+++ b/splink/internals/dialects.py
@@ -97,6 +97,12 @@ class SplinkDialect(ABC):
             f"Backend '{self.name}' does not have a 'Jaccard' function"
         )
 
+    @property
+    def cosine_similarity_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.name}' does not have a 'Cosine Similarity' function"
+        )
+
     def random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None
     ):
@@ -251,6 +257,10 @@ class DuckDBDialect(SplinkDialect):
             other_columns_to_retain.append(column_to_explode)
             return f"""select {','.join(cols_to_select)}
                 from ({self.explode_arrays_sql(tbl_name,columns_to_explode,other_columns_to_retain)})"""  # noqa: E501
+
+    @property
+    def cosine_similarity_function_name(self):
+        return "array_cosine_similarity"
 
 
 class SparkDialect(SplinkDialect):


### PR DESCRIPTION
<details>
<summary>Runnable example</summary>

```python
import numpy as np
import pyarrow as pa

import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator

EMBEDDING_DIMENSION = 50
NUM_RECORDS = 3

unique_ids = range(1, NUM_RECORDS + 1)
embeddings = [np.random.rand(EMBEDDING_DIMENSION).tolist() for _ in unique_ids]

data = pa.table(
    {
        "unique_id": unique_ids,
        "embedding": pa.array(
            embeddings, type=pa.list_(pa.float32(), list_size=EMBEDDING_DIMENSION)
        ),
    }
)

settings = SettingsCreator(
    link_type="dedupe_only",
    comparisons=[cl.CosineSimilarityAtThresholds("embedding", [0.9, 0.7, 0.5])],
    blocking_rules_to_generate_predictions=["1=1"],
)


db_api = DuckDBAPI()

linker = Linker(data, settings, db_api)

linker.inference.predict().as_duckdbpyrelation()

```
</details>