### PR TITLE
Update README.md to use comparison_libary rather than comparison_template_library

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ For more detailed tutorial, please see [here](https://moj-analytical-services.gi
 
 ```py
 import splink.comparison_library as cl
-import splink.comparison_template_library as ctl
 from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets
 
 db_api = DuckDBAPI()
@@ -119,14 +118,14 @@ settings = SettingsCreator(
     comparisons=[
         cl.JaroWinklerAtThresholds("first_name", [0.9, 0.7]),
         cl.JaroAtThresholds("surname", [0.9, 0.7]),
-        ctl.DateComparison(
+        cl.DateOfBirthComparison(
             "dob",
             input_is_string=True,
             datetime_metrics=["year", "month"],
             datetime_thresholds=[1, 1],
         ),
         cl.ExactMatch("city").configure(term_frequency_adjustments=True),
-        ctl.EmailComparison("email"),
+        cl.EmailComparison("email"),
     ],
     blocking_rules_to_generate_predictions=[
         block_on("first_name"),


### PR DESCRIPTION
`comparison_template_library` removed in splink v4 according to https://github.com/moj-analytical-services/splink/discussions/2415. While the example at the [getting started](https://moj-analytical-services.github.io/splink/getting_started.html) page was updated, the QUICKSTART in the README.md file still references the old `comparison_template_libary`. 

### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [X ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

No. Related discussion is here for different part of docs website: https://github.com/moj-analytical-services/splink/discussions/2415

### Give a brief description for the solution you have provided

Update the README example to import from comparison_library rather than comparison_template_library for splink v4. Also updates relevant comparisons from the `ctl` to `cl` import. 



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [ ] Made changes based off the latest version of Splink
- [ ] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)

Hello! Small thing I ran into when updating to v4, hopefully that is okay. Thank you for this library!!
