### PR TITLE
(Superceded) cluster multiple thresholds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink"
-version = "4.0.3.dev1"
+version = "4.0.3.dev4"
 description = "Fast probabilistic data linkage at scale"
 authors = ["Robin Linacre <robinlinacre@hotmail.com>", "Sam Lindsay", "Theodore Manassis", "Tom Hepworth", "Andy Bond", "Ross Kennedy"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink"
-version = "4.0.1"
+version = "4.0.3.dev1"
 description = "Fast probabilistic data linkage at scale"
 authors = ["Robin Linacre <robinlinacre@hotmail.com>", "Sam Lindsay", "Theodore Manassis", "Tom Hepworth", "Andy Bond", "Ross Kennedy"]
 license = "MIT"

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -39,7 +39,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'splink' has no attribute '{name}'") from None
 
 
-__version__ = "4.0.1"
+__version__ = "4.0.3.dev1"
 
 
 __all__ = [

--- a/splink/internals/clustering.py
+++ b/splink/internals/clustering.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import List, Optional
 
@@ -7,6 +8,8 @@ from splink.internals.input_column import InputColumn
 from splink.internals.misc import ascii_uid
 from splink.internals.pipeline import CTEPipeline
 from splink.internals.splink_dataframe import SplinkDataFrame
+
+logger = logging.getLogger(__name__)
 
 
 def cluster_pairwise_predictions_at_threshold(
@@ -180,7 +183,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         f"Time taken to pre-query: {end_time_pre_query - start_time_pre_query:.2f} seconds"
     )
     for NEW_THRESHOLD in match_probability_thresholds:
-        print(f"Now clustering at threshold {NEW_THRESHOLD}")
+        logger.info("=" * 80)
+        logger.info(f"Now clustering at threshold {NEW_THRESHOLD}")
         start_time = time.time()
         # First filter the edges and the nodes to remove any where
         # min_match_probability is > the NEW_THRESHOLD
@@ -330,7 +334,10 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         all_results[NEW_THRESHOLD] = final_new_clusters
         OLD_THRESHOLD = NEW_THRESHOLD
         end_time = time.time()
-        print(f"Iteration Time taken: {end_time - start_time:.2f} seconds")
+        logger.info(
+            "Multithreshold clustering iteration time taken: "
+            f"{end_time - start_time:.2f} seconds"
+        )
 
         # print("final_new_clusters")
         # print(final_new_clusters.as_duckdbpyrelation())

--- a/splink/internals/clustering.py
+++ b/splink/internals/clustering.py
@@ -1,8 +1,10 @@
-from typing import Optional
+from typing import List, Optional
 
 from splink.internals.connected_components import solve_connected_components
 from splink.internals.database_api import AcceptableInputTableType, DatabaseAPISubClass
 from splink.internals.input_column import InputColumn
+from splink.internals.misc import ascii_uid
+from splink.internals.pipeline import CTEPipeline
 from splink.internals.splink_dataframe import SplinkDataFrame
 
 
@@ -15,8 +17,15 @@ def cluster_pairwise_predictions_at_threshold(
     edge_id_column_name_right: Optional[str] = None,
     threshold_match_probability: Optional[float] = None,
 ) -> SplinkDataFrame:
-    nodes_sdf = db_api.register_table(nodes, "__splink__df_nodes", overwrite=True)
-    edges_sdf = db_api.register_table(edges, "__splink__df_edges", overwrite=True)
+    if not isinstance(nodes, SplinkDataFrame):
+        nodes_sdf = db_api.register_table(nodes, "__splink__df_nodes", overwrite=True)
+    else:
+        nodes_sdf = nodes
+
+    if not isinstance(edges, SplinkDataFrame):
+        edges_sdf = db_api.register_table(edges, "__splink__df_edges", overwrite=True)
+    else:
+        edges_sdf = edges
 
     if not edge_id_column_name_left:
         edge_id_column_name_left = InputColumn(
@@ -41,3 +50,164 @@ def cluster_pairwise_predictions_at_threshold(
     )
     cc.metadata["threshold_match_probability"] = threshold_match_probability
     return cc
+
+
+def cluster_pairwise_predictions_at_multiple_thresholds(
+    nodes: AcceptableInputTableType,
+    edges: AcceptableInputTableType,
+    db_api: DatabaseAPISubClass,
+    node_id_column_name: str,
+    match_probability_thresholds: List[float],
+    edge_id_column_name_left: Optional[str] = None,
+    edge_id_column_name_right: Optional[str] = None,
+) -> SplinkDataFrame:
+    tid = ascii_uid(8)
+
+    nodes_sdf = db_api.register_table(
+        nodes, f"__splink__df_nodes_{tid}", overwrite=True
+    )
+    edges_sdf = db_api.register_table(
+        edges, f"__splink__df_edges_{tid}", overwrite=True
+    )
+
+    if not edge_id_column_name_left:
+        edge_id_column_name_left = InputColumn(
+            node_id_column_name,
+            sqlglot_dialect_str=db_api.sql_dialect.sqlglot_dialect,
+        ).name_l
+
+    if not edge_id_column_name_right:
+        edge_id_column_name_right = InputColumn(
+            node_id_column_name,
+            sqlglot_dialect_str=db_api.sql_dialect.sqlglot_dialect,
+        ).name_r
+
+    match_probability_thresholds = sorted(match_probability_thresholds)
+
+    INITIAL_THRESHOLD = match_probability_thresholds.pop(0)
+
+    # First cluster at the lowest threshold
+    cc = cluster_pairwise_predictions_at_threshold(
+        nodes=nodes,
+        edges=edges,
+        db_api=db_api,
+        node_id_column_name=node_id_column_name,
+        edge_id_column_name_left=edge_id_column_name_left,
+        edge_id_column_name_right=edge_id_column_name_right,
+        threshold_match_probability=INITIAL_THRESHOLD,
+    )
+
+    pipeline = CTEPipeline([cc, edges_sdf])
+
+    # Calculate cluster_min_probs
+    sql = f"""
+    SELECT
+        c.cluster_id,
+        COALESCE(MIN(e.match_probability), 1.0) AS min_match_probability
+    FROM {cc.physical_name} c
+    LEFT JOIN {edges_sdf.physical_name} e
+    ON c.{node_id_column_name} = e.{edge_id_column_name_left}
+       OR c.{node_id_column_name} = e.{edge_id_column_name_right}
+    GROUP BY c.cluster_id
+    """
+    pipeline.enqueue_sql(sql, "__splink__cluster_min_probs")
+
+    # Join with nodes to get one row per node
+
+    sql = f"""
+    SELECT
+        n.cluster_id,
+        n.{node_id_column_name},
+        cmp.min_match_probability
+    FROM {cc.physical_name} n
+    JOIN __splink__cluster_min_probs cmp ON n.cluster_id = cmp.cluster_id
+    """
+    pipeline.enqueue_sql(sql, "__splink__node_cluster_min_probabilities")
+
+    node_cluster_min_probabilities = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+
+    # node_cluster_min_probabilities is
+    # |   cluster_id |   node_id |   min_match_probability |
+    # |-------------:|----------:|------------------------:|
+    # |            1 |         1 |                     0.8 |
+    # |            1 |         2 |                     0.8 |
+    # |            1 |         3 |                     0.8 |
+    # |            4 |         4 |                     1   |
+
+    # Next is the main loop where we calculate the result for the rest of the thresholds
+    OLD_THRESHOLD = INITIAL_THRESHOLD
+    for NEW_THRESHOLD in match_probability_thresholds:
+        # First filter the edges and the nodes to remove any where
+        # min_match_probability is > the NEW_THRESHOLD
+
+        pipeline = CTEPipeline([node_cluster_min_probabilities])
+        sql = f"""
+        SELECT
+            {node_id_column_name},
+            cluster_id
+        FROM __splink__node_cluster_min_probabilities
+        WHERE min_match_probability >= {NEW_THRESHOLD}
+        """
+        pipeline.enqueue_sql(sql, "__splink__stable_nodes")
+
+        stable_clusters = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+        print(stable_clusters.as_duckdbpyrelation())
+
+        # Filter the nodes to remove any where min_match_probability is < the NEW_THRESHOLD
+
+        pipeline = CTEPipeline([nodes_sdf, stable_clusters])
+        sql = f"""
+        SELECT
+            {node_id_column_name}
+        FROM {nodes_sdf.templated_name}
+        WHERE {node_id_column_name} not in (SELECT {node_id_column_name} FROM __splink__stable_nodes)
+        """
+        pipeline.enqueue_sql(sql, "__splink__nodes_in_play")
+        nodes_in_play = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+        print("nodes_in_play")
+        print(nodes_in_play.as_duckdbpyrelation())
+
+        # Filter edges to keep only those not in stable clusters
+        pipeline = CTEPipeline([edges_sdf, stable_clusters])
+        sql = f"""
+        SELECT
+            e.{edge_id_column_name_left},
+            e.{edge_id_column_name_right},
+            e.match_probability
+        FROM {edges_sdf.templated_name} e
+        WHERE e.{edge_id_column_name_left} NOT IN (SELECT {node_id_column_name} FROM __splink__stable_nodes)
+          AND e.{edge_id_column_name_right} NOT IN (SELECT {node_id_column_name} FROM __splink__stable_nodes)
+          AND e.match_probability >= {OLD_THRESHOLD}
+        """
+
+        pipeline.enqueue_sql(sql, "__splink__edges_in_play")
+
+        edges_in_play = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+        print("edges_in_play")
+        print(edges_in_play.as_duckdbpyrelation())
+
+        # Now we cluster the ones still in play
+        new_clusters = cluster_pairwise_predictions_at_threshold(
+            nodes=nodes_in_play,
+            edges=edges_in_play,
+            db_api=db_api,
+            node_id_column_name=node_id_column_name,
+            edge_id_column_name_left=edge_id_column_name_left,
+            edge_id_column_name_right=edge_id_column_name_right,
+            threshold_match_probability=NEW_THRESHOLD,
+        )
+
+        print(stable_clusters.as_duckdbpyrelation())
+        print(new_clusters.as_duckdbpyrelation())
+
+        # Concat new clusters with stable_clusters
+        pipeline = CTEPipeline([stable_clusters, new_clusters])
+        sql = f"""
+        SELECT * FROM {stable_clusters.templated_name}
+        UNION ALL
+        SELECT * FROM {new_clusters.templated_name}
+        """
+
+        pipeline.enqueue_sql(sql, "__splink__all_clusters")
+        new_clusters = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+        return new_clusters

--- a/splink/internals/clustering.py
+++ b/splink/internals/clustering.py
@@ -105,8 +105,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
     )
     all_results[INITIAL_THRESHOLD] = cc
 
-    print(f"Original clustering results at threshold {INITIAL_THRESHOLD}")
-    print(cc.as_duckdbpyrelation())
+    # print(f"Original clustering results at threshold {INITIAL_THRESHOLD}")
+    # print(cc.as_duckdbpyrelation())
 
     pipeline = CTEPipeline([cc, edges_sdf])
 
@@ -156,12 +156,12 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
     # Next is the main loop where we calculate the result for the rest of the thresholds
     OLD_THRESHOLD = INITIAL_THRESHOLD
 
-    print("node_cluster_min_probabilities")
-    print(node_cluster_min_probabilities.as_duckdbpyrelation())
+    # print("node_cluster_min_probabilities")
+    # print(node_cluster_min_probabilities.as_duckdbpyrelation())
 
-    print("----------------------------------")
+    # print("----------------------------------")
     for NEW_THRESHOLD in match_probability_thresholds:
-        print(f"Now clustering at threshold {NEW_THRESHOLD}")
+        # print(f"Now clustering at threshold {NEW_THRESHOLD}")
         # First filter the edges and the nodes to remove any where
         # min_match_probability is > the NEW_THRESHOLD
 
@@ -219,8 +219,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         stable_nodes = db_api.sql_pipeline_to_splink_dataframe(
             pipeline, use_cache=False
         )
-        print("stable_nodes")
-        print(stable_nodes.as_duckdbpyrelation())
+        # print("stable_nodes")
+        # print(stable_nodes.as_duckdbpyrelation())
 
         # Filter the nodes to remove any where min_match_probability is < the NEW_THRESHOLD
 
@@ -235,8 +235,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         nodes_in_play = db_api.sql_pipeline_to_splink_dataframe(
             pipeline, use_cache=False
         )
-        print("nodes_in_play")
-        print(nodes_in_play.as_duckdbpyrelation())
+        # print("nodes_in_play")
+        # print(nodes_in_play.as_duckdbpyrelation())
 
         # Filter edges to keep only those not in stable clusters
         pipeline = CTEPipeline([edges_sdf, stable_nodes])
@@ -256,8 +256,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         edges_in_play = db_api.sql_pipeline_to_splink_dataframe(
             pipeline, use_cache=False
         )
-        print("edges_in_play")
-        print(edges_in_play.as_duckdbpyrelation())
+        # print("edges_in_play")
+        # print(edges_in_play.as_duckdbpyrelation())
 
         # Now we cluster the ones still in play
         marginal_new_clusters = cluster_pairwise_predictions_at_threshold(
@@ -288,8 +288,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         all_results[NEW_THRESHOLD] = final_new_clusters
         OLD_THRESHOLD = NEW_THRESHOLD
 
-        print("final_new_clusters")
-        print(final_new_clusters.as_duckdbpyrelation())
-        print("----------------------------------")
+        # print("final_new_clusters")
+        # print(final_new_clusters.as_duckdbpyrelation())
+        # print("----------------------------------")
 
     return all_results

--- a/splink/internals/clustering.py
+++ b/splink/internals/clustering.py
@@ -271,8 +271,8 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         nodes_in_play = db_api.sql_pipeline_to_splink_dataframe(
             pipeline, use_cache=False
         )
-        # print("nodes_in_play")
-        # print(nodes_in_play.as_duckdbpyrelation())
+        print("nodes_in_play")
+        print(nodes_in_play.as_duckdbpyrelation().count("*"))
 
         # Filter edges to keep only those not in stable clusters
         pipeline = CTEPipeline([edges_sdf, stable_nodes])
@@ -292,10 +292,12 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
         edges_in_play = db_api.sql_pipeline_to_splink_dataframe(
             pipeline, use_cache=False
         )
-        # print("edges_in_play")
+        print("edges_in_play")
         # print(edges_in_play.as_duckdbpyrelation())
+        print(edges_in_play.as_duckdbpyrelation().count("*"))
 
         # Now we cluster the ones still in play
+        start_time_clustering = time.time()
         marginal_new_clusters = cluster_pairwise_predictions_at_threshold(
             nodes=nodes_in_play,
             edges=edges_in_play,
@@ -304,6 +306,10 @@ def cluster_pairwise_predictions_at_multiple_thresholds(
             edge_id_column_name_left=edge_id_column_name_left,
             edge_id_column_name_right=edge_id_column_name_right,
             threshold_match_probability=NEW_THRESHOLD,
+        )
+        end_time_clustering = time.time()
+        print(
+            f"Time taken to cluster at threshold {NEW_THRESHOLD}: {end_time_clustering - start_time_clustering:.2f} seconds"
         )
 
         pipeline = CTEPipeline([stable_nodes, marginal_new_clusters])

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -395,8 +395,9 @@ def solve_connected_components(
 
     sql = f"""
     select
+        representative as cluster_id,
         node_id as {node_id_column_name},
-        representative as cluster_id
+
     from {representatives.templated_name}
     order by cluster_id, node_id
     """

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -412,9 +412,6 @@ def solve_connected_components(
         """
         pipeline.enqueue_sql(sql, "stable_clusters")
 
-        # print("stable_clusters")
-        # print(stable_clusters.as_duckdbpyrelation())
-
         # Grab stable clusters and save to table
 
         sql = f"""
@@ -428,6 +425,7 @@ def solve_connected_components(
 
         # print("found stable representatives for removal")
         # representatives_stable.as_duckdbpyrelation().show()
+        # print(representatives_stable.as_duckdbpyrelation().count("*").fetchone()[0])
         converged_repr_tables.append(representatives_stable)
 
         # print("representatives_stable")
@@ -446,8 +444,11 @@ def solve_connected_components(
         pipeline.enqueue_sql(sql, "representatives_thinned")
         representatives_thinned = db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
-        # print("representatives_thinned")
+        logger.info("representatives_thinned")
         # print(representatives_thinned.as_duckdbpyrelation())
+        logger.info(
+            representatives_thinned.as_duckdbpyrelation().count("*").fetchone()[0]
+        )
 
         pipeline = CTEPipeline()
         # Update table reference

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -426,6 +426,9 @@ def solve_connected_components(
         pipeline.enqueue_sql(sql, "representatives_thinned")
         representatives_thinned = db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
+        thinned = representatives_thinned.as_duckdbpyrelation().count("*").fetchone()[0]
+        logger.info(f"Thinned count: {thinned:,.0f}")
+
         pipeline = CTEPipeline()
         # Update table reference
         prev_representatives_table.drop_table_from_database_and_remove_from_cache()

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -335,9 +335,6 @@ def solve_connected_components(
     pipeline.enqueue_sql(sql, "__splink__df_representatives")
 
     representatives = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-    # c = representatives.as_duckdbpyrelation().count("*").fetchone()[0]
-    # print(f"representatives: {c:,.0f}")
-    # print(representatives.as_duckdbpyrelation().show())
 
     prev_representatives_table = representatives
 
@@ -348,7 +345,6 @@ def solve_connected_components(
     while root_rows_count > 0:
         start_time = time.time()
         iteration += 1
-        # print(f"Starting iteration {iteration}")
 
         # Loop summary:
 
@@ -359,8 +355,6 @@ def solve_connected_components(
 
         # Generates our representatives table for the next iteration
         # by joining our previous tables onto our neighbours table.
-        # print("prev_representatives_table")
-        # print(prev_representatives_table.as_duckdbpyrelation())
 
         pipeline = CTEPipeline([neighbours])
         sql = _cc_generate_representatives_loop_cond(
@@ -380,9 +374,6 @@ def solve_connected_components(
         )
 
         representatives = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-
-        # print("representatives")
-        # print(representatives.as_duckdbpyrelation())
 
         # Report stable clusters - those where the cluster size
         # has not changed (or become null) since the last iteration
@@ -423,13 +414,7 @@ def solve_connected_components(
         pipeline.enqueue_sql(sql, "__splink__representatives_stable")
         representatives_stable = db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
-        # print("found stable representatives for removal")
-        # representatives_stable.as_duckdbpyrelation().show()
-        # print(representatives_stable.as_duckdbpyrelation().count("*").fetchone()[0])
         converged_repr_tables.append(representatives_stable)
-
-        # print("representatives_stable")
-        # print(representatives_stable.as_duckdbpyrelation())
 
         # Filter out the stable cluster and recalculate the representatives table
         # to drop the stable nodes
@@ -443,12 +428,6 @@ def solve_connected_components(
         """
         pipeline.enqueue_sql(sql, "representatives_thinned")
         representatives_thinned = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-
-        logger.info("representatives_thinned")
-        # print(representatives_thinned.as_duckdbpyrelation())
-        logger.info(
-            representatives_thinned.as_duckdbpyrelation().count("*").fetchone()[0]
-        )
 
         pipeline = CTEPipeline()
         # Update table reference

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -408,6 +408,8 @@ def solve_connected_components(
         JOIN cluster_composition_previous p
         ON c.representative = p.representative
         WHERE c.node_ids = p.node_ids
+          AND c.node_ids IS NOT NULL
+          AND p.node_ids IS NOT NULL
         """
         pipeline.enqueue_sql(sql, "__splink__df_stable_clusters")
         stable_clusters = db_api.sql_pipeline_to_splink_dataframe(pipeline)

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -335,8 +335,8 @@ def solve_connected_components(
     pipeline.enqueue_sql(sql, "__splink__df_representatives")
 
     representatives = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-    c = representatives.as_duckdbpyrelation().count("*").fetchone()[0]
-    print(f"representatives: {c:,.0f}")
+    # c = representatives.as_duckdbpyrelation().count("*").fetchone()[0]
+    # print(f"representatives: {c:,.0f}")
     # print(representatives.as_duckdbpyrelation().show())
 
     prev_representatives_table = representatives
@@ -441,9 +441,9 @@ def solve_connected_components(
         pipeline.enqueue_sql(sql, "representatives_thinned")
         representatives_thinned = db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
-        print("representatives_thinned")
-        c = representatives_thinned.as_duckdbpyrelation().count("*").fetchone()[0]
-        print(f"representatives_thinned: {c:,.0f}")
+        # print("representatives_thinned")
+        # c = representatives_thinned.as_duckdbpyrelation().count("*").fetchone()[0]
+        # print(f"representatives_thinned: {c:,.0f}")
 
         pipeline = CTEPipeline()
         # Update table reference
@@ -470,7 +470,7 @@ def solve_connected_components(
 
     pipeline = CTEPipeline()
 
-    sql = " UNION ".join(
+    sql = " UNION ALL ".join(
         [f"select * from {t.physical_name}" for t in converged_repr_tables]
     )
 

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -413,6 +413,7 @@ def solve_connected_components(
         """
         pipeline.enqueue_sql(sql, "__splink__df_stable_clusters")
         stable_clusters = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+        print(stable_clusters.as_duckdbpyrelation())
         # print("stable_clusters")
         # print(stable_clusters.as_duckdbpyrelation())
 
@@ -426,6 +427,9 @@ def solve_connected_components(
         """
         pipeline.enqueue_sql(sql, "representatives_stable")
         representatives_stable = db_api.sql_pipeline_to_splink_dataframe(pipeline)
+
+        print("found stable")
+        representatives_stable.as_duckdbpyrelation().show()
         converged_repr_tables.append(representatives_stable)
 
         # print("representatives_stable")

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -194,11 +194,11 @@ def _cc_generate_representatives_loop_cond(
 
         from __splink__df_neighbours as neighbours
 
-        left join {prev_representatives} as repr_neighbour
+        inner join {prev_representatives} as repr_neighbour
         on neighbours.neighbour = repr_neighbour.node_id
 
         where
-            repr_neighbour.rep_match
+            repr_neighbour.rep_match = True
 
         UNION ALL
 
@@ -208,6 +208,8 @@ def _cc_generate_representatives_loop_cond(
             representative
 
         from {prev_representatives}
+        where
+            {prev_representatives}.rep_match = False
 
     ) AS source
     group by source.node_id

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -382,10 +382,19 @@ def solve_connected_components(
 
         # Step 1: Find non-stable representatives
         sql = f"""
-        WITH non_stable_representatives AS (
+        WITH
+        filtered_neighbours AS (
+            SELECT *
+            FROM __splink__df_neighbours
+            WHERE node_id IN (
+                SELECT node_id
+                FROM {representatives.templated_name}
+            )
+        ),
+        non_stable_representatives AS (
             SELECT DISTINCT r.representative
             FROM {representatives.templated_name} r
-            JOIN __splink__df_neighbours n ON r.node_id = n.node_id
+            JOIN filtered_neighbours n ON r.node_id = n.node_id
             JOIN {representatives.templated_name} r2 ON n.neighbour = r2.node_id
             WHERE r.representative != r2.representative
         )


### PR DESCRIPTION
Working example of how we can cluster efficiently at multiple thresholds.

We start with the lowest/loosest threshold.

At each iteration, we use the clusters from the previous iteration to find 'stable clusters' - ones which we know in advance won't change.

The algorithm for identifying stable clusters is as follows:

- Suppose initial clustering was at 50%
- Next threshold is 60%
- For each 50% cluster, identify the edges, then find the minimum `match_probability` amongst the dges
- If the minimum `match_probability` is >60%, we know the cluster is unaffected by the new cluster
- Prior to running the clustering at 60%, remove all nodes and edges associated with stable clusters



This method is independent of the clustering algorithm so we should be able to use it even if we find a faster way of clustering at a single threshold

<details>
<summary>Click to expand</summary>

```python
import pandas as pd

import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets
from splink.internals.pipeline import CTEPipeline
from splink.internals.vertically_concatenate import (
    compute_df_concat_with_tf,
)

db_api = DuckDBAPI()

df = splink_datasets.fake_1000

settings = SettingsCreator(
    link_type="dedupe_only",
    comparisons=[
        cl.ExactMatch("first_name"),
        cl.ExactMatch("surname"),
        cl.ExactMatch("dob"),
        cl.ExactMatch("city").configure(term_frequency_adjustments=True),
        cl.ExactMatch("email"),
    ],
    blocking_rules_to_generate_predictions=[
        block_on("first_name"),
        block_on("surname"),
    ],
    max_iterations=4,
)

linker = Linker(df, settings, db_api)

linker.training.estimate_probability_two_random_records_match(
    [block_on("first_name", "surname")], recall=0.7
)

linker.training.estimate_u_using_random_sampling(max_pairs=1e6)

linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))

pairwise_predictions = linker.inference.predict(threshold_match_weight=-10)


clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
    pairwise_predictions, 0.5
)

clusters.templated_name
# __splink__df_predict
pipeline = CTEPipeline()
nodes_with_tf = compute_df_concat_with_tf(linker, pipeline)

pipeline = CTEPipeline([pairwise_predictions, clusters, nodes_with_tf])


OLD_THRESHOLD = clusters.metadata["threshold_match_probability"]
NEW_THRESHOLD = 0.51


sql = f"""
select unique_id_l, unique_id_r, match_probability
 from __splink__df_predict
union all
select unique_id as unique_id_l, unique_id as unique_id_r, 1.0 as match_probability
from __splink__df_concat_with_tf

"""
pipeline.enqueue_sql(sql, "edges")

sql = """
SELECT e.*,
        cl.cluster_id AS cluster_id_l,
        cr.cluster_id AS cluster_id_r
FROM edges e
LEFT JOIN __splink__df_representatives cl ON e.unique_id_l = cl.unique_id
LEFT JOIN __splink__df_representatives cr ON e.unique_id_r = cr.unique_id
"""
pipeline.enqueue_sql(sql, "edges_with_clusters")


sql = f"""
SELECT
   cluster_id_l as cluster_id, min(match_probability) as min_match_probability
FROM edges_with_clusters
WHERE match_probability >= {OLD_THRESHOLD}
GROUP BY cluster_id_l
HAVING MIN(match_probability) >= {NEW_THRESHOLD}
ORDER BY cluster_id_l
"""


pipeline.enqueue_sql(sql, "__splink__stable_clusters")

stable_clusters = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
stable_clusters.as_duckdbpyrelation()
pipeline = CTEPipeline([stable_clusters, clusters])

sql = """
SELECT cluster_id, unique_id
FROM __splink__df_representatives ic
WHERE ic.cluster_id IN (
    SELECT cluster_id FROM __splink__stable_clusters
)
"""
pipeline.enqueue_sql(sql, "__splink__stable_nodes")

stable_nodes = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
stable_nodes.as_duckdbpyrelation()


pipeline = CTEPipeline([stable_nodes, pairwise_predictions, nodes_with_tf])

sql = f"""
select unique_id_l, unique_id_r, match_probability
 from __splink__df_predict
union all
select unique_id as unique_id_l, unique_id as unique_id_r, 1.0 as match_probability
from __splink__df_concat_with_tf

"""
pipeline.enqueue_sql(sql, "edges")

sql = """
SELECT e.unique_id_l, e.unique_id_r, e.match_probability
FROM edges e
WHERE e.unique_id_l NOT IN (SELECT unique_id FROM __splink__stable_nodes)
  AND e.unique_id_r NOT IN (SELECT unique_id FROM __splink__stable_nodes)
"""
pipeline.enqueue_sql(sql, "__splink__edges_in_play")

edges_in_play = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
edges_in_play.as_duckdbpyrelation()

pipeline = CTEPipeline([nodes_with_tf, stable_nodes])
sql = """
SELECT unique_id
FROM __splink__df_concat_with_tf
WHERE unique_id NOT IN (SELECT unique_id FROM __splink__stable_nodes)
"""
pipeline.enqueue_sql(sql, "__splink__nodes_in_play")

nodes_in_play = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
nodes_in_play.as_duckdbpyrelation()

import logging

logger = logging.getLogger("splink")
logger.info("done one ")

linker2 = Linker(df, SettingsCreator(link_type="dedupe_only"), db_api=db_api)
linker2.table_management.register_table_input_nodes_concat_with_tf(
    nodes_in_play.physical_name
)
clusters_2 = linker2.clustering.cluster_pairwise_predictions_at_threshold(
    edges_in_play, 0.98
)

df_clusters_1 = stable_nodes.as_pandas_dataframe()

df_clusters_2 = clusters_2.as_pandas_dataframe()

combined_clusters = pd.concat([df_clusters_1, df_clusters_2], ignore_index=True)
combined_clusters


```
</details>

Once nice feature of this is we'll be able to produce a chart that shows, for each threshold probability/match weight, how much the end results change.  Could this chart be used to identify sensible thresholds?  e.g. we expect it to be steepest at 50%.  If it's not does that indicate an issue with modell?

At each iteration, we use the clusters from the previous iteration to find which clusters do not change.

For each iteration, when we compute the clusters, should we add on the min probability in the cluster so it can be used in the next iteration?


On the first run, we can actually get out a table of cluster vs. at what probability we need to re-analyse the cluster., that's what `min_match_probability` does.  So on the next run, before we do the expensive join of clusters to edges, we can prior to that filter out all the nodes/clusters/edges  we know in advance are going to be unaffected

TODO:
- [ ] Clean up tables create by Splink
- [ ] Try it on more complex graphs
- [ ] Remove the 'out of play' (rep match = false) records at each iteratino of connected components os the algo is only dealing with smaller tables