### PR TITLE
Updating instances of linker.predict to linker.inference.predict in the docs

### DIFF
--- a/splink/internals/graph_metrics.py
+++ b/splink/internals/graph_metrics.py
@@ -40,7 +40,7 @@ def _node_degree_centralisation_sql(
     This is includes nodes with no edges, as identified via the clusters table.
 
     Args:
-        df_predict (SplinkDataFrame): The results of `linker.predict()`.
+        df_predict (SplinkDataFrame): The results of `linker.inference.predict()`.
         df_clustered (SplinkDataFrame): The outputs of
                 `linker.cluster_pairwise_predictions_at_threshold()`.
         composite_uid_edges_l (str): unique id for left-hand edges.

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -65,7 +65,7 @@ class Linker:
     model.
 
     Most of Splink's functionality can  be accessed by calling methods (functions)
-    on the linker, such as `linker.predict()`, `linker.profile_columns()` etc.
+    on the linker, such as `linker.inference.predict()`, `linker.profile_columns()` etc.
 
     The Linker class is intended for subclassing for specific backends, e.g.
     a `DuckDBLinker`.

--- a/splink/internals/linker_components/clustering.py
+++ b/splink/internals/linker_components/clustering.py
@@ -56,7 +56,7 @@ class LinkerClustering:
         the same entity).
 
         Args:
-            df_predict (SplinkDataFrame): The results of `linker.predict()`
+            df_predict (SplinkDataFrame): The results of `linker.inference.predict()`
             threshold_match_probability (float, optional): Pairwise comparisons with a
                 `match_probability` at or above this threshold are matched
             threshold_match_weight (float, optional): Pairwise comparisons with a
@@ -200,7 +200,7 @@ class LinkerClustering:
         `duplicate_free_datasets`.
 
         Args:
-            df_predict (SplinkDataFrame): The results of `linker.predict()`
+            df_predict (SplinkDataFrame): The results of `linker.inference.predict()`
             duplicate_free_datasets: (List[str]): The source datasets which should be
                 treated as having no duplicates. Clusters will not form with more than
                 one record from each of these datasets. This can be a subset of all of
@@ -454,7 +454,7 @@ class LinkerClustering:
         Internal function for computing cluster-level metrics.
 
         Accepts output of `linker._compute_node_metrics()` (which has the relevant
-        information from `linker.predict() and
+        information from `linker.inference.predict()` and
         `linker.clustering.cluster_pairwise_at_threshold()`), produces a table of
         cluster metrics.
 

--- a/splink/internals/linker_components/visualisations.py
+++ b/splink/internals/linker_components/visualisations.py
@@ -311,7 +311,7 @@ class LinkerVisualisations:
 
 
         Args:
-            df_predict (SplinkDataFrame): The outputs of `linker.predict()`
+            df_predict (SplinkDataFrame): The outputs of `linker.inference.predict()`
             out_path (str): The path (including filename) to save the html file to.
             overwrite (bool, optional): Overwrite the html file if it already exists?
                 Defaults to False.
@@ -326,7 +326,7 @@ class LinkerVisualisations:
 
         Examples:
             ```py
-            df_predictions = linker.predict()
+            df_predictions = linker.inference.predict()
             linker.visualisations.comparison_viewer_dashboard(
                 df_predictions, "scv.html", True, 2
             )
@@ -382,7 +382,7 @@ class LinkerVisualisations:
         save to `out_path`.
 
         Args:
-            df_predict (SplinkDataFrame): The outputs of `linker.predict()`
+            df_predict (SplinkDataFrame): The outputs of `linker.inference.predict()`
             df_clustered (SplinkDataFrame): The outputs of
                 `linker.cluster_pairwise_predictions_at_threshold()`
             out_path (str): The path (including filename) to save the html file to.


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?



### Give a brief description for the solution you have provided

I noticed a case of the docs referring to `linker.predict()` so I did a quick search and replace for any other cases of that.


### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


