### PR TITLE
Realtime custom join

### DIFF
--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -101,7 +101,17 @@ def compare_records(
     Args:
         record_1 (dict): First record to compare
         record_2 (dict): Second record to compare
+        settings (SettingsCreator, dict, Path, str): Model settings, or path to
+            a saved model
         db_api (DatabaseAPISubClass): Database API to use for computations
+        use_sql_from_cache (bool): Use cached SQL if available,
+            rather than re-constructing. Default True
+        include_found_by_blocking_rules (bool): Include a column indicating whether
+            or not the pairs of records would have been picked up by the supplied
+            blocking rules. Defaults to False.
+        join_condition (str): A SQL expression in terms of the tables 'l' and 'r',
+            which is used to filter which records are compared.
+            Defaults to '1=1' (meaning all pairs of records remain)
 
     Returns:
         SplinkDataFrame: Comparison results

--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -93,6 +93,7 @@ def compare_records(
     db_api: DatabaseAPISubClass,
     use_sql_from_cache: bool = True,
     include_found_by_blocking_rules: bool = False,
+    join_condition: str = "1=1",
 ) -> SplinkDataFrame:
     """Compare two records and compute similarity scores without requiring a Linker.
     Assumes any required term frequency values are provided in the input records.
@@ -161,7 +162,8 @@ def compare_records(
     sql = f"""
     select {select_expr}, 0 as match_key
     from __splink__compare_records_left as l
-    cross join __splink__compare_records_right as r
+    join __splink__compare_records_right as r
+    on {join_condition}
     """
     pipeline.enqueue_sql(sql, "__splink__compare_two_records_blocked")
 


### PR DESCRIPTION
This allows `compare_records` to use an arbitrary join condition.

The main use-case is for running a dedupe on small-scale data in realtime environments. `compare_records` is well set up for linking two sets of records, but performs redundant scoring in a dedupe case as we cannot filter the blocks.