### PR TITLE
Simplify Altair import

### DIFF
--- a/splink/internals/charts.py
+++ b/splink/internals/charts.py
@@ -7,8 +7,7 @@ from typing import Any, Dict, Union
 
 import numpy as np
 import pandas as pd
-from altair import Chart
-from altair.core import SchemaBase
+from altair import Chart, SchemaBase
 
 from splink.internals.misc import read_resource
 from splink.internals.waterfall_chart import records_to_waterfall_data

--- a/splink/internals/charts.py
+++ b/splink/internals/charts.py
@@ -3,26 +3,18 @@ from __future__ import annotations
 import json
 import math
 import os
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import Any, Dict, Union
 
 import numpy as np
 import pandas as pd
+from altair import Chart
+from altair.core import SchemaBase
 
 from splink.internals.misc import read_resource
 from splink.internals.waterfall_chart import records_to_waterfall_data
 
-altair_installed = True
-
-try:
-    import altair as alt
-except ImportError:
-    altair_installed = False
-
-if TYPE_CHECKING:
-    import altair as alt
-
 # type alias:
-ChartReturnType = Union[Dict[Any, Any], alt.core.SchemaBase]
+ChartReturnType = Union[Dict[Any, Any], SchemaBase]
 
 
 def load_chart_definition(filename):
@@ -42,13 +34,8 @@ def _load_external_libs():
 def altair_or_json(
     chart_dict: dict[Any, Any], as_dict: bool = False
 ) -> ChartReturnType:
-    if altair_installed:
-        if not as_dict:
-            try:
-                return alt.Chart.from_dict(chart_dict)
-
-            except ModuleNotFoundError:
-                return chart_dict
+    if not as_dict:
+        return Chart.from_dict(chart_dict)
 
     return chart_dict
 


### PR DESCRIPTION
Currently there is a slightly cryptic error if you try to use splink in an environment where Altair is not installed. I have made it so that this will give a normal error about a missing import.

There was also some code nominally to guard for the case of Altair not being installed. I have removed this as
* Altair is currently a non-optional dependency anyhow, so should always be present
* Splink currently doesn't work without Altair anyway, due to the above-mentioned issue.

Closes #2474.