### PR TITLE
Score missing intra-cluster edges

### DIFF
--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -294,7 +294,7 @@ class LinkerInference:
         self,
         df_clusters: SplinkDataFrame,
         # TODO: should work without predict, just get the full lot
-        df_predict: SplinkDataFrame,
+        df_predict: SplinkDataFrame = None,
         threshold_match_probability: float = None,
         threshold_match_weight: float = None,
     ) -> SplinkDataFrame:
@@ -317,13 +317,17 @@ class LinkerInference:
         sqls[0]["output_table_name"] = "__splink__raw_blocked_id_pairs"
 
         # TODO: generalise id columns
-        sql = f"""
         SELECT *
+        sql = """
         FROM __splink__raw_blocked_id_pairs ne
-        LEFT JOIN {df_predict.physical_name} oe
-        ON oe.unique_id_l = ne.join_key_l AND oe.unique_id_r = ne.join_key_r
-        WHERE oe.unique_id_l IS NULL AND oe.unique_id_r IS NULL
         """
+        if df_predict is not None:
+            sql = f"""
+            {sql}
+            LEFT JOIN {df_predict.physical_name} oe
+            ON oe.unique_id_l = ne.join_key_l AND oe.unique_id_r = ne.join_key_r
+            WHERE oe.unique_id_l IS NULL AND oe.unique_id_r IS NULL
+            """
 
         sqls.append({"sql": sql, "output_table_name": "__splink__blocked_id_pairs"})
 

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -304,8 +304,12 @@ class LinkerInference:
         pipeline = CTEPipeline()
         blocking_input_tablename_l = df_clusters.physical_name
         blocking_input_tablename_r = df_clusters.physical_name
-        source_dataset_input_column = self._linker._settings_obj.column_info_settings.source_dataset_input_column
-        unique_id_input_column = self._linker._settings_obj.column_info_settings.unique_id_input_column
+        source_dataset_input_column = (
+            self._linker._settings_obj.column_info_settings.source_dataset_input_column
+        )
+        unique_id_input_column = (
+            self._linker._settings_obj.column_info_settings.unique_id_input_column
+        )
 
         link_type = self._linker._settings_obj._link_type
         # TODO: rename cluster_id
@@ -326,7 +330,10 @@ class LinkerInference:
         """
         if df_predict is not None:
             if source_dataset_input_column:
-                unique_id_columns = [source_dataset_input_column, unique_id_input_column]
+                unique_id_columns = [
+                    source_dataset_input_column,
+                    unique_id_input_column,
+                ]
             else:
                 unique_id_columns = [unique_id_input_column]
             uid_l_expr = _composite_unique_id_from_edges_sql(unique_id_columns, "l")
@@ -338,7 +345,7 @@ class LinkerInference:
             sqls.append(
                 {
                     "sql": sql_predict_with_join_keys,
-                    "output_table_name": "__splink__df_predict_with_join_keys"
+                    "output_table_name": "__splink__df_predict_with_join_keys",
                 }
             )
 

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -321,14 +321,16 @@ class LinkerInference:
             source_dataset_input_column=source_dataset_input_column,
             unique_id_input_column=unique_id_input_column,
         )
+        # we are going to insert an intermediate table, so rename this
         sqls[0]["output_table_name"] = "__splink__raw_blocked_id_pairs"
 
-        # TODO: generalise id columns
         sql = """
         SELECT ne.*
         FROM __splink__raw_blocked_id_pairs ne
         """
         if df_predict is not None:
+            # if we are given edges, we left join them, and then keep only rows
+            # where we _didn't_ have corresponding rows in edges table
             if source_dataset_input_column:
                 unique_id_columns = [
                     source_dataset_input_column,

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -298,6 +298,50 @@ class LinkerInference:
         threshold_match_probability: float = None,
         threshold_match_weight: float = None,
     ) -> SplinkDataFrame:
+        """
+        Given a table of clustered records, create a dataframe of scored
+        pairwise comparisons for all pairs of records that belong to the same cluster.
+
+        If you also supply a scored edges table, this will only return pairwise
+        comparisons that are not already present in your scored edges table.
+
+        Args:
+            df_clusters (SplinkDataFrame): A table of clustered records, such
+                as the output of
+                `linker.clustering.cluster_pairwise_predictions_at_threshold()`.
+                All edges within the same cluster as specified by this table will
+                be scored.
+                Table needs cluster_id, id columns, and any columns used in
+                model comparisons.
+            df_predict (SplinkDataFrame, optional): An edges table, the output of
+                `linker.inference.predict()`.
+                If supplied, resulting table will not include any edges already
+                included in this table.
+            threshold_match_probability (float, optional): If specified,
+                filter the results to include only pairwise comparisons with a
+                match_probability above this threshold. Defaults to None.
+            threshold_match_weight (float, optional): If specified,
+                filter the results to include only pairwise comparisons with a
+                match_weight above this threshold. Defaults to None.
+
+        Examples:
+            ```py
+            linker = linker(df, "saved_settings.json", db_api=db_api)
+            df_edges = linker.inference.predict()
+            df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
+                df_edges,
+                0.9,
+            )
+            df_remaining_edges = linker.score_missing_cluster_edges(
+                df_clusters,
+                df_edges,
+            )
+            df_remaining_edges.as_pandas_dataframe(limit=5)
+            ```
+        Returns:
+            SplinkDataFrame: A SplinkDataFrame of the scored pairwise comparisons.
+        """
+
         start_time = time.time()
 
         pipeline = CTEPipeline()

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -321,7 +321,7 @@ class LinkerInference:
             unique_id_input_column=unique_id_input_column,
         )
         # we are going to insert an intermediate table, so rename this
-        sqls[0]["output_table_name"] = "__splink__raw_blocked_id_pairs"
+        sqls[-1]["output_table_name"] = "__splink__raw_blocked_id_pairs"
 
         sql = """
         SELECT ne.*
@@ -377,6 +377,7 @@ class LinkerInference:
             threshold_match_weight,
             sql_infinity_expression=self._linker._infinity_expression,
         )
+        sqls[-1]["output_table_name"] = "__splink__df_predict_missing_cluster_edges"
         pipeline.enqueue_list_of_sqls(sqls)
 
         predictions = self._linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -294,7 +294,6 @@ class LinkerInference:
     def score_missing_cluster_edges(
         self,
         df_clusters: SplinkDataFrame,
-        # TODO: should work without predict, just get the full lot
         df_predict: SplinkDataFrame = None,
         threshold_match_probability: float = None,
         threshold_match_weight: float = None,

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -317,8 +317,8 @@ class LinkerInference:
         sqls[0]["output_table_name"] = "__splink__raw_blocked_id_pairs"
 
         # TODO: generalise id columns
-        SELECT *
         sql = """
+        SELECT ne.*
         FROM __splink__raw_blocked_id_pairs ne
         """
         if df_predict is not None:

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -11,7 +11,7 @@ from .decorator import mark_with_dialects_excluding
     ["link_type", "copies_of_df"],
     [["dedupe_only", 1], ["link_only", 2], ["link_and_dedupe", 2], ["link_only", 3]],
 )
-def test_score_missing_edges_dedupe(test_helpers, dialect, link_type, copies_of_df):
+def test_score_missing_edges(test_helpers, dialect, link_type, copies_of_df):
     helper = test_helpers[dialect]
 
     df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
@@ -45,3 +45,44 @@ def test_score_missing_edges_dedupe(test_helpers, dialect, link_type, copies_of_
     assert not df_missing_edges.empty, "No missing edges found"
     assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
     assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
+
+
+@mark_with_dialects_excluding()
+@mark.parametrize(
+    ["link_type", "copies_of_df"],
+    [["dedupe_only", 1], ["link_only", 2]],
+)
+def test_score_missing_edges_all_edges(test_helpers, dialect, link_type, copies_of_df):
+    helper = test_helpers[dialect]
+
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    settings = SettingsCreator(
+        link_type=link_type,
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+            cl.ExactMatch("city"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("surname"),
+            block_on("dob"),
+        ],
+        retain_intermediate_calculation_columns=True,
+    )
+    linker_input = df if copies_of_df == 1 else [df for _ in range(copies_of_df)]
+    linker = Linker(linker_input, settings, **helper.extra_linker_args())
+
+    df_predict = linker.inference.predict()
+    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
+        df_predict, 0.95
+    )
+
+    df_missing_edges = linker.inference.score_missing_cluster_edges(
+        df_clusters,
+    ).as_pandas_dataframe()
+
+    assert not df_missing_edges.empty, "No missing edges found"
+    # some of these should be present now, as we are scoring all intracluster edges
+    assert any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
+    assert any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from pytest import mark
 
 import splink.comparison_library as cl
@@ -86,3 +87,54 @@ def test_score_missing_edges_all_edges(test_helpers, dialect, link_type, copies_
     # some of these should be present now, as we are scoring all intracluster edges
     assert any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
     assert any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
+
+
+@mark_with_dialects_excluding()
+@mark.parametrize(
+    ["link_type"],
+    [["dedupe_only"], ["link_only"]],
+)
+def test_score_missing_edges_changed_column_names(test_helpers, dialect, link_type):
+    helper = test_helpers[dialect]
+
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df["record_id"] = df["unique_id"]
+    del df["unique_id"]
+    df["sds"] = "frame_1"
+    settings = SettingsCreator(
+        link_type=link_type,
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+            cl.ExactMatch("city"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("surname"),
+            block_on("dob"),
+        ],
+        retain_intermediate_calculation_columns=True,
+        unique_id_column_name="record_id",
+        source_dataset_column_name="sds",
+    )
+    if link_type == "dedupe_only":
+        linker_input = helper.convert_frame(df)
+    else:
+        df_2 = df.copy()
+        df_2["sds"] = "frame_2"
+        linker_input = [helper.convert_frame(df), helper.convert_frame(df_2)]
+    linker = Linker(linker_input, settings, **helper.extra_linker_args())
+
+    df_predict = linker.inference.predict()
+    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
+        df_predict, 0.95
+    )
+
+    df_missing_edges = linker.inference.score_missing_cluster_edges(
+        df_clusters,
+        df_predict,
+    ).as_pandas_dataframe()
+
+    assert not df_missing_edges.empty, "No missing edges found"
+    assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
+    assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -26,12 +26,50 @@ def test_score_missing_edges_dedupe(test_helpers, dialect):
     linker = Linker(df, settings, **helper.extra_linker_args())
 
     df_predict = linker.inference.predict()
-    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(df_predict, 0.95)
+    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
+        df_predict, 0.95
+    )
 
     df_missing_edges = linker.inference.score_missing_cluster_edges(
         df_clusters,
         df_predict,
     ).as_pandas_dataframe()
+
+    assert not df_missing_edges.empty, "No missing edges found"
+    assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
+    assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
+
+@mark_with_dialects_excluding()
+def test_score_missing_edges_link_only(test_helpers, dialect):
+    helper = test_helpers[dialect]
+
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    settings = SettingsCreator(
+        link_type="link_only",
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+            cl.ExactMatch("city"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("surname"),
+            block_on("dob"),
+        ],
+        retain_intermediate_calculation_columns=True,
+    )
+    linker = Linker([df, df], settings, **helper.extra_linker_args())
+
+    df_predict = linker.inference.predict()
+    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
+        df_predict, 0.95
+    )
+
+    df_missing_edges = linker.inference.score_missing_cluster_edges(
+        df_clusters,
+        df_predict,
+    ).as_pandas_dataframe()
+
     assert not df_missing_edges.empty, "No missing edges found"
     assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
     assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 import splink.comparison_library as cl
 from splink import Linker, SettingsCreator, block_on
 
@@ -5,12 +7,13 @@ from .decorator import mark_with_dialects_excluding
 
 
 @mark_with_dialects_excluding()
-def test_score_missing_edges_dedupe(test_helpers, dialect):
+@mark.parametrize(["link_type", "copies_of_df"], [["dedupe_only", 1], ["link_only", 2]])
+def test_score_missing_edges_dedupe(test_helpers, dialect, link_type, copies_of_df):
     helper = test_helpers[dialect]
 
     df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings = SettingsCreator(
-        link_type="dedupe_only",
+        link_type=link_type,
         comparisons=[
             cl.ExactMatch("first_name"),
             cl.ExactMatch("surname"),
@@ -23,42 +26,8 @@ def test_score_missing_edges_dedupe(test_helpers, dialect):
         ],
         retain_intermediate_calculation_columns=True,
     )
-    linker = Linker(df, settings, **helper.extra_linker_args())
-
-    df_predict = linker.inference.predict()
-    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
-        df_predict, 0.95
-    )
-
-    df_missing_edges = linker.inference.score_missing_cluster_edges(
-        df_clusters,
-        df_predict,
-    ).as_pandas_dataframe()
-
-    assert not df_missing_edges.empty, "No missing edges found"
-    assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
-    assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
-
-@mark_with_dialects_excluding()
-def test_score_missing_edges_link_only(test_helpers, dialect):
-    helper = test_helpers[dialect]
-
-    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    settings = SettingsCreator(
-        link_type="link_only",
-        comparisons=[
-            cl.ExactMatch("first_name"),
-            cl.ExactMatch("surname"),
-            cl.ExactMatch("dob"),
-            cl.ExactMatch("city"),
-        ],
-        blocking_rules_to_generate_predictions=[
-            block_on("surname"),
-            block_on("dob"),
-        ],
-        retain_intermediate_calculation_columns=True,
-    )
-    linker = Linker([df, df], settings, **helper.extra_linker_args())
+    linker_input = df if copies_of_df == 1 else [df for _ in range(copies_of_df)]
+    linker = Linker(linker_input, settings, **helper.extra_linker_args())
 
     df_predict = linker.inference.predict()
     df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -7,7 +7,10 @@ from .decorator import mark_with_dialects_excluding
 
 
 @mark_with_dialects_excluding()
-@mark.parametrize(["link_type", "copies_of_df"], [["dedupe_only", 1], ["link_only", 2]])
+@mark.parametrize(
+    ["link_type", "copies_of_df"],
+    [["dedupe_only", 1], ["link_only", 2], ["link_and_dedupe", 2], ["link_only", 3]],
+)
 def test_score_missing_edges_dedupe(test_helpers, dialect, link_type, copies_of_df):
     helper = test_helpers[dialect]
 

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -1,0 +1,37 @@
+import splink.comparison_library as cl
+from splink import Linker, SettingsCreator, block_on
+
+from .decorator import mark_with_dialects_excluding
+
+
+@mark_with_dialects_excluding()
+def test_score_missing_edges_dedupe(test_helpers, dialect):
+    helper = test_helpers[dialect]
+
+    df = helper.load_frame_from_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+            cl.ExactMatch("city"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("surname"),
+            block_on("dob"),
+        ],
+        retain_intermediate_calculation_columns=True,
+    )
+    linker = Linker(df, settings, **helper.extra_linker_args())
+
+    df_predict = linker.inference.predict()
+    df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(df_predict, 0.95)
+
+    df_missing_edges = linker.inference.score_missing_cluster_edges(
+        df_clusters,
+        df_predict,
+    ).as_pandas_dataframe()
+    assert not df_missing_edges.empty, "No missing edges found"
+    assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
+    assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])


### PR DESCRIPTION
This adds a function `linker.inference.score_missing_cluster_edges()` which accepts a clusters frame, and scores all edges between nodes in the same cluster. You can also supply an edges table, and any previously-scored edges will be excluded.

This may be useful for:
* identifying high-probability edges that were missed by blocking rules, in order to find promising avenues for expanded blocking rules
* in looking at evaluation of clusters disentangling (comparisons + blocking rules) vs (just comparisons) by removing blocking from the equation

Here is an example (a simple model with `historical_50k`) cluster studio of using the standard edges, and the result when you join these to the result of this new function:
<p>
<img width="400" alt="Screenshot 2024-10-02 at 15 56 53" src="https://github.com/user-attachments/assets/d95bbd26-8ebd-4e49-9ee3-2660fcba38d0">
<img width="400" alt="Screenshot 2024-10-02 at 15 57 00" src="https://github.com/user-attachments/assets/82c4f9d4-aebd-4622-bd79-9f488f347c9c">
</p>
We can also filter out edges below 0.99 to see what new 'high-quality' edges we had excluded from the blocking:
<img width="400" alt="Screenshot 2024-10-02 at 15 59 59" src="https://github.com/user-attachments/assets/08675adf-164f-4710-ace6-d3cde651f05b">

or just the new ones in isolation:
<img width="400" alt="Screenshot 2024-10-02 at 17 32 20" src="https://github.com/user-attachments/assets/72333bfc-ef3e-4f55-9f64-a1bf608bcebc">