### PR TITLE
Take converged clusters out of play

### DIFF
--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -257,7 +257,9 @@ def _cc_assess_exit_condition(representatives_name: str) -> str:
     return sql
 
 
-def _cc_find_converged_nodes(representatives_name: str, neighbours_name: str) -> str:
+def _cc_find_converged_nodes(
+    representatives_name: str, neighbours_name: str
+) -> list[dict[str, str]]:
     """SQL to find nodes that have converged so are part of a stable cluster.
     These can be removed 'from play' to slim down tables and make the algorithm
     run faster.

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -170,9 +170,9 @@ def _cc_generate_representatives_loop_cond(
     The key difference between this function and 'cc_update_neighbours_first_iter',
     is the usage of 'needs_updating'.
 
-    The logic behind 'needs_updating' is summarised in 'cc_update_representatives_first_iter'
-    and it can be used here to reduce our neighbours table to only those nodes that need
-    updating.
+    The logic behind 'needs_updating' is summarised in
+    'cc_update_representatives_first_iter' and it can be used here to reduce our
+    neighbours table to only those nodes that need updating.
     """
 
     sql = f"""
@@ -399,18 +399,14 @@ def solve_connected_components(
     while needs_updating_count > 0:
         start_time = time.time()
         iteration += 1
-        logger.info("-" * 40 + f" Iteration {iteration} " + "-" * 40)
+        logger.info(15, "-" * 40 + f" CC Iteration {iteration} " + "-" * 40)
 
-        c = prev_representatives_table.as_duckdbpyrelation().count("*").fetchone()[0]
-        logger.info(f"Number of representatives: {c:,.0f}")
-        c = filtered_neighbours.as_duckdbpyrelation().count("*").fetchone()[0]
-        logger.info(f"Number of filtered neighbours: {c:,.0f}")
         # Loop summary:
         # 1. Find stable clusters and remove from representatives table
         #    Stable clusters are those where a set of nodes are within the same cluster
         #    and those nodes have no neighbours outside of their cluster.
         #    Add to list of converged clusters.
-        # 2. Update representatives table by following links from current representatives
+        # 2. Update representatives table by following links from current reps
         #    to their neighbours, and recalculating min representative
         # 3. Join on the representatives table from the previous iteration
         #    to create the "needs_updating" column based on whether rep has changed
@@ -478,9 +474,6 @@ def solve_connected_components(
         # Now the new representatives have been computed from the thinned
         # representatives we no longer need the older table
         prev_representatives_thinned.drop_table_from_database_and_remove_from_cache()
-
-        c = representatives.as_duckdbpyrelation().count("*").fetchone()[0]
-        logger.info(f"New representatives: {c:,.0f}")
 
         pipeline = CTEPipeline()
         # Update table reference

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -399,7 +399,6 @@ def solve_connected_components(
     while needs_updating_count > 0:
         start_time = time.time()
         iteration += 1
-        logger.info(15, "-" * 40 + f" CC Iteration {iteration} " + "-" * 40)
 
         # Loop summary:
         # 1. Find stable clusters and remove from representatives table

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -505,7 +505,7 @@ def solve_connected_components(
 
     sql = " UNION ALL ".join(
         [
-            f"""select node_id as {node_id_column_name}, representative as cluster_id,
+            f"""select node_id as {node_id_column_name}, representative as cluster_id
             from {t.physical_name}"""
             for t in converged_clusters_tables
         ]

--- a/splink/internals/linker_components/clustering.py
+++ b/splink/internals/linker_components/clustering.py
@@ -150,7 +150,7 @@ class LinkerClustering:
         select
             cc.cluster_id,
             {select_columns_sql}
-        from __splink__clustering_output as cc
+        from __splink__clustering_output_final as cc
         left join __splink__df_concat
         on cc.node_id = {uid_concat_nodes}
         """


### PR DESCRIPTION
<details>
<summary>A testing script </summary>

```python
import random
import time

import duckdb
import matplotlib.pyplot as plt
import networkx as nx
import numpy as np
import pandas as pd

from splink import DuckDBAPI
from splink.internals.clustering import (
    # cluster_pairwise_predictions_at_multiple_thresholds,
    cluster_pairwise_predictions_at_threshold,
)


def generate_random_graph(graph_size, seed=47):
    if graph_size < 10:
        density = 1 / graph_size
    else:
        density = 2 / graph_size
    # print(f"Graph size: {graph_size}, Density: {density}")

    graph = nx.fast_gnp_random_graph(graph_size, density, seed=seed, directed=False)
    return graph


def nodes_and_edges_from_graph(G):
    edges = nx.to_pandas_edgelist(G)
    edges.columns = ["unique_id_l", "unique_id_r"]

    nodes = pd.DataFrame({"unique_id": list(G.nodes)})

    return nodes, edges


# Create 10 copies of nodes and edges with unique IDs
all_base_nodes = []
all_base_edges = []
unique_id_counter = 0
for size in range(1, 100):
    num_graphs = max(1, 20 - size // 5)
    for i in range(num_graphs):
        G = generate_random_graph(size)
        nodes, edges = nodes_and_edges_from_graph(G)

        # Update unique IDs
        nodes["unique_id"] += unique_id_counter
        edges["unique_id_l"] += unique_id_counter
        edges["unique_id_r"] += unique_id_counter

        unique_id_counter += len(nodes)

        all_base_nodes.append(nodes)
        all_base_edges.append(edges)
        # plot graph
        # nx.draw(G, with_labels=True)
        # plt.show()

base_nodes = pd.concat(all_base_nodes, ignore_index=True)
base_edges = pd.concat(all_base_edges, ignore_index=True)

all_nodes = []
all_edges = []

for _ in range(1, 2):
    offset = _ * unique_id_counter

    new_nodes = base_nodes.copy()
    new_nodes["unique_id"] += offset
    all_nodes.append(new_nodes)

    new_edges = base_edges.copy()
    new_edges["unique_id_l"] += offset
    new_edges["unique_id_r"] += offset
    all_edges.append(new_edges)

# Combine all copies
nodes = pd.concat(all_nodes, ignore_index=True)
edges = pd.concat(all_edges, ignore_index=True)

import numpy as np

np.random.seed(42)
edges["match_probability"] = np.random.rand(len(edges))

print(f"Final graph size: Nodes: {len(nodes):,.0f}, Edges: {len(edges):,.0f}")


db_api = DuckDBAPI(connection=":default:")
import logging

logging.basicConfig(format="%(message)s")
logging.getLogger("splink").setLevel(15)

start_time = time.time()

clusters = cluster_pairwise_predictions_at_threshold(
    nodes,
    edges,
    node_id_column_name="unique_id",
    db_api=db_api,
)
end_time = time.time()
print(f"Time taken: {end_time - start_time} seconds")
# clusters.as_duckdbpyrelation().show()
clusters_ddb = clusters.as_duckdbpyrelation()
sql = """
with cluster_sizes as (
select
cluster_id, count(*) as cluster_size
from clusters_ddb
group by cluster_id)
select
cluster_size, count(*) as count
from cluster_sizes
group by cluster_size
order by cluster_size
"""
duckdb.sql(sql).show()
clusters_ddb.count("*").fetchone()[0]


sql = """
select unique_id_l, unique_id_r from edges
union all
select unique_id as unique_id_l, unique_id as unique_id_r from nodes

