### PR TITLE
Sql dialect error - added sql_dialect property, initialised sql_dialect to init #2314

### DIFF
--- a/splink/internals/cluster_studio.py
+++ b/splink/internals/cluster_studio.py
@@ -233,7 +233,7 @@ def _get_cluster_id_of_each_size(
     where row_num <= {rows_per_partition}
     """
 
-    pipeline.enqueue_sql(sql, "__splink__cluster_count_row_numbered")
+    pipeline.enqueue_sql(sql, "__splink__cluster_count_row_numbered_2")
     df_cluster_sample_with_size = linker._db_api.sql_pipeline_to_splink_dataframe(
         pipeline
     )

--- a/splink/internals/cluster_studio.py
+++ b/splink/internals/cluster_studio.py
@@ -233,7 +233,7 @@ def _get_cluster_id_of_each_size(
     where row_num <= {rows_per_partition}
     """
 
-    pipeline.enqueue_sql(sql, "__splink__cluster_count_row_numbered_2")
+    pipeline.enqueue_sql(sql, "__splink__cluster_count_row_numbered")
     df_cluster_sample_with_size = linker._db_api.sql_pipeline_to_splink_dataframe(
         pipeline
     )

--- a/splink/internals/column_expression.py
+++ b/splink/internals/column_expression.py
@@ -47,8 +47,16 @@ class ColumnExpression:
     def __init__(self, sql_expression: str, sql_dialect: SplinkDialect = None):
         self.raw_sql_expression = sql_expression
         self.operations: list[ColumnExpressionOperation] = []
-        if sql_dialect is not None:
-            self.sql_dialect: SplinkDialect = sql_dialect
+        self._sql_dialect = sql_dialect
+    
+    @property
+    def sql_dialect(self) -> SplinkDialect:
+        """A safe property for accessing `sql_dialect` with an error message if unset."""
+        if self._sql_dialect is None:
+            raise ValueError(
+                "SQL dialect has not been set. Please set it before using ColumnExpression. "
+            )
+        return self._sql_dialect
 
     def _clone(self) -> "ColumnExpression":
         clone = copy(self)


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

#2314 



### Give a brief description for the solution you have provided

Included a more descriptive error message for when an SQL dialect is not provided in ColumnExpression class. The sql_dialect is now assigned to a private attribute (_sql_dialect), and a property sql_dialect handles case where this value is None. 
Run all tests locally with no issues.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [x] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


