### PR TITLE
use unique_id from settings

### DIFF
--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -126,8 +126,9 @@ def estimate_u_values(linker: Linker, max_pairs: float, seed: int = None) -> Non
     # (which is what we want when we are supplying a seed)
     # don't bother when we aren't using a seed as it is needless computation
     if seed is not None:
+        uid_colname = settings_obj.column_info_settings.unique_id_input_column.name
         table_to_sample_from = (
-            f"(select * from {table_to_sample_from} order by unique_id)"
+            f"(select * from {table_to_sample_from} order by {uid_colname})"
         )
 
     pipeline = CTEPipeline()


### PR DESCRIPTION
Closes #2657

<details><summary>This now works</summary>

```python
import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets

db_api = DuckDBAPI()

df = splink_datasets.fake_1000
df["uid"] = df["unique_id"]
del df["unique_id"]
settings = SettingsCreator(
    link_type="dedupe_only",
    unique_id_column_name="uid",
    comparisons=[
        cl.ExactMatch("first_name"),
        cl.ExactMatch("surname"),
        cl.ExactMatch("dob"),
        cl.ExactMatch("city").configure(term_frequency_adjustments=True),
        cl.ExactMatch("email"),
    ],
    blocking_rules_to_generate_predictions=[
        block_on("first_name"),
        block_on("surname"),
    ],
    max_iterations=2,
    retain_intermediate_calculation_columns=True,
    retain_matching_columns=True,
)

linker = Linker(df, settings, db_api)

linker.training.estimate_probability_two_random_records_match(
    [block_on("first_name", "surname")], recall=0.7
)

linker.training.estimate_u_using_random_sampling(max_pairs=1e6, seed=123)

```
</details> 