### PR TITLE
Deprecation warning for python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Deprecated
+
+- Deprecated support for python `3.8.x` following end of support for that minor version ([#2520](https://github.com/moj-analytical-services/splink/pull/2520))
+
 ## [4.0.6] - 2024-12-05
 
 ### Added

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -1,4 +1,6 @@
+from sys import version_info
 from typing import TYPE_CHECKING
+from warnings import warn
 
 from splink.internals.blocking_rule_library import block_on
 from splink.internals.column_expression import ColumnExpression
@@ -16,6 +18,19 @@ from splink.internals.settings_creator import SettingsCreator
 if TYPE_CHECKING:
     from splink.internals.duckdb.database_api import DuckDBAPI
     from splink.internals.spark.database_api import SparkAPI
+
+if version_info.minor == 8:
+    warn(
+        (
+            "Python 3.8 has reached end-of-life.  "
+            "Future releases of Splink may no longer be compatible with "
+            "this python version.\n"
+            "Please consider upgrading your python version if you wish "
+            "to continue to be able to install the latest version of Splink."
+        ),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 # Use getarr to make the error appear at the point of use


### PR DESCRIPTION
Closes #2476.

As outlined in the linked issue, according to our docs we have a policy of dropping support for python versions after end-of-life, following an additional 6-month grace period.

I don't think we need to drop support for 3.8 any time soon. We don't really need to stop until it becomes too cumbersome to continue to support, which for now it's not. But this will likely change as time goes on - several (maybe most?) of our dependencies don't support 3.8 in their latest releases, so we will probably encounter issues at some point with this mismatch.

I think it will be good to get this deprecation warning in now. It doesn't commit us to any particular timeline, but gives people warning that if they will need to upgrade their python version to continue getting the latest version of Splink. If we start warning now, we should be giving people plenty of notice to be able to manage that upgrade. Then when the time comes that 3.8 becomes difficult to keep supporting we can (potentially) just drop it, as affected users should have had plenty of notice by that point.