### PR TITLE
ColumnExpression - `NULLIF`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new `PairwiseStringDistanceFunctionLevel` and `PairwiseStringDistanceFunctionAtThresholds`
   for comparing array columns using a string similarity on each pair of values ([#2517](https://github.com/moj-analytical-services/splink/pull/2517))
 - Compare two records now allows typed inputs, not just dict ([#2498](https://github.com/moj-analytical-services/splink/pull/2498))
-- Clustering allows match weight args not just match probability ([#2454]https://github.com/moj-analytical-services/splink/pull/2454))
+- Clustering allows match weight args not just match probability ([#2454](https://github.com/moj-analytical-services/splink/pull/2454))
 
 ### Fixed
 
@@ -185,7 +185,8 @@ Major release - see our [blog](https://moj-analytical-services.github.io/splink/
 - Corrected path for Spark `.jar` file containing UDFs to work correctly for Spark < 3.0 ([#1622](https://github.com/moj-analytical-services/splink/pull/1622))
 - Spark UDF `damerau_levensthein` is now only registered for Spark >= 3.0, as it is not compatible with earlier versions ([#1622](https://github.com/moj-analytical-services/splink/pull/1622))
 
-[Unreleased]: https://github.com/moj-analytical-services/splink/compare/4.0.5...HEAD
+[Unreleased]: https://github.com/moj-analytical-services/splink/compare/4.0.6...HEAD
+[4.0.6]: https://github.com/moj-analytical-services/splink/compare/4.0.5...4.0.6
 [4.0.5]: https://github.com/moj-analytical-services/splink/compare/4.0.4...4.0.5
 [4.0.4]: https://github.com/moj-analytical-services/splink/compare/4.0.3...4.0.4
 [4.0.3]: https://github.com/moj-analytical-services/splink/compare/4.0.2...4.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `ColumnExpression` now supports accessing first or last element of an array column via method `access_extreme_array_element()` ([#2520](https://github.com/moj-analytical-services/splink/pull/2585))
+- `ColumnExpression` now supports accessing first or last element of an array column via method `access_extreme_array_element()` ([#2585](https://github.com/moj-analytical-services/splink/pull/2585)), or converting string literals to `NULL` via `nullif()` ([#2586](https://github.com/moj-analytical-services/splink/pull/2586))
 
 ### Deprecated
 

--- a/splink/internals/column_expression.py
+++ b/splink/internals/column_expression.py
@@ -201,6 +201,34 @@ class ColumnExpression:
 
         return clone
 
+    def _nullif_dialected(
+        self,
+        name: str,
+        null_value: str,
+        sql_dialect: SplinkDialect,
+    ) -> str:
+        substr_sql = sqlglot.parse_one(f"nullif(___col___, '{null_value}')").sql(
+            dialect=sql_dialect.sqlglot_dialect
+        )
+        return substr_sql.replace("___col___", name)
+
+    def nullif(self, null_value: str) -> "ColumnExpression":
+        """
+        Applies a nullif transform to the input expression,
+        with the specified string value that should be converted to NULL.
+
+        Args:
+            null_value (str): The string literal that should be converted to NULL.
+        """
+        clone = self._clone()
+        op = partial(
+            clone._nullif_dialected,
+            null_value=null_value,
+        )
+        clone.operations.append(op)
+
+        return clone
+
     def _try_parse_date_dialected(
         self,
         name: str,

--- a/tests/test_column_expression.py
+++ b/tests/test_column_expression.py
@@ -48,3 +48,43 @@ def test_access_extreme_array_element(test_helpers, dialect):
     pd.testing.assert_series_equal(
         res["last_element"], pd.Series(["last", "zzebra", "only"], name="last_element")
     )
+
+
+@mark_with_dialects_excluding()
+def test_nullif(test_helpers, dialect):
+    df_arr = pd.DataFrame(
+        [
+            {"unique_id": 1, "name": "name_1"},
+            {"unique_id": 2, "name": ""},
+            {"unique_id": 3, "name": None},
+            {"unique_id": 4, "name": "name_4"},
+            # dataset-specific invalid value:
+            {"unique_id": 5, "name": "NA"},
+        ]
+    )
+
+    helper = test_helpers[dialect]
+    # register table with backend
+    table_name = "nully_name_table"
+    table = helper.convert_frame(df_arr)
+    db_api = helper.DatabaseAPI(**helper.db_api_args())
+    nully_table = db_api.register_table(table, table_name)
+
+    # construct a SQL query from ColumnExpressions and run it against backend
+    splink_dialect = SplinkDialect.from_string(dialect)
+    nullif_name_empty_or_na = (
+        ColumnExpression("name", sql_dialect=splink_dialect).nullif("").nullif("NA")
+    )
+
+    sql = (
+        f"SELECT unique_id, {nullif_name_empty_or_na.name} AS cleaned_name "
+        f"FROM {nully_table.physical_name} ORDER BY unique_id"
+    )
+    res = db_api.sql_to_splink_dataframe_checking_cache(
+        sql, "test_first"
+    ).as_pandas_dataframe()
+
+    pd.testing.assert_series_equal(
+        res["cleaned_name"],
+        pd.Series(["name_1", None, None, "name_4", None], name="cleaned_name"),
+    )


### PR DESCRIPTION
Following up #2585, adds an available transformation `nullif()` for wrapping columns to eliminate problematic values.

e.g.
```py
ColumnExpression("name").nullif("").nullif("NA").nullif("NOT FOUND").
```