### PR TITLE
Explicit tf columns select

### DIFF
--- a/scripts/postgres_docker/teardown.sh
+++ b/scripts/postgres_docker/teardown.sh
@@ -2,4 +2,4 @@
 # run from root
 
 # remove -v (removing volume) if you want to keep data
-docker-compose -f scripts/postgres/docker-compose.yaml down -v
+docker-compose -f scripts/postgres_docker/docker-compose.yaml down -v

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -58,9 +58,10 @@ def _join_tf_to_df_concat_sql(linker: Linker) -> str:
         tbl = colname_to_tf_tablename(col)
         select_cols.append(f"{tbl}.{col.tf_name}")
 
-    input_columns = linker._input_columns()
+    column_names_in_df_concat = linker._concat_table_column_names
+
     aliased_concat_column_names = [
-        f"__splink__df_concat.{col.name} AS {col.name}" for col in input_columns
+        f"__splink__df_concat.{col} AS {col}" for col in column_names_in_df_concat
     ]
 
     select_cols = aliased_concat_column_names + select_cols

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -58,7 +58,12 @@ def _join_tf_to_df_concat_sql(linker: Linker) -> str:
         tbl = colname_to_tf_tablename(col)
         select_cols.append(f"{tbl}.{col.tf_name}")
 
-    select_cols.insert(0, "__splink__df_concat.*")
+    input_columns = linker._input_columns()
+    aliased_concat_column_names = [
+        f"__splink__df_concat.{col.name} AS {col.name}" for col in input_columns
+    ]
+
+    select_cols = aliased_concat_column_names + select_cols
     select_cols_str = ", ".join(select_cols)
 
     templ = "left join {tbl} on __splink__df_concat.{col} = {tbl}.{col}"
@@ -72,7 +77,7 @@ def _join_tf_to_df_concat_sql(linker: Linker) -> str:
     left_joins_str = " ".join(left_joins)
 
     sql = f"""
-    select {select_cols_str }
+    select {select_cols_str}
     from __splink__df_concat
     {left_joins_str}
     """


### PR DESCRIPTION
Use `_concat_table_column_name` to make column names explicit in tf select SQL to avoid potential ambiguities in multi-join statement.