"""

edges_with_self = duckdb.sql(sql).to_df()

# Create NetworkX graph from edges
G = nx.from_pandas_edgelist(edges_with_self, "unique_id_l", "unique_id_r")

# Use NetworkX to find connected components (clusters)
nx_clusters = list(nx.connected_components(G))

# Convert NetworkX clusters to DataFrame
nx_clusters_df = pd.DataFrame(
    [(node, i) for i, cluster in enumerate(nx_clusters) for node in cluster],
    columns=["unique_id", "cluster_id"],
)

# Sort both DataFrames by cluster_id and unique_id
nx_clusters_df = nx_clusters_df.sort_values(["cluster_id", "unique_id"])
splink_clusters_pd = clusters.as_pandas_dataframe().sort_values(
    ["cluster_id", "unique_id"]
)

# Assert that the DataFrames are the same
try:
    assert (
        splink_clusters_pd.values == nx_clusters_df.values
    ).all(), "The clusters do not match"
    print("Clusters match successfully!")
except AssertionError as e:
    print("Clusters do not match:")
    print(e)

sql_query = """
WITH cluster_sizes AS (
    SELECT cluster_id, COUNT(*) AS size
    FROM {}
    GROUP BY cluster_id
)
SELECT
    COUNT(*) AS num_clusters,
    AVG(size) AS avg_cluster_size
FROM cluster_sizes
"""

# Execute query for NetworkX results
print("\nNetworkX clustering results:")
duckdb.sql(sql_query.format("nx_clusters_df")).show()

# Execute query for Splink results
print("\nSplink clustering results:")
duckdb.sql(sql_query.format("splink_clusters_pd")).show()
```
</details>

<details>
<summary>Testing against previous versions</summary>

```python
import duckdb

import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets
from splink.blocking_analysis import (
    cumulative_comparisons_to_be_scored_from_blocking_rules_chart,
)

df = splink_datasets.historical_50k

db_api = DuckDBAPI(":default:")


df["first_name_surname_concat"] = df["first_name"] + " " + df["surname"]

linker = Linker(df, "50k_model.json", db_api=db_api)


df_predict = linker.inference.predict(threshold_match_probability=0.4)

clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(df_predict, 0.5)
clusters_ddb = clusters.as_duckdbpyrelation()


sql_query = """
WITH cluster_sizes AS (
    SELECT cluster_id, COUNT(*) AS size
    FROM clusters_ddb
    GROUP BY cluster_id
)
SELECT
    COUNT(*) AS num_clusters,
    AVG(size) AS avg_cluster_size,
    MIN(size) AS min_cluster_size,
    MAX(size) AS max_cluster_size
FROM cluster_sizes
"""

duckdb.sql(sql_query).show()

# This branch
# ┌──────────────┬───────────────────┬──────────────────┬──────────────────┐
# │ num_clusters │ avg_cluster_size  │ min_cluster_size │ max_cluster_size │
# │    int64     │      double       │      int64       │      int64       │
# ├──────────────┼───────────────────┼──────────────────┼──────────────────┤
# │         8514 │ 5.940568475452197 │                1 │              846 │
# └──────────────┴───────────────────┴──────────────────┴──────────────────┘

# v4.0.3
# ┌──────────────┬───────────────────┬──────────────────┬──────────────────┐
# │ num_clusters │ avg_cluster_size  │ min_cluster_size │ max_cluster_size │
# │    int64     │      double       │      int64       │      int64       │
# ├──────────────┼───────────────────┼──────────────────┼──────────────────┤
# │         8514 │ 5.940568475452197 │                1 │              846 │
# └──────────────┴───────────────────┴──────────────────┴──────────────────┘


# v4.0.1
# ┌──────────────┬───────────────────┬──────────────────┬──────────────────┐
# │ num_clusters │ avg_cluster_size  │ min_cluster_size │ max_cluster_size │
# │    int64     │      double       │      int64       │      int64       │
# ├──────────────┼───────────────────┼──────────────────┼──────────────────┤
# │         8514 │ 5.940568475452197 │                1 │              846 │
# └──────────────┴───────────────────┴──────────────────┴──────────────────┘
```
</details>