### PR TITLE
Fix reference to similarity_jar_location

### DIFF
--- a/splink/internals/spark/database_api.py
+++ b/splink/internals/spark/database_api.py
@@ -179,7 +179,7 @@ class SparkAPI(DatabaseAPI[spark_df]):
                 "for an example.\n"
                 "You will not be able to use these functions in your linkage.\n"
                 "You can find the location of the jar by calling the following function"
-                ":\nfrom splink.spark.jar_location import similarity_jar_location"
+                ":\nfrom splink.backends.spark import similarity_jar_location"
                 "\n\nFull error:\n"
                 f"{e}"
             )


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->



### Give a brief description for the solution you have provided
Fix an out of date reference to similarity_jar_location in a warning message when jar is not registered.



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


