### PR TITLE
Specify SQL cache key for realtime linking

### DIFF
--- a/splink/internals/realtime.py
+++ b/splink/internals/realtime.py
@@ -46,7 +46,7 @@ def compare_records(
     record_2: dict[str, Any] | AcceptableInputTableType,
     settings: SettingsCreator | dict[str, Any] | Path | str,
     db_api: DatabaseAPISubClass,
-    sql_cache_key: str | None = "model_sql",
+    sql_cache_key: str | None = None,
     include_found_by_blocking_rules: bool = False,
     join_condition: str = "1=1",
 ) -> SplinkDataFrame:
@@ -61,7 +61,7 @@ def compare_records(
         db_api (DatabaseAPISubClass): Database API to use for computations
         sql_cache_key (str): Use cached SQL if available, rather than re-constructing,
             stored under this cache key. If None, do not retrieve sql, or cache it.
-            Default 'model_sql'.
+            Default None.
         include_found_by_blocking_rules (bool): Include a column indicating whether
             or not the pairs of records would have been picked up by the supplied
             blocking rules. Defaults to False.

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -80,29 +80,29 @@ def test_realtime_cache_two_records(test_helpers, dialect):
         retain_matching_columns=True,
     )
 
-    res1_2_first = compare_records(df1, df2, settings, db_api).as_record_dict()[0][
-        "match_weight"
-    ]
+    res1_2_first = compare_records(
+        df1, df2, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
+    ).as_record_dict()[0]["match_weight"]
 
     res1_2_not_from_cache = compare_records(
         df1, df2, settings, db_api, sql_cache_key=None
     ).as_record_dict()[0]["match_weight"]
 
     res1_2_from_cache = compare_records(
-        df1, df2, settings, db_api, sql_cache_key="model_c2r"
+        df1, df2, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1_2_first == pytest.approx(res1_2_not_from_cache)
     assert res1_2_first == pytest.approx(res1_2_from_cache)
 
-    res1_3_first = compare_records(df1, df3, settings, db_api).as_record_dict()[0][
-        "match_weight"
-    ]
+    res1_3_first = compare_records(
+        df1, df3, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
+    ).as_record_dict()[0]["match_weight"]
     res1_3_not_from_cache = compare_records(
         df1, df3, settings, db_api, sql_cache_key=None
     ).as_record_dict()[0]["match_weight"]
     res1_3_from_cache = compare_records(
-        df1, df3, settings, db_api, sql_cache_key="model_c2r"
+        df1, df3, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1_3_first == pytest.approx(res1_3_not_from_cache)
@@ -230,13 +230,13 @@ def test_realtime_cache_multiple_records(test_helpers, dialect):
 
     # Compare df1 and df2
     res1_2_first = compare_records(
-        df1, df2, settings, db_api, sql_cache_key="model_cmr"
+        df1, df2, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
     ).as_pandas_dataframe()
     res1_2_not_from_cache = compare_records(
         df1, df2, settings, db_api, sql_cache_key=None
     ).as_pandas_dataframe()
     res1_2_from_cache = compare_records(
-        df1, df2, settings, db_api, sql_cache_key="model_cmr"
+        df1, df2, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
     ).as_pandas_dataframe()
 
     # Compare match weights using pandas merge
@@ -262,12 +262,14 @@ def test_realtime_cache_multiple_records(test_helpers, dialect):
         check_names=False,
     )
 
-    res1_3_first = compare_records(df1, df3, settings, db_api).as_pandas_dataframe()
+    res1_3_first = compare_records(
+        df1, df3, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
+    ).as_pandas_dataframe()
     res1_3_not_from_cache = compare_records(
         df1, df3, settings, db_api, sql_cache_key=None
     ).as_pandas_dataframe()
     res1_3_from_cache = compare_records(
-        df1, df3, settings, db_api, sql_cache_key="model_cmr"
+        df1, df3, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
     ).as_pandas_dataframe()
 
     merged = res1_3_first.merge(
@@ -343,17 +345,17 @@ def test_realtime_cache_different_settings(test_helpers, dialect):
     )
 
     res1 = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key="first_model"
+        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     res2 = compare_records(
-        df1, df2, settings_2, db_api, sql_cache_key="second_model"
+        df1, df2, settings_2, db_api, sql_cache_key=f"second_model_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1 != pytest.approx(res2)
 
     res1_again = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key="first_model"
+        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_{dialect}"
     ).as_record_dict()[0]["match_weight"]
     assert res1 == pytest.approx(res1_again)
 
@@ -408,12 +410,12 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
     }
 
     res1 = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key="first_model_dict"
+        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_dict_{dialect}"
     )
     res1 = res1.as_record_dict()[0]["match_weight"]
 
     res2 = compare_records(
-        df1, df2, settings_2, db_api, sql_cache_key="second_model_dict"
+        df1, df2, settings_2, db_api, sql_cache_key=f"second_model_dict_{dialect}"
     )
     res2 = res2.as_record_dict()[0]["match_weight"]
 
@@ -421,7 +423,7 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
     assert res1 != pytest.approx(res2)
 
     res1_again = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key="first_model_dict"
+        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_dict_{dialect}"
     )
     res1_again = res1_again.as_record_dict()[0]["match_weight"]
     # using cache

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -85,11 +85,11 @@ def test_realtime_cache_two_records(test_helpers, dialect):
     ]
 
     res1_2_not_from_cache = compare_records(
-        df1, df2, settings, db_api, use_sql_from_cache=False
+        df1, df2, settings, db_api, sql_cache_key=None
     ).as_record_dict()[0]["match_weight"]
 
     res1_2_from_cache = compare_records(
-        df1, df2, settings, db_api, use_sql_from_cache=True
+        df1, df2, settings, db_api, sql_cache_key="model_c2r"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1_2_first == pytest.approx(res1_2_not_from_cache)
@@ -99,10 +99,10 @@ def test_realtime_cache_two_records(test_helpers, dialect):
         "match_weight"
     ]
     res1_3_not_from_cache = compare_records(
-        df1, df3, settings, db_api, use_sql_from_cache=False
+        df1, df3, settings, db_api, sql_cache_key=None
     ).as_record_dict()[0]["match_weight"]
     res1_3_from_cache = compare_records(
-        df1, df3, settings, db_api, use_sql_from_cache=True
+        df1, df3, settings, db_api, sql_cache_key="model_c2r"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1_3_first == pytest.approx(res1_3_not_from_cache)
@@ -229,12 +229,14 @@ def test_realtime_cache_multiple_records(test_helpers, dialect):
     )
 
     # Compare df1 and df2
-    res1_2_first = compare_records(df1, df2, settings, db_api).as_pandas_dataframe()
+    res1_2_first = compare_records(
+        df1, df2, settings, db_api, sql_cache_key="model_cmr"
+    ).as_pandas_dataframe()
     res1_2_not_from_cache = compare_records(
-        df1, df2, settings, db_api, use_sql_from_cache=False
+        df1, df2, settings, db_api, sql_cache_key=None
     ).as_pandas_dataframe()
     res1_2_from_cache = compare_records(
-        df1, df2, settings, db_api, use_sql_from_cache=True
+        df1, df2, settings, db_api, sql_cache_key="model_cmr"
     ).as_pandas_dataframe()
 
     # Compare match weights using pandas merge
@@ -262,10 +264,10 @@ def test_realtime_cache_multiple_records(test_helpers, dialect):
 
     res1_3_first = compare_records(df1, df3, settings, db_api).as_pandas_dataframe()
     res1_3_not_from_cache = compare_records(
-        df1, df3, settings, db_api, use_sql_from_cache=False
+        df1, df3, settings, db_api, sql_cache_key=None
     ).as_pandas_dataframe()
     res1_3_from_cache = compare_records(
-        df1, df3, settings, db_api, use_sql_from_cache=True
+        df1, df3, settings, db_api, sql_cache_key="model_cmr"
     ).as_pandas_dataframe()
 
     merged = res1_3_first.merge(
@@ -341,17 +343,17 @@ def test_realtime_cache_different_settings(test_helpers, dialect):
     )
 
     res1 = compare_records(
-        df1, df2, settings_1, db_api, use_sql_from_cache=True
+        df1, df2, settings_1, db_api, sql_cache_key="first_model"
     ).as_record_dict()[0]["match_weight"]
 
     res2 = compare_records(
-        df1, df2, settings_2, db_api, use_sql_from_cache=True
+        df1, df2, settings_2, db_api, sql_cache_key="second_model"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1 != pytest.approx(res2)
 
     res1_again = compare_records(
-        df1, df2, settings_1, db_api, use_sql_from_cache=True
+        df1, df2, settings_1, db_api, sql_cache_key="first_model"
     ).as_record_dict()[0]["match_weight"]
     assert res1 == pytest.approx(res1_again)
 
@@ -405,16 +407,22 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
         "blocking_rules_to_generate_predictions": [block_on("first_name")],
     }
 
-    res1 = compare_records(df1, df2, settings_1, db_api, use_sql_from_cache=True)
+    res1 = compare_records(
+        df1, df2, settings_1, db_api, sql_cache_key="first_model_dict"
+    )
     res1 = res1.as_record_dict()[0]["match_weight"]
 
-    res2 = compare_records(df1, df2, settings_2, db_api, use_sql_from_cache=True)
+    res2 = compare_records(
+        df1, df2, settings_2, db_api, sql_cache_key="second_model_dict"
+    )
     res2 = res2.as_record_dict()[0]["match_weight"]
 
     # should be different results as different model
     assert res1 != pytest.approx(res2)
 
-    res1_again = compare_records(df1, df2, settings_1, db_api, use_sql_from_cache=True)
+    res1_again = compare_records(
+        df1, df2, settings_1, db_api, sql_cache_key="first_model_dict"
+    )
     res1_again = res1_again.as_record_dict()[0]["match_weight"]
     # using cache
     assert res1 == pytest.approx(res1_again)
@@ -453,7 +461,7 @@ def test_realtime_custom_join(test_helpers, dialect):
         df,
         settings,
         db_api,
-        use_sql_from_cache=False,
+        sql_cache_key=None,
     )
     # count of comparisons = 5 * 5
     assert len(res.as_record_dict()) == 25
@@ -463,7 +471,7 @@ def test_realtime_custom_join(test_helpers, dialect):
         df,
         settings,
         db_api,
-        use_sql_from_cache=False,
+        sql_cache_key=None,
         join_condition="l.unique_id < r.unique_id",
     )
     # count of comparisons = 5 * 4 / 2


### PR DESCRIPTION
Closes #2662.

After scratching my head a little about best way to handle #2662 I think I have come to the conclusion that we should just let the user specify their own key to be used for caching the SQL in `compare_records`. 

My reasoning:
* Already in the linked issue I've come across a use-case that wasn't quite catered for. I could imagine even adding a workaround for table-names could still leave other use-cases that don't work quite as desired
* It reduces some of the complexity around how this caching works, particularly making irrelevant all the complications discussed in #2515, and the fixes in #2589
* I don't think it's too burdensome on the user to have to set their own cache key, and simple if they want to use a different model
* It's probably somewhat uncommon people are using this in high-performance settings, and it's internal, so a breaking change is not awful 🫢 

Let me know any objections / if I am missing anything
