### PR TITLE
Add Spark support for PairwiseStringDistanceFunction

### DIFF
--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -679,7 +679,10 @@ class PairwiseStringDistanceFunctionLevel(ComparisonLevelCreator):
                                 )
                             )
                         ),
-                        pair -> {distance_function_name_transpiled}(pair[{sql_dialect.array_first_index}], pair[{sql_dialect.array_first_index + 1}])
+                        pair -> {distance_function_name_transpiled}(
+                            pair[{sql_dialect.array_first_index}],
+                            pair[{sql_dialect.array_first_index + 1}]
+                        )
                     )
                 ) {self._comparator()} {self.distance_threshold}"""
 

--- a/splink/internals/dialects.py
+++ b/splink/internals/dialects.py
@@ -108,28 +108,26 @@ class SplinkDialect(ABC):
             f"Backend '{self.sql_dialect_str}' does not have a "
             "'Cosine Similarity' function"
         )
-    
+
     @property
     def array_max_function_name(self):
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have an "
-            "'Array max' function"
+            f"Backend '{self.sql_dialect_str}' does not have an 'Array max' function"
         )
-    
+
     @property
     def array_min_function_name(self):
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have an "
-            "'Array min' function"
+            f"Backend '{self.sql_dialect_str}' does not have an 'Array min' function"
         )
-    
+
     @property
     def array_transform_function_name(self):
         raise NotImplementedError(
             f"Backend '{self.sql_dialect_str}' does not have an "
             "'Array transform' function"
         )
-    
+
     @property
     def array_first_index(self):
         raise NotImplementedError(
@@ -229,19 +227,19 @@ class DuckDBDialect(SplinkDialect):
     @property
     def jaccard_function_name(self):
         return "jaccard"
-    
+
     @property
     def array_max_function_name(self):
         return "list_max"
-    
+
     @property
     def array_min_function_name(self):
         return "list_min"
-    
+
     @property
     def array_transform_function_name(self):
         return "list_transform"
-    
+
     @property
     def array_first_index(self):
         return 1
@@ -344,19 +342,19 @@ class SparkDialect(SplinkDialect):
     @property
     def jaccard_function_name(self):
         return "jaccard"
-    
+
     @property
     def array_max_function_name(self):
         return "array_max"
-    
+
     @property
     def array_min_function_name(self):
         return "array_min"
-    
+
     @property
     def array_transform_function_name(self):
         return "transform"
-    
+
     @property
     def array_first_index(self):
         return 0

--- a/splink/internals/dialects.py
+++ b/splink/internals/dialects.py
@@ -108,6 +108,34 @@ class SplinkDialect(ABC):
             f"Backend '{self.sql_dialect_str}' does not have a "
             "'Cosine Similarity' function"
         )
+    
+    @property
+    def array_max_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.sql_dialect_str}' does not have an "
+            "'Array max' function"
+        )
+    
+    @property
+    def array_min_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.sql_dialect_str}' does not have an "
+            "'Array min' function"
+        )
+    
+    @property
+    def array_transform_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.sql_dialect_str}' does not have an "
+            "'Array transform' function"
+        )
+    
+    @property
+    def array_first_index(self):
+        raise NotImplementedError(
+            f"Backend '{self.sql_dialect_str}' does not have a "
+            "first array index defined"
+        )
 
     def random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None
@@ -201,6 +229,22 @@ class DuckDBDialect(SplinkDialect):
     @property
     def jaccard_function_name(self):
         return "jaccard"
+    
+    @property
+    def array_max_function_name(self):
+        return "list_max"
+    
+    @property
+    def array_min_function_name(self):
+        return "list_min"
+    
+    @property
+    def array_transform_function_name(self):
+        return "list_transform"
+    
+    @property
+    def array_first_index(self):
+        return 1
 
     @property
     def default_date_format(self):
@@ -300,6 +344,22 @@ class SparkDialect(SplinkDialect):
     @property
     def jaccard_function_name(self):
         return "jaccard"
+    
+    @property
+    def array_max_function_name(self):
+        return "array_max"
+    
+    @property
+    def array_min_function_name(self):
+        return "array_min"
+    
+    @property
+    def array_transform_function_name(self):
+        return "transform"
+    
+    @property
+    def array_first_index(self):
+        return 0
 
     @property
     def default_date_format(self):

--- a/tests/test_comparison_lib.py
+++ b/tests/test_comparison_lib.py
@@ -65,7 +65,7 @@ def test_distance_function_comparison():
             assert sum(df_pred[f"gamma_{col}"] == gamma_val) == expected_count
 
 
-@mark_with_dialects_excluding("sqlite", "spark", "postgres", "athena")
+@mark_with_dialects_excluding("sqlite", "postgres", "athena")
 def test_pairwise_stringdistance_function_comparison(test_helpers, dialect):
     helper = test_helpers[dialect]
     db_api = helper.extra_linker_args()["db_api"]
@@ -88,25 +88,25 @@ def test_pairwise_stringdistance_function_comparison(test_helpers, dialect):
                     "forename_l": ["Geof"],
                     "forename_r": ["Geoff"],
                     "expected_value": 2,
-                    "expected_label": "Min `damerau_levenshtein` distance of 'forename <= than 1'",  # noqa: E501
+                    "expected_label": "Min `damerau_levenshtein` distance of 'forename' <= than 1'",  # noqa: E501
                 },
                 {
                     "forename_l": ["Saly", "Barey"],
                     "forename_r": ["Sally", "Barry"],
                     "expected_value": 2,
-                    "expected_label": "Min `damerau_levenshtein` distance of 'forename <= than 1'",  # noqa: E501
+                    "expected_label": "Min `damerau_levenshtein` distance of 'forename' <= than 1'",  # noqa: E501
                 },
                 {
                     "forename_l": ["Carry", "Different"],
                     "forename_r": ["Barry", "Completely"],
                     "expected_value": 2,
-                    "expected_label": "Min `damerau_levenshtein` distance of 'forename <= than 1'",  # noqa: E501
+                    "expected_label": "Min `damerau_levenshtein` distance of 'forename' <= than 1'",  # noqa: E501
                 },
                 {
                     "forename_l": ["Carry", "Sabby"],
                     "forename_r": ["Cally"],
                     "expected_value": 1,
-                    "expected_label": "Min `damerau_levenshtein` distance of 'forename <= than 2'",  # noqa: E501
+                    "expected_label": "Min `damerau_levenshtein` distance of 'forename' <= than 2'",  # noqa: E501
                 },
                 {
                     "forename_l": ["Completely", "Different"],


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

Extends #2517 to support Spark in addition to DuckDB.

### Give a brief description for the solution you have provided

I figured that now that two dialects were supported, it would be cleaner to abstract away differences using the dialect objects.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


