### PR TITLE
2710 comparison viewer performance

### DIFF
--- a/splink/internals/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/internals/files/splink_vis_utils/splink_vis_utils.js
@@ -8421,7 +8421,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 	  });
 
 	  cvd_filtered = cvd_filtered.filter(
-	    (d) => d.count_rows_in_comparison_vector_group >= filter_count
+	    (d) => d.count >= filter_count
 	  );
 
 	  if (cvd_filtered.length == 0) {

--- a/splink/internals/linker_components/visualisations.py
+++ b/splink/internals/linker_components/visualisations.py
@@ -302,6 +302,7 @@ class LinkerVisualisations:
         out_path: str,
         overwrite: bool = False,
         num_example_rows: int = 2,
+        minimum_comparison_vector_count: int = 0,
         return_html_as_string: bool = False,
     ) -> str | None:
         """Generate an interactive html visualization of the linker's predictions and
@@ -316,6 +317,11 @@ class LinkerVisualisations:
                 Defaults to False.
             num_example_rows (int, optional): Number of example rows per comparison
                 vector. Defaults to 2.
+            minimum_comparison_vector_count (int, optional): The minimum number
+                of times that a comparison vector has to occur for it to
+                be included in the dashboard. This can reduce the size of
+                the produced html file by eliminating the rarest comparison
+                vectors. Defaults to 0 (all comparison vectors are included).
             return_html_as_string: If True, return the html as a string
 
         Examples:
@@ -340,7 +346,11 @@ class LinkerVisualisations:
         sql = comparison_vector_distribution_sql(self._linker)
         pipeline.enqueue_sql(sql, "__splink__df_comparison_vector_distribution")
 
-        sqls = comparison_viewer_table_sqls(self._linker, num_example_rows)
+        sqls = comparison_viewer_table_sqls(
+            self._linker,
+            num_example_rows,
+            minimum_comparison_vector_count,
+        )
         pipeline.enqueue_list_of_sqls(sqls)
 
         df = self._linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -58,8 +58,7 @@ def row_examples(
     sql = """
     select *,
         ROW_NUMBER() OVER (PARTITION BY gam_concat order by rand_order)
-            AS row_example_index,
-        COUNT(*) OVER (PARTITION BY gam_concat) AS count
+            AS row_example_index
     from __splink__df_predict_with_row_id
     """
 
@@ -93,7 +92,7 @@ def comparison_viewer_table_sqls(
     sql = """
     select ser.*,
            cvd.sum_gam,
-           cvd.count_rows_in_comparison_vector_group,
+           cvd.count_rows_in_comparison_vector_group as count,
            cvd.proportion_of_comparisons
     from __splink__df_example_rows as ser
     left join

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -85,11 +85,13 @@ def row_examples(
 
 
 def comparison_viewer_table_sqls(
-    linker: Linker, example_rows_per_category: int = 2
+    linker: Linker,
+    example_rows_per_category: int = 2,
+    minimum_comparison_vector_count: int = 0,
 ) -> list[dict[str, str]]:
     sqls = row_examples(linker, example_rows_per_category)
 
-    sql = """
+    sql = f"""
     select ser.*,
            cvd.sum_gam,
            cvd.count_rows_in_comparison_vector_group as count,
@@ -98,6 +100,7 @@ def comparison_viewer_table_sqls(
     left join
      __splink__df_comparison_vector_distribution as cvd
     on ser.gam_concat = cvd.gam_concat
+    where cvd.count_rows_in_comparison_vector_group >= {minimum_comparison_vector_count}
     """
 
     sql_info = {

--- a/tests/test_comparison_viewer_dashboard.py
+++ b/tests/test_comparison_viewer_dashboard.py
@@ -1,0 +1,129 @@
+import os
+
+import pandas as pd
+
+import splink.comparison_library as cl
+from splink import DuckDBAPI, Linker
+from splink.internals.comparison_vector_distribution import (
+    comparison_vector_distribution_sql,
+)
+from splink.internals.pipeline import CTEPipeline
+from splink.internals.splink_comparison_viewer import (
+    comparison_viewer_table_sqls,
+)
+
+from .basic_settings import get_settings_dict
+from .decorator import mark_with_dialects_including
+
+
+@mark_with_dialects_including("duckdb")
+def test_comparison_viewer_dashboard(tmp_path):
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    settings_dict = get_settings_dict()
+
+    linker = Linker(
+        df,
+        settings=settings_dict,
+        db_api=DuckDBAPI(),
+    )
+
+    df_predict = linker.inference.predict()
+
+    linker.visualisations.comparison_viewer_dashboard(
+        df_predict,
+        os.path.join(tmp_path, "test_scv.html"),
+        overwrite=True,
+        num_example_rows=5,
+        minimum_comparison_vector_count=10,
+    )
+
+
+@mark_with_dialects_including("duckdb")
+def test_comparison_viewer_table():
+    # contrived input data to get 10 name agreements
+    # and 5 name disagreements.
+    df = pd.DataFrame(
+        {
+            "unique_id": [1, 2, 3, 4, 5, 6],
+            "first_name": [
+                "JOHN",
+                "JOHN",
+                "JOHN",
+                "JOHN",
+                "JOHN",
+                "HENRY",
+            ],
+        }
+    )
+
+    settings_dict = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            cl.ExactMatch("first_name"),
+        ],
+        "blocking_rules_to_generate_predictions": [
+            "1=1",
+        ],
+        "retain_matching_columns": True,
+        "retain_intermediate_calculation_columns": True,
+    }
+
+    linker = Linker(
+        df,
+        settings=settings_dict,
+        db_api=DuckDBAPI(),
+    )
+
+    df_predict = linker.inference.predict()
+
+    pipeline = CTEPipeline([df_predict])
+    sql = comparison_vector_distribution_sql(linker)
+    pipeline.enqueue_sql(sql, "__splink__df_comparison_vector_distribution")
+
+    sqls = comparison_viewer_table_sqls(
+        linker,
+        4,
+        minimum_comparison_vector_count=0,
+    )
+    pipeline.enqueue_list_of_sqls(sqls)
+
+    df = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
+    result = df.as_pandas_dataframe()[["gamma_first_name", "count"]]
+    result = result.value_counts().reset_index(name="value_count")
+
+    correct_result = pd.DataFrame(
+        {
+            "gamma_first_name": [0, 1],
+            "count": [5, 10],
+            "value_count": [4, 4],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, correct_result, check_dtype=False)
+
+    # now test with a higher minimum
+
+    pipeline = CTEPipeline([df_predict])
+    sql = comparison_vector_distribution_sql(linker)
+    pipeline.enqueue_sql(sql, "__splink__df_comparison_vector_distribution")
+
+    sqls = comparison_viewer_table_sqls(
+        linker,
+        4,
+        minimum_comparison_vector_count=7,
+    )
+    pipeline.enqueue_list_of_sqls(sqls)
+
+    df = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
+    result = df.as_pandas_dataframe()[["gamma_first_name", "count"]]
+    result = result.value_counts().reset_index(name="value_count")
+
+    correct_result = pd.DataFrame(
+        {
+            "gamma_first_name": [1],
+            "count": [10],
+            "value_count": [4],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, correct_result, check_dtype=False)


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [x] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Closes #2710 


### Give a brief description for the solution you have provided
Removed the redundant window function that counted the number of rows in each comparison vector group. Added an option for filtering out comparison vector groups which have a count below a given threshold. 


### PR Checklist

- [x] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


