### PR TITLE
Used .blocking_rule_sql property match_weights_interactive_history_chart()

### DIFF
--- a/splink/internals/em_training_session.py
+++ b/splink/internals/em_training_session.py
@@ -371,7 +371,7 @@ class EMTrainingSession:
         """
         records = self._iteration_history_records
         return match_weights_interactive_history_chart(
-            records, blocking_rule=self._blocking_rule_for_training
+            records, blocking_rule=self._blocking_rule_for_training.blocking_rule_sql
         )
 
     def m_u_values_interactive_history_chart(self) -> ChartReturnType:


### PR DESCRIPTION
### Type of PR

- [X ] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

Issue #1387



### Give a brief description for the solution you have provided
Added the .blocking_rule_sql property on _blocking_rule_for_training so a readable string is returned instead of an object id code in the chart subtitle. Tested locally and had no errors from this change. 




### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [X ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


