### PR TITLE
Change name of second __splink__cluster_count_row_numbered query, prevent table name conflict

### DIFF
--- a/splink/internals/cluster_studio.py
+++ b/splink/internals/cluster_studio.py
@@ -233,7 +233,7 @@ def _get_cluster_id_of_each_size(
     where row_num <= {rows_per_partition}
     """
 
-    pipeline.enqueue_sql(sql, "__splink__cluster_count_row_numbered")
+    pipeline.enqueue_sql(sql, "__splink__cluster_count_row_numbered_2")
     df_cluster_sample_with_size = linker._db_api.sql_pipeline_to_splink_dataframe(
         pipeline
     )


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

[#1823](https://github.com/moj-analytical-services/splink/issues/1823)



### Give a brief description for the solution you have provided

The second query that goes to enqueue __splink__cluster_count_row_numbered has the same name as a query already executed in lines 226 and 232. This leads to a "table already exists" error, so I have simply renamed the last query to __splink__cluster_count_row_numbered_2 as just changing the name was advised in the issue description.



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


