### PR TITLE
Fix spark database double-quoting

### DIFF
--- a/splink/internals/spark/database_api.py
+++ b/splink/internals/spark/database_api.py
@@ -155,8 +155,13 @@ class SparkAPI(DatabaseAPI[spark_df]):
         # be stored. The filter will remove none, so if catalog is not provided and
         # spark version is < 3.3.0 we will use the default catalog.
         self.splink_data_store = ".".join(
-            [f"`{x}`" for x in [catalog, database] if x is not None]
+            [self._quote_if_needed(x) for x in [catalog, database] if x is not None]
         )
+
+    def _quote_if_needed(self, identifier):
+        if identifier.startswith("`") and identifier.endswith("`"):
+            return identifier
+        return f"`{identifier}`"
 
     def _register_udfs_from_jar(self):
         # TODO: this should check if these are already registered and skip if so

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -70,6 +70,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
 
     completeness_chart(df_spark, spark_api)
 
+    spark.sql("USE DATABASE `1111`")
     linker = Linker(
         df_spark,
         settings,
@@ -77,7 +78,6 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api):
             spark_session=spark,
             break_lineage_method="checkpoint",
             num_partitions_on_repartition=2,
-            database="1111",
         ),
     )
 


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Closes #2576.

### Give a brief description for the solution you have provided
The spark session database is [coming already quoted](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala#L79) from currentDatabase() in cases when it's [not a valid identifier](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala#L49) such as `1111`. We want to avoid double quoting it. I also changed the test to pass database name through spark.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)
