### PR TITLE
Bug - Realtime cache collision

### DIFF
--- a/splink/internals/comparison.py
+++ b/splink/internals/comparison.py
@@ -61,12 +61,18 @@ class Comparison:
 
     def __init__(
         self,
-        comparison_levels: List[ComparisonLevel],
+        comparison_levels: List[ComparisonLevel | dict],
         sqlglot_dialect: str,
         output_column_name: str = None,
         comparison_description: str = None,
         column_info_settings: ColumnInfoSettings = None,
     ):
+        comparison_levels: list[ComparisonLevel] = [
+            ComparisonLevel(**cl, sqlglot_dialect=sqlglot_dialect)
+            if isinstance(cl, dict)
+            else cl
+            for cl in comparison_levels
+        ]
         self.comparison_levels: list[ComparisonLevel] = comparison_levels
 
         self._column_info_settings: Optional[ColumnInfoSettings] = column_info_settings

--- a/splink/internals/comparison.py
+++ b/splink/internals/comparison.py
@@ -61,19 +61,19 @@ class Comparison:
 
     def __init__(
         self,
-        comparison_levels: List[ComparisonLevel | dict],
+        comparison_levels: List[ComparisonLevel | dict[str, Any]],
         sqlglot_dialect: str,
         output_column_name: str = None,
         comparison_description: str = None,
         column_info_settings: ColumnInfoSettings = None,
     ):
-        comparison_levels: list[ComparisonLevel] = [
+        comparison_levels_as_objs: list[ComparisonLevel] = [
             ComparisonLevel(**cl, sqlglot_dialect=sqlglot_dialect)
             if isinstance(cl, dict)
             else cl
             for cl in comparison_levels
         ]
-        self.comparison_levels: list[ComparisonLevel] = comparison_levels
+        self.comparison_levels: list[ComparisonLevel] = comparison_levels_as_objs
 
         self._column_info_settings: Optional[ColumnInfoSettings] = column_info_settings
 

--- a/splink/internals/comparison_creator.py
+++ b/splink/internals/comparison_creator.py
@@ -140,7 +140,7 @@ class ComparisonCreator(ABC):
             "comparison_description": self.create_description(),
             "output_column_name": self.create_output_column_name(),
             "comparison_levels": [
-                cl.get_comparison_level(sql_dialect_str)
+                cl.get_comparison_level(sql_dialect_str).as_dict()
                 for cl in self.get_configured_comparison_levels()
             ],
         }

--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -658,6 +658,9 @@ class ComparisonLevel:
         if self._u_probability and self._u_is_trained:
             output["u_probability"] = self.u_probability
 
+        output["fix_m_probability"] = self._fix_m_probability
+        output["fix_u_probability"] = self._fix_u_probability
+
         if self._has_tf_adjustments:
             output["tf_adjustment_column"] = self._tf_adjustment_input_column.input_name
             if self._tf_minimum_u_value != 0:

--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -15,17 +15,17 @@ from splink.internals.settings_creator import SettingsCreator
 from splink.internals.splink_dataframe import SplinkDataFrame
 
 
+
 class SQLCache:
     def __init__(self):
         self._cache = {}
 
     # TODO: if we have path/string, do we want to think about behaviour if underlying
     # file changes between calls?
-    # TODO: might need to think about how equality works with WeakKeyDictionary in case
-    # there are any gotchas
-    # TODO: maybe check if string interning affects this in some way
-    def get(self, settings: SettingsCreator | dict[str, Any] | Path | str, new_uid: str) -> str | None:
-        settings_id = id(settings)
+    def get(
+        self, settings: SettingsCreator | dict[str, Any] | Path | str, new_uid: str
+    ) -> str | None:
+        settings_id = self._cache_id(settings)
         if settings_id not in self._cache:
             return None
         sql, cached_uid, settings_ref = self._cache[settings_id]
@@ -39,10 +39,33 @@ class SQLCache:
             sql = sql.replace(cached_uid, new_uid)
         return sql
 
-    def set(self, settings: SettingsCreator | dict[str, Any] | Path | str, sql: str | None, uid: str | None) -> None:
-        settings_id = id(settings)
+    def set(
+        self,
+        settings: SettingsCreator | dict[str, Any] | Path | str,
+        sql: str | None,
+        uid: str | None,
+    ) -> None:
         if sql is not None:
-            self._cache[settings_id] = (sql, uid, ref(settings))
+            settings_id = self._cache_id(settings)
+            # kind of hacky
+            # allows us to not need to special-case retrieval - will appear as though
+            # weakref is always live, so don't need to intervene
+            settings_ref = (
+                ref(settings)
+                if isinstance(settings, SettingsCreator)
+                else (lambda x: True)
+            )
+            self._cache[settings_id] = (sql, uid, settings_ref)
+
+    @staticmethod
+    def _cache_id(settings: SettingsCreator | dict[str, Any] | Path | str):
+        if isinstance(settings, SettingsCreator):
+            return str(id(settings))
+        if isinstance(settings, str):
+            return settings
+        if isinstance(settings, Path):
+            return str(settings)
+        # TODO: dict?
 
 
 _sql_cache = SQLCache()

--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -65,7 +65,7 @@ class SQLCache:
     @staticmethod
     def _cache_id(
         settings: SettingsCreator | dict[str, Any] | Path | str, sql_dialect_str: str
-    ):
+    ) -> str:
         if isinstance(settings, SettingsCreator):
             return str(id(settings))
         if isinstance(settings, str):

--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 from pathlib import Path
 from typing import Any
 from weakref import ref
@@ -23,9 +25,13 @@ class SQLCache:
     # TODO: if we have path/string, do we want to think about behaviour if underlying
     # file changes between calls?
     def get(
-        self, settings: SettingsCreator | dict[str, Any] | Path | str, new_uid: str
+        self,
+        settings: SettingsCreator | dict[str, Any] | Path | str,
+        new_uid: str,
+        *,
+        sql_dialect_str: str,
     ) -> str | None:
-        settings_id = self._cache_id(settings)
+        settings_id = self._cache_id(settings, sql_dialect_str)
         if settings_id not in self._cache:
             return None
         sql, cached_uid, settings_ref = self._cache[settings_id]
@@ -44,28 +50,40 @@ class SQLCache:
         settings: SettingsCreator | dict[str, Any] | Path | str,
         sql: str | None,
         uid: str | None,
+        *,
+        sql_dialect_str: str,
     ) -> None:
         if sql is not None:
-            settings_id = self._cache_id(settings)
+            settings_id = self._cache_id(settings, sql_dialect_str)
             # kind of hacky
             # allows us to not need to special-case retrieval - will appear as though
             # weakref is always live, so don't need to intervene
             settings_ref = (
                 ref(settings)
                 if isinstance(settings, SettingsCreator)
-                else (lambda x: True)
+                else (lambda: True)
             )
             self._cache[settings_id] = (sql, uid, settings_ref)
 
     @staticmethod
-    def _cache_id(settings: SettingsCreator | dict[str, Any] | Path | str):
+    def _cache_id(
+        settings: SettingsCreator | dict[str, Any] | Path | str, sql_dialect_str: str
+    ):
         if isinstance(settings, SettingsCreator):
             return str(id(settings))
         if isinstance(settings, str):
             return settings
         if isinstance(settings, Path):
             return str(settings)
-        # TODO: dict?
+        # we have a dict
+        try:
+            key = json.dumps(settings)
+        except TypeError:
+            settings_dict = SettingsCreator(**settings).create_settings_dict(
+                sql_dialect_str=sql_dialect_str
+            )
+            key = json.dumps(settings_dict)
+        return key
 
 
 _sql_cache = SQLCache()
@@ -93,6 +111,7 @@ def compare_records(
     global _sql_cache
 
     uid = ascii_uid(8)
+    sql_dialect_str = db_api.sql_dialect.sql_dialect_str
 
     if isinstance(record_1, dict):
         to_register_left: AcceptableInputTableType = [record_1]
@@ -118,9 +137,11 @@ def compare_records(
     )
     df_records_right.templated_name = "__splink__compare_records_right"
 
-    settings_id = id(settings)
     if use_sql_from_cache:
-        if cached_sql := _sql_cache.get(settings, uid):
+        cached_sql = _sql_cache.get(
+            settings, uid, sql_dialect_str=sql_dialect_str
+        )
+        if cached_sql:
             return db_api._sql_to_splink_dataframe(
                 cached_sql,
                 templated_name="__splink__realtime_compare_records",
@@ -173,6 +194,8 @@ def compare_records(
         pipeline.enqueue_sql(sql, "__splink__found_by_blocking_rules")
 
     predictions = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-    _sql_cache.set(settings, predictions.sql_used_to_create, uid)
+    _sql_cache.set(
+        settings, predictions.sql_used_to_create, uid, sql_dialect_str=sql_dialect_str
+    )
 
     return predictions

--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Any
 from weakref import ref
@@ -15,7 +14,6 @@ from splink.internals.predict import (
 )
 from splink.internals.settings_creator import SettingsCreator
 from splink.internals.splink_dataframe import SplinkDataFrame
-
 
 
 class SQLCache:
@@ -40,7 +38,6 @@ class SQLCache:
             del self._cache[settings_id]
             return None
 
-        sql, cached_uid = self._cache[settings]
         if cached_uid:
             sql = sql.replace(cached_uid, new_uid)
         return sql
@@ -138,9 +135,7 @@ def compare_records(
     df_records_right.templated_name = "__splink__compare_records_right"
 
     if use_sql_from_cache:
-        cached_sql = _sql_cache.get(
-            settings, uid, sql_dialect_str=sql_dialect_str
-        )
+        cached_sql = _sql_cache.get(settings, uid, sql_dialect_str=sql_dialect_str)
         if cached_sql:
             return db_api._sql_to_splink_dataframe(
                 cached_sql,

--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from weakref import WeakKeyDictionary
+from weakref import ref
 
 from splink.internals.accuracy import _select_found_by_blocking_rules
 from splink.internals.database_api import AcceptableInputTableType, DatabaseAPISubClass
@@ -17,7 +17,7 @@ from splink.internals.splink_dataframe import SplinkDataFrame
 
 class SQLCache:
     def __init__(self):
-        self._cache: WeakKeyDictionary = WeakKeyDictionary()
+        self._cache = {}
 
     # TODO: if we have path/string, do we want to think about behaviour if underlying
     # file changes between calls?
@@ -25,7 +25,13 @@ class SQLCache:
     # there are any gotchas
     # TODO: maybe check if string interning affects this in some way
     def get(self, settings: SettingsCreator | dict[str, Any] | Path | str, new_uid: str) -> str | None:
-        if settings not in self._cache:
+        settings_id = id(settings)
+        if settings_id not in self._cache:
+            return None
+        sql, cached_uid, settings_ref = self._cache[settings_id]
+        # if reference is dead, delete cache entry and return nowt
+        if settings_ref() is None:
+            del self._cache[settings_id]
             return None
 
         sql, cached_uid = self._cache[settings]
@@ -34,8 +40,9 @@ class SQLCache:
         return sql
 
     def set(self, settings: SettingsCreator | dict[str, Any] | Path | str, sql: str | None, uid: str | None) -> None:
+        settings_id = id(settings)
         if sql is not None:
-            self._cache[settings] = (sql, uid)
+            self._cache[settings_id] = (sql, uid, ref(settings))
 
 
 _sql_cache = SQLCache()
@@ -143,6 +150,6 @@ def compare_records(
         pipeline.enqueue_sql(sql, "__splink__found_by_blocking_rules")
 
     predictions = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-    _sql_cache.set(settings_id, predictions.sql_used_to_create, uid)
+    _sql_cache.set(settings, predictions.sql_used_to_create, uid)
 
     return predictions

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -354,3 +354,70 @@ def test_realtime_cache_different_settings(test_helpers, dialect):
         df1, df2, settings_1, db_api, use_sql_from_cache=True
     ).as_record_dict()[0]["match_weight"]
     assert res1 == pytest.approx(res1_again)
+
+
+@mark_with_dialects_excluding()
+def test_realtime_cache_different_settings_dict(test_helpers, dialect):
+    helper = test_helpers[dialect]
+    db_api = helper.extra_linker_args()["db_api"]
+
+    df1 = pd.DataFrame(
+        [
+            {
+                "unique_id": 0,
+                "first_name": "Julia",
+                "surname": "Taylor",
+                "city": "London",
+                "email": "julia@email.com",
+            }
+        ]
+    )
+
+    df2 = pd.DataFrame(
+        [
+            {
+                "unique_id": 1,
+                "first_name": "Julia",
+                "surname": "Taylor",
+                "city": "London",
+                "email": "bad@address.com",
+            }
+        ]
+    )
+
+    settings_1 = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("city"),
+        ],
+        "blocking_rules_to_generate_predictions": [block_on("first_name")],
+    }
+
+    settings_2 = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("email"),
+        ],
+        "blocking_rules_to_generate_predictions": [block_on("first_name")],
+    }
+
+    res1 = compare_records(df1, df2, settings_1, db_api, use_sql_from_cache=True)
+    res1 = res1.as_record_dict()[0]["match_weight"]
+
+    res2 = compare_records(df1, df2, settings_2, db_api, use_sql_from_cache=True)
+    res2 = res2.as_record_dict()[0]["match_weight"]
+
+    # should be different results as different model
+    assert res1 != pytest.approx(res2)
+
+    res1_again = compare_records(
+        df1, df2, settings_1, db_api, use_sql_from_cache=True
+    )
+    res1_again = res1_again.as_record_dict()[0]["match_weight"]
+    # using cache
+    assert res1 == pytest.approx(res1_again)
+

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -414,10 +414,7 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
     # should be different results as different model
     assert res1 != pytest.approx(res2)
 
-    res1_again = compare_records(
-        df1, df2, settings_1, db_api, use_sql_from_cache=True
-    )
+    res1_again = compare_records(df1, df2, settings_1, db_api, use_sql_from_cache=True)
     res1_again = res1_again.as_record_dict()[0]["match_weight"]
     # using cache
     assert res1 == pytest.approx(res1_again)
-


### PR DESCRIPTION
Fixes #2515.

There were occasional failings of test runs in `tests/test_realtime.py`, particularly in CI, that would generally be resolved on re-running.

The issue was that we used `id(settings)` as a cache key. In CPython this [is simply the address of the object in memory](https://docs.python.org/3/library/functions.html#id), and in general is not guaranteed to be unique. When new objects are put in the same memory location as those that have been garbage-collected, we got cache collisions, resulting in the wrong SQL being returned.

We use a slightly different approach for a cache key to how we check if we have some SQL already cached, depending on the type of object:
* `pathlib.Path` or `str` (representing saved models) we just use the string itself
* `dict` we use a `json` dump (possibly after converting to serialisable types)
* for `SettingsCreator` we use the `id` still, but we also store a [weak reference](https://docs.python.org/3/library/weakref.html) to the object. This won't prevent it being garbage collected, but allows us to see if the object still lives. If we find a supposèd cache hit, we check the associated `weakref` (which we also keep in the cache), and if it's dead (and thus we have the case of recycled `id` values) we delete the entry and return as though we found no hit.

The custom solutions for `str` and `dict` are mainly because these cannot be (directly) `weakref`ed.

You can see in [this PR](https://github.com/ADBond/splink/pull/43) test runs where we see that this `weakref` solution is triggered, and fixes the issue (with a hack to fail the tests on a separate condition, which occurs only on that logic branch).