### PR TITLE
Handle threshold_match_probablity 0 in predict() #2420

### DIFF
--- a/splink/internals/predict.py
+++ b/splink/internals/predict.py
@@ -99,8 +99,7 @@ def predict_from_comparison_vectors_sqls(
     )
     # Add condition to treat case of 0 as None
     if threshold_match_probability == 0:
-        threshold_match_probability = None
-        
+        threshold_match_probability = None     
     # In case user provided both, take the minimum of the two thresholds
     if threshold_match_probability is not None:
         thres_prob_as_weight = prob_to_match_weight(threshold_match_probability)

--- a/splink/internals/predict.py
+++ b/splink/internals/predict.py
@@ -97,7 +97,10 @@ def predict_from_comparison_vectors_sqls(
         bf_terms,
         sql_infinity_expression,
     )
-
+    # Add condition to treat case of 0 as None
+    if threshold_match_probability == 0:
+        threshold_match_probability = None
+        
     # In case user provided both, take the minimum of the two thresholds
     if threshold_match_probability is not None:
         thres_prob_as_weight = prob_to_match_weight(threshold_match_probability)

--- a/splink/internals/predict.py
+++ b/splink/internals/predict.py
@@ -99,7 +99,7 @@ def predict_from_comparison_vectors_sqls(
     )
     # Add condition to treat case of 0 as None
     if threshold_match_probability == 0:
-        threshold_match_probability = None     
+        threshold_match_probability = None
     # In case user provided both, take the minimum of the two thresholds
     if threshold_match_probability is not None:
         thres_prob_as_weight = prob_to_match_weight(threshold_match_probability)


### PR DESCRIPTION

Updated predict_from_comparison_vectors_sqls_using_settings function to handle threshold_match_probability 0 as None.  Modified the logic in lines 100-117, this is to prevent maths errors when doing log2. 


### Type of PR

- [X] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

Existing Issue #2420


### Give a brief description for the solution you have provided

Whenever this predict function is called it will first check for 0 and assign threshold_match_probability to None. 
Then when it is later passed into log2 it won't return a math error. 
As its a minor change I haven't changed documentation or changelog.



### PR Checklist

- [ ] Added documentation for changes  
- [ ] Added feature to example notebooks or tutorial (if appropriate) 
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate) 
- [X] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


