### PR TITLE
Add ArrayIntersect default

### DIFF
--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -927,7 +927,7 @@ class CosineSimilarityLevel(ComparisonLevelCreator):
 
 
 class ArrayIntersectLevel(ComparisonLevelCreator):
-    def __init__(self, col_name: str | ColumnExpression, min_intersection: int):
+    def __init__(self, col_name: str | ColumnExpression, min_intersection: int = 1):
         """Represents a comparison level based around the size of an intersection of
         arrays
 


### PR DESCRIPTION
### Type of PR

- [X] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->

NA

### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->

`ArrayIntersect` docs say that min intersect is 1 by default, but this isn't in the code. Adding default of one to match the docstring.

### PR Checklist

- [X] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


