### PR TITLE
Fix deprecated job steps

### DIFF
--- a/.github/workflows/poetry_pypi_release.yml
+++ b/.github/workflows/poetry_pypi_release.yml
@@ -19,7 +19,7 @@ jobs:
           pip install poetry
           poetry build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist
 
@@ -33,7 +33,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Follow-up to #2643.

Another [one of these](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) - see also #2602.