### PR TITLE
Compare two records - allow dataframes to be registered 

### DIFF
--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -686,13 +686,30 @@ class LinkerInference:
         cache = self._linker._intermediate_table_cache
 
         uid = ascii_uid(8)
+
+        # Check if input is a DuckDB relation without importing DuckDB
+        if isinstance(record_1, dict):
+            to_register_left = [record_1]
+        else:
+            to_register_left = record_1
+
+        if isinstance(record_2, dict):
+            to_register_right = [record_2]
+        else:
+            to_register_right = record_2
+
         df_records_left = self._linker.table_management.register_table(
-            [record_1], f"__splink__compare_two_records_left_{uid}", overwrite=True
+            to_register_left,
+            f"__splink__compare_two_records_left_{uid}",
+            overwrite=True,
         )
+
         df_records_left.templated_name = "__splink__compare_two_records_left"
 
         df_records_right = self._linker.table_management.register_table(
-            [record_2], f"__splink__compare_two_records_right_{uid}", overwrite=True
+            to_register_right,
+            f"__splink__compare_two_records_right_{uid}",
+            overwrite=True,
         )
         df_records_right.templated_name = "__splink__compare_two_records_right"
 


### PR DESCRIPTION
Here's a reprex of the current inability to use the function if you use date types:

<details>
<summary>Click to expand</summary>

```python
import datetime

import pandas as pd

import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets
from splink.exploratory import profile_columns

db_api = DuckDBAPI()
con = db_api._con

df = splink_datasets.fake_1000
df.loc[df.index[::2], "dob"] = None
profile_columns(df, db_api, column_expressions=["dob"])

sql = """
create table in_data
as
select
* exclude(dob), cast(dob as date) as dob
from df
"""
con.execute(sql)


settings = SettingsCreator(
    link_type="dedupe_only",
    comparisons=[
        cl.ExactMatch("first_name"),
        cl.ExactMatch("surname"),
        cl.DateOfBirthComparison("dob", input_is_string=False),
        cl.ExactMatch("city").configure(term_frequency_adjustments=True),
        cl.ExactMatch("email"),
    ],
    blocking_rules_to_generate_predictions=[
        block_on("first_name"),
        block_on("surname"),
    ],
    max_iterations=2,
    retain_intermediate_calculation_columns=True,
    retain_matching_columns=True,
)

linker = Linker("in_data", settings, db_api)

linker.training.estimate_probability_two_random_records_match(
    [block_on("first_name", "surname")], recall=0.7
)

linker.training.estimate_u_using_random_sampling(max_pairs=1e6)

linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))
df.head(2).to_dict(orient="records")
r1 = {
    "unique_id": 0,
    "first_name": "Robert",
    "surname": "Alan",
    "dob": None,
    "city": None,
    "email": "robert255@smith.net",
}

r2 = {
    "unique_id": 1,
    "first_name": "Robert",
    "surname": "Allen",
    "dob": datetime.date(1971, 5, 24),
    "city": None,
    "email": "roberta25@smith.net",
}


linker.inference.compare_two_records(r1, r2)


```
</details>

This PR allows like:
```

# How about if the records are duckdbpyrelation
sql = """
select *
from in_data
limit 1
"""
r1 = con.sql(sql)

sql = """
select *
from in_data
limit 1 offset 1
"""
r2 = con.sql(sql)

linker.inference.compare_two_records(r1, r2)
```


See https://github.com/moj-analytical-services/splink/issues/2423 - a fix for the Spark issues is coming in https://github.com/moj-analytical-services/splink/pull/2426