### PR TITLE
Add cosine similarity tests and allow schemad data

### DIFF
--- a/tests/literal_utils.py
+++ b/tests/literal_utils.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List
 
+import pyarrow as pa
+
 from splink import DuckDBAPI
 from splink.internals.testing import comparison_vector_value, is_in_level
 
@@ -8,13 +10,16 @@ db_api = DuckDBAPI()
 
 def run_is_in_level_tests(test_cases: List[Dict[str, Any]], db_api: Any) -> None:
     for case in test_cases:
-        inputs = []
-        expected = []
-
-        for input_data in case["inputs"]:
-            input_dict = {k: v for k, v in input_data.items() if k != "expected"}
-            inputs.append(input_dict)
-            expected.append(input_data["expected"])
+        if isinstance(case["inputs"], pa.Table):
+            inputs = case["inputs"]
+            expected = inputs["expected"].to_pylist()
+        else:
+            inputs = []
+            expected = []
+            for input_data in case["inputs"]:
+                input_dict = {k: v for k, v in input_data.items() if k != "expected"}
+                inputs.append(input_dict)
+                expected.append(input_data["expected"])
 
         results = is_in_level(case["level"], inputs, db_api)
         assert (
@@ -26,19 +31,23 @@ def run_comparison_vector_value_tests(
     test_cases: List[Dict[str, Any]], db_api: Any
 ) -> None:
     for case in test_cases:
-        inputs = []
-        expected_values = []
-        expected_labels = []
-
-        for input_data in case["inputs"]:
-            input_dict = {
-                k: v
-                for k, v in input_data.items()
-                if k not in ["expected_value", "expected_label"]
-            }
-            inputs.append(input_dict)
-            expected_values.append(input_data["expected_value"])
-            expected_labels.append(input_data["expected_label"])
+        if isinstance(case["inputs"], pa.Table):
+            inputs = case["inputs"]
+            expected_values = inputs["expected_value"].to_pylist()
+            expected_labels = inputs["expected_label"].to_pylist()
+        else:
+            inputs = []
+            expected_values = []
+            expected_labels = []
+            for input_data in case["inputs"]:
+                input_dict = {
+                    k: v
+                    for k, v in input_data.items()
+                    if k not in ["expected_value", "expected_label"]
+                }
+                inputs.append(input_dict)
+                expected_values.append(input_data["expected_value"])
+                expected_labels.append(input_data["expected_label"])
 
         results = comparison_vector_value(case["comparison"], inputs, db_api)
 

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -3,7 +3,7 @@ import splink.internals.comparison_level_library as cll
 from splink import ColumnExpression
 from tests.literal_utils import run_comparison_vector_value_tests, run_is_in_level_tests
 
-from .decorator import mark_with_dialects_excluding
+from .decorator import mark_with_dialects_excluding, mark_with_dialects_including
 
 
 @mark_with_dialects_excluding()
@@ -365,7 +365,7 @@ def test_absolute_difference(test_helpers, dialect):
     run_comparison_vector_value_tests(test_cases, db_api)
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_including("duckdb")
 def test_cosine_similarity_level(test_helpers, dialect):
     import pyarrow as pa
 

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -365,7 +365,7 @@ def test_absolute_difference(test_helpers, dialect):
     run_comparison_vector_value_tests(test_cases, db_api)
 
 
-@mark_with_dialects_including("duckdb")
+@mark_with_dialects_including("duckdb", pass_dialect=True)
 def test_cosine_similarity_level(test_helpers, dialect):
     import pyarrow as pa
 


### PR DESCRIPTION
This allows tests to be specified as a pyarrow table which in turn means that a stricter schema can be imposed on the incoming data.

In this case, using DuckDB, the cosine similarity function can only be used if the data is a fixed length array.  When passing a python list to pyarrow, by default, this is treated as a variable length array and hence the old framework was not quite flexible enough to accomodat e