### PR TITLE
Less caching in debug mode

### DIFF
--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -221,6 +221,8 @@ class DatabaseAPI(ABC, Generic[TablishType]):
                 )
                 run_time = parse_duration(time.time() - start_time)
                 print(f"Step ran in: {run_time}")  # noqa: T201
+            # don't want to cache anything in debug mode
+            self._intermediate_table_cache.invalidate_cache()
 
         # if there is an error the pipeline will not reset, leaving caller to handle
 

--- a/splink/internals/vertically_concatenate.py
+++ b/splink/internals/vertically_concatenate.py
@@ -131,18 +131,21 @@ def compute_df_concat_with_tf(linker: Linker, pipeline: CTEPipeline) -> SplinkDa
 def enqueue_df_concat(linker: Linker, pipeline: CTEPipeline) -> CTEPipeline:
     cache = linker._intermediate_table_cache
 
-    if "__splink__df_concat" in cache:
-        nodes_with_tf = cache.get_with_logging("__splink__df_concat")
-        pipeline.append_input_dataframe(nodes_with_tf)
-        return pipeline
+    # when using debug_mode we don't use the cache elsewhere,
+    # so let's not use it here
+    if not linker._debug_mode:
+        if "__splink__df_concat" in cache:
+            nodes_with_tf = cache.get_with_logging("__splink__df_concat")
+            pipeline.append_input_dataframe(nodes_with_tf)
+            return pipeline
 
-    # __splink__df_concat_with_tf is a superset of __splink__df_concat
-    # so if it exists, use it instead
-    elif "__splink__df_concat_with_tf" in cache:
-        nodes_with_tf = cache.get_with_logging("__splink__df_concat_with_tf")
-        nodes_with_tf.templated_name = "__splink__df_concat"
-        pipeline.append_input_dataframe(nodes_with_tf)
-        return pipeline
+        # __splink__df_concat_with_tf is a superset of __splink__df_concat
+        # so if it exists, use it instead
+        elif "__splink__df_concat_with_tf" in cache:
+            nodes_with_tf = cache.get_with_logging("__splink__df_concat_with_tf")
+            nodes_with_tf.templated_name = "__splink__df_concat"
+            pipeline.append_input_dataframe(nodes_with_tf)
+            return pipeline
 
     sds_ic = linker._settings_obj.column_info_settings.source_dataset_input_column
 

--- a/splink/internals/vertically_concatenate.py
+++ b/splink/internals/vertically_concatenate.py
@@ -131,21 +131,18 @@ def compute_df_concat_with_tf(linker: Linker, pipeline: CTEPipeline) -> SplinkDa
 def enqueue_df_concat(linker: Linker, pipeline: CTEPipeline) -> CTEPipeline:
     cache = linker._intermediate_table_cache
 
-    # when using debug_mode we don't use the cache elsewhere,
-    # so let's not use it here
-    if not linker._debug_mode:
-        if "__splink__df_concat" in cache:
-            nodes_with_tf = cache.get_with_logging("__splink__df_concat")
-            pipeline.append_input_dataframe(nodes_with_tf)
-            return pipeline
+    if "__splink__df_concat" in cache:
+        nodes_with_tf = cache.get_with_logging("__splink__df_concat")
+        pipeline.append_input_dataframe(nodes_with_tf)
+        return pipeline
 
-        # __splink__df_concat_with_tf is a superset of __splink__df_concat
-        # so if it exists, use it instead
-        elif "__splink__df_concat_with_tf" in cache:
-            nodes_with_tf = cache.get_with_logging("__splink__df_concat_with_tf")
-            nodes_with_tf.templated_name = "__splink__df_concat"
-            pipeline.append_input_dataframe(nodes_with_tf)
-            return pipeline
+    # __splink__df_concat_with_tf is a superset of __splink__df_concat
+    # so if it exists, use it instead
+    elif "__splink__df_concat_with_tf" in cache:
+        nodes_with_tf = cache.get_with_logging("__splink__df_concat_with_tf")
+        nodes_with_tf.templated_name = "__splink__df_concat"
+        pipeline.append_input_dataframe(nodes_with_tf)
+        return pipeline
 
     sds_ic = linker._settings_obj.column_info_settings.source_dataset_input_column
 


### PR DESCRIPTION
Debug mode switches off caching for `sql_pipeline_to_splink_dataframe`, but previously frames would still be added to the cache. This means they will still be picked up in areas where we look in the cache directly, not going via this method.

In particular this fixes #2428.