### PR TITLE
Spark test session handling

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -188,11 +188,14 @@ class LazyDict(UserDict):
     # write only in creation
     def __init__(self, **kwargs):
         self.data = {}
+        # set of keys we have accessed
+        self.accessed = set()
         for key, val in kwargs.items():
             self.data[key] = val
 
     def __getitem__(self, key):
         func, args = self.data[key]
+        self.accessed.add(key)
         return func(*args)
 
     def __setitem__(self, key, value):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,7 +71,11 @@ class SparkTestHelper(TestHelper):
         return SparkAPI
 
     def db_api_args(self):
-        return {"spark_session": self.spark, "num_partitions_on_repartition": 1}
+        return {
+            "spark_session": self.spark,
+            "num_partitions_on_repartition": 1,
+            "break_lineage_method": "checkpoint",
+        }
 
     def convert_frame(self, df):
         spark_frame = self.spark.createDataFrame(df)


### PR DESCRIPTION
Fixes two unrelated issues occurring in Spark tests.

## Cleanup

We cleanup the spark session when the relevant fixture falls out of scope. This is necessary as otherwise we might get out-of-date catalogs meaning spark thinks tables exist when they don't. This can lead to undesired coupling between tests, if we reuse table names.

This required a slight tweak to the `LazyDict` test utility class, so that we can find out if the `spark` dialect was accessed in a given test session, so we know we have to clean up after it.

## Break lineage

The other issue occurs when we wish to query a table that has no rows. This happens particularly when computing clusters in debug mode (debug mode meaning we are querying a table rather than being part of a CTE). Using the `parquet` `break_lineage_method` spark will (sometimes?) optimise these tables away, and then when you come to query them you get an error.

Instead we switch to using the `checkpoint` method (when using the `test_helpers` fixture). This also has a speed boost - all `spark_only` tests now run in ~590s instead of ~700s previously. I don't _think_ this should have any significant impact in terms of functionality - in any case I think if so we should be able to isolate that by testing individual `break_lineage_method`s in isolation.