### PR TITLE
Fix clustering in linky jobs with source dataset column on Postgres

### DIFF
--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -54,6 +54,7 @@ from splink.internals.unique_id_concat import (
 )
 from splink.internals.vertically_concatenate import (
     compute_df_concat_with_tf,
+    concat_table_column_names,
 )
 
 logger = logging.getLogger(__name__)
@@ -251,6 +252,15 @@ class Linker:
             self._settings_obj.column_info_settings.source_dataset_column_name
             in input_cols
         )
+
+    @property
+    def _concat_table_column_names(self) -> list[str]:
+        """
+        Returns the columns actually present in __splink__df_concat table.
+        Includes source dataset name if it's been created, and logic of additional
+        columns already taken care of
+        """
+        return concat_table_column_names(self)
 
     @property
     def _cache_uid(self):

--- a/splink/internals/linker_components/clustering.py
+++ b/splink/internals/linker_components/clustering.py
@@ -139,8 +139,10 @@ class LinkerClustering:
         enqueue_df_concat(linker, pipeline)
 
         columns = concat_table_column_names(self._linker)
+        # don't want to include salting column in output if present
+        columns_without_salt = filter(lambda x: x != "__splink_salt", columns)
 
-        select_columns_sql = ", ".join(columns)
+        select_columns_sql = ", ".join(columns_without_salt)
 
         sql = f"""
         select

--- a/splink/internals/linker_components/clustering.py
+++ b/splink/internals/linker_components/clustering.py
@@ -17,7 +17,10 @@ from splink.internals.unique_id_concat import (
     _composite_unique_id_from_edges_sql,
     _composite_unique_id_from_nodes_sql,
 )
-from splink.internals.vertically_concatenate import enqueue_df_concat
+from splink.internals.vertically_concatenate import (
+    concat_table_column_names,
+    enqueue_df_concat,
+)
 
 if TYPE_CHECKING:
     from splink.internals.linker import Linker
@@ -135,14 +138,7 @@ class LinkerClustering:
 
         enqueue_df_concat(linker, pipeline)
 
-        df_obj = next(iter(linker._input_tables_dict.values()))
-        columns = df_obj.columns_escaped
-
-        if linker._settings_obj._get_source_dataset_column_name_is_required():
-            columns.insert(
-                1,
-                linker._settings_obj.column_info_settings.source_dataset_input_column.name,
-            )
+        columns = concat_table_column_names(self._linker)
 
         select_columns_sql = ", ".join(columns)
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,0 +1,65 @@
+import pandas as pd
+from pytest import mark
+
+import splink.comparison_library as cl
+from splink import Linker, SettingsCreator, block_on
+
+from .decorator import mark_with_dialects_excluding
+
+df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+# we just want to check it runs, so use a small slice of the data
+df = df[0:25]
+df_l = df.copy()
+df_r = df.copy()
+df_m = df.copy()
+df_l["source_dataset"] = "my_left_ds"
+df_r["source_dataset"] = "my_right_ds"
+df_m["source_dataset"] = "my_middle_ds"
+df_combined = pd.concat([df_l, df_r])
+
+
+@mark_with_dialects_excluding()
+@mark.parametrize(
+    ["link_type", "input_pd_tables"],
+    [
+        ["dedupe_only", [df]],
+        ["link_only", [df, df]],  # no source dataset
+        ["link_only", [df_l, df_r]],  # source dataset column
+        ["link_only", [df_combined]],  # concatenated frame
+        ["link_only", [df_l, df_m, df_r]],
+        ["link_and_dedupe", [df, df]],  # no source dataset
+        ["link_and_dedupe", [df_l, df_r]],  # source dataset column
+        ["link_and_dedupe", [df_combined]],  # concatenated frame
+    ],
+    ids=[
+        "dedupe",
+        "link_only_no_source_dataset",
+        "link_only_with_source_dataset",
+        "link_only_concat",
+        "link_only_three_tables",
+        "link_and_dedupe_no_source_dataset",
+        "link_and_dedupe_with_source_dataset",
+        "link_and_dedupe_concat",
+    ],
+)
+def test_clustering(test_helpers, dialect, link_type, input_pd_tables):
+    helper = test_helpers[dialect]
+
+    settings = SettingsCreator(
+        link_type=link_type,
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+            cl.ExactMatch("city"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("surname"),
+            block_on("dob"),
+        ],
+    )
+    linker_input = list(map(helper.convert_frame, input_pd_tables))
+    linker = Linker(linker_input, settings, **helper.extra_linker_args())
+
+    df_predict = linker.inference.predict()
+    linker.clustering.cluster_pairwise_predictions_at_threshold(df_predict, 0.95)


### PR DESCRIPTION
Fixes #2443.

The issue was logic around `source_dataset` for constructing the columns appearing in `SELECT`. This logic needs to make sure the source dataset column is present, but account for the fact that the column may or may not be present in the original source data.

The function `concat_table_column_names()` is actually something I wrote for another branch, where I needed to know what columns the `df_concat` table would have without necessarily instantiating, so I just isolated that change and cherry-picked it here.

A small tangible difference is that this means the clusters table will once again return the `__splink_salt` column (as it did before recent clustering changes #2412). If that is a potential problem then it would be easy enough to remove.