### PR TITLE
Docs splink_fundamentals/settings : Make sure simple model SettingsCreator is consistent 

### DIFF
--- a/docs/topic_guides/splink_fundamentals/settings.md
+++ b/docs/topic_guides/splink_fundamentals/settings.md
@@ -33,7 +33,7 @@ settings = SettingsCreator(
     link_type="dedupe_only",
     blocking_rules_to_generate_predictions=[
         block_on("first_name"),
-        block_on("surname"),
+        block_on("surname", "dob"),
     ],
     comparisons=[
         ctl.NameComparison("first_name"),


### PR DESCRIPTION
In `splink/topic_guides/splink_fundamentals/settings` there is a later reference which discusses `block_on("surname", "dob"),` but example SettingsCreator object had only `block_on("surname"),`


### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

