### PR TITLE
Specify version range for `pytest-cov` in CI

### DIFF
--- a/.github/workflows/pytest_duckdb.yml
+++ b/.github/workflows/pytest_duckdb.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          poetry add pytest-cov
+          poetry add "pytest-cov>=5.0.0"
           poetry run pytest -v --durations=0 -m "duckdb_only or core" --cov=splink --cov-report=xml --cov-report=term tests/
 
       - name: Upload coverage report


### PR DESCRIPTION
`pytest-cov` 6.0.0 dropped support for python 3.8 support.

If we don't specify, `poetry add` will add it as `^6.0.0` (even when running on python 3.8). This causes dependency resolution to fail. Note that this happens even for the tests on python >= 3.9, as it finds that our general support for `>=3.8` is incompatible with `pytest-cov = ^6.0.0`.

Output:
```
The current project's supported Python range (>=3.8.0,<4.0.0) is not compatible with some of the required packages Python requirement:
  - pytest-cov requires Python >=3.9, so it will not be satisfied for Python >=3.8.0,<3.9

Because no versions of pytest-cov match >6.0.0,<7.0.0
 and pytest-cov (6.0.0) requires Python >=3.9, pytest-cov is forbidden.
So, because splink depends on pytest-cov (^6.0.0), version solving failed.
```

For now we can add `pytest-cov` as `>=5.0.0`.

First hint of some friction with 3.8 - see #2476.