### PR TITLE
Duckdb as record dict no longer uses pandas

### DIFF
--- a/splink/internals/duckdb/dataframe.py
+++ b/splink/internals/duckdb/dataframe.py
@@ -43,11 +43,10 @@ class DuckDBDataFrame(SplinkDataFrame):
         if limit:
             sql += f" limit {limit}"
 
-        return (
-            self.db_api._execute_sql_against_backend(sql)
-            .to_df()
-            .to_dict(orient="records")
-        )
+        duckdb_table = self.db_api._execute_sql_against_backend(sql)
+        rows = duckdb_table.fetchall()
+        column_names = [desc[0] for desc in duckdb_table.description]
+        return [dict(zip(column_names, row)) for row in rows]
 
     def as_pandas_dataframe(self, limit: int = None) -> pd_DataFrame:
         sql = f"select * from {self.physical_name}"


### PR DESCRIPTION
Better to avoid going through pandas where possible because it causes data typing issues like https://github.com/moj-analytical-services/splink/issues/2604