### PR TITLE
Consistent mypy version

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -24,7 +24,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.1"
+          python-version: "3.10"
           cache: "poetry"
 
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ markers = [
 ]
 
 [tool.mypy]
+python_version = "3.10"
 packages = "splink"
 # for now at least allow implicit optionals
 # to cut down on noise. Easy to fix.


### PR DESCRIPTION
Explicitly aligning the version of mypy specified in config + used in github actions, to make it easier to get results consistent with those locally.

Results will vary between different python minor versions. Pinning this version makes it easier to align with the version running in CI, and means that it easier to avoid accidentally introducing typing features not available until newer python versions. 3.10 seems a reasonable minimum, ahead of 3.9's retirement later in the year.