### PR TITLE
`ColumnExpression` first/last index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `ColumnExpression` now supports accessing first or last element of an array column via method `access_extreme_array_element()` ([#2520](https://github.com/moj-analytical-services/splink/pull/2585))
+
 ### Deprecated
 
 - Deprecated support for python `3.8.x` following end of support for that minor version ([#2520](https://github.com/moj-analytical-services/splink/pull/2520))

--- a/docs/api_docs/column_expression.md
+++ b/docs/api_docs/column_expression.md
@@ -16,6 +16,7 @@ However, there may be situations where you don't wish to derive a new column, pe
 
 This is where a `ColumnExpression` may be used. It represents some SQL expression, which may be a column, or some more complicated construct,
 to which you can also apply zero or more transformations. These are lazily evaluated, and in particular will not be tied to a specific SQL dialect until they are put (via [settings](./settings_dict_guide.md) into a linker).
+This can be particularly useful if you want to write code that can easily be switched between different backends.
 
 ??? warning "Term frequency adjustments"
     One caveat to using a `ColumnExpression` is that it cannot be combined with term frequency adjustments.

--- a/splink/internals/column_expression.py
+++ b/splink/internals/column_expression.py
@@ -4,7 +4,7 @@ import re
 import string
 from copy import copy
 from functools import partial
-from typing import Protocol, Union
+from typing import Literal, Protocol, Union
 
 import sqlglot
 
@@ -244,6 +244,36 @@ class ColumnExpression:
         op = partial(
             clone._try_parse_timestamp_dialected,
             timestamp_format=timestamp_format,
+        )
+        clone.operations.append(op)
+
+        return clone
+
+    def _access_extreme_array_element_dialected(
+        self,
+        name: str,
+        sql_dialect: SplinkDialect,
+        first_or_last: Literal["first", "last"],
+    ) -> str:
+        return sql_dialect.access_extreme_array_element(
+            name, first_or_last=first_or_last
+        )
+
+    def access_extreme_array_element(
+        self, first_or_last: Literal["first", "last"]
+    ) -> "ColumnExpression":
+        """
+        Applies a transformation to access either the first or the last element
+        of an array
+
+        Args:
+            first_or_last (str): 'first' for returning the first elemen of the array,
+                'last' for the last element
+        """
+        clone = self._clone()
+        op = partial(
+            clone._access_extreme_array_element_dialected,
+            first_or_last=first_or_last,
         )
         clone.operations.append(op)
 

--- a/tests/test_column_expression.py
+++ b/tests/test_column_expression.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+from splink import ColumnExpression
+from splink.internals.dialects import SplinkDialect
+
+from .decorator import mark_with_dialects_excluding
+
+
+@mark_with_dialects_excluding("sqlite")
+def test_access_extreme_array_element(test_helpers, dialect):
+    # test data!
+    df_arr = pd.DataFrame(
+        [
+            {"unique_id": 1, "name_arr": ["first", "middle", "last"]},
+            {"unique_id": 2, "name_arr": ["aardvark", "llama", "ssnake", "zzebra"]},
+            {"unique_id": 3, "name_arr": ["only"]},
+        ]
+    )
+
+    helper = test_helpers[dialect]
+    # register table with backend
+    table_name = "arr_tab"
+    table = helper.convert_frame(df_arr)
+    db_api = helper.DatabaseAPI(**helper.db_api_args())
+    arr_tab = db_api.register_table(table, table_name)
+
+    # construct a SQL query from ColumnExpressions and run it against backend
+    splink_dialect = SplinkDialect.from_string(dialect)
+    first_element = ColumnExpression(
+        "name_arr", sql_dialect=splink_dialect
+    ).access_extreme_array_element("first")
+    last_element = ColumnExpression(
+        "name_arr", sql_dialect=splink_dialect
+    ).access_extreme_array_element("last")
+    sql = (
+        f"SELECT unique_id, {first_element.name} AS first_element, "
+        f"{last_element.name} AS last_element "
+        f"FROM {arr_tab.physical_name} ORDER BY unique_id"
+    )
+    res = db_api.sql_to_splink_dataframe_checking_cache(
+        sql, "test_first"
+    ).as_pandas_dataframe()
+
+    pd.testing.assert_series_equal(
+        res["first_element"],
+        pd.Series(["first", "aardvark", "only"], name="first_element"),
+    )
+    pd.testing.assert_series_equal(
+        res["last_element"], pd.Series(["last", "zzebra", "only"], name="last_element")
+    )


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->



### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
This provides some tooling for a dialect-agnostic way to select the first or last element of an array column, usable for instance in a blocking rule. So instead of
```python
block_on("first_names_arr[1]", "last_names_arr[-1]")
```
in duckdb, which you would need to rewrite for other backends, you could have
```python
block_on(
    ColumnExpression("first_names_arr").access_extreme_array_element("first"),
    ColumnExpression("last_names_arr").access_extreme_array_element("last"),
)
```
which will work for any backend.


### PR Checklist

- [x] Added documentation for changes
- [x] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [x] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


