### PR TITLE
(WIP) Speed enhancement: 'Pushing up' common elements of CASE statements into reused computations

### DIFF
--- a/splink/internals/comparison.py
+++ b/splink/internals/comparison.py
@@ -85,7 +85,7 @@ class Comparison:
             comparison_description or self._default_comparison_description()
         )
 
-        self.experimental_optimisation = True
+        self.experimental_function_reuse_optimisation = False
 
         # Assign comparison vector values starting at highest level, count down to 0
         num_levels = self._num_levels

--- a/splink/internals/comparison.py
+++ b/splink/internals/comparison.py
@@ -85,6 +85,8 @@ class Comparison:
             comparison_description or self._default_comparison_description()
         )
 
+        self.experimental_optimisation = True
+
         # Assign comparison vector values starting at highest level, count down to 0
         num_levels = self._num_levels
         counter = num_levels - 1

--- a/splink/internals/comparison_vector_values.py
+++ b/splink/internals/comparison_vector_values.py
@@ -47,7 +47,7 @@ def compute_comparison_vector_values_from_id_pairs_sqls(
     source_dataset_input_column: Optional[InputColumn],
     unique_id_input_column: InputColumn,
     include_clerical_match_score: bool = False,
-    experimental_optimisation: bool = True,
+    experimental_function_reuse_optimisation: bool = False,
 ) -> list[dict[str, str]]:
     """Compute the comparison vectors from __splink__blocked_id_pairs, the
     materialised dataframe of blocked pairwise record comparisons.
@@ -85,7 +85,7 @@ def compute_comparison_vector_values_from_id_pairs_sqls(
 
     sqls.append({"sql": sql, "output_table_name": "blocked_with_cols"})
 
-    if experimental_optimisation:
+    if experimental_function_reuse_optimisation:
         # Find repeated functions and get modified columns
         repeated_functions, modified_columns = _find_repeated_functions(
             columns_to_select_for_comparison_vector_values,
@@ -111,7 +111,7 @@ def compute_comparison_vector_values_from_id_pairs_sqls(
     else:
         clerical_match_score = ""
 
-    if experimental_optimisation:
+    if experimental_function_reuse_optimisation:
         table_select_from = "reusable_function_values_optimisation"
     else:
         table_select_from = "blocked_with_cols"

--- a/splink/internals/em_training_session.py
+++ b/splink/internals/em_training_session.py
@@ -57,7 +57,7 @@ class EMTrainingSession:
         fix_m_probabilities: bool = False,
         fix_probability_two_random_records_match: bool = False,
         estimate_without_term_frequencies: bool = False,
-        experimental_optimisation: bool = False,
+        experimental_function_reuse_optimisation: bool = False,
     ):
         logger.info("\n----- Starting EM training session -----\n")
 
@@ -76,7 +76,9 @@ class EMTrainingSession:
 
         self._blocking_rule_for_training = blocking_rule_for_training
         self.estimate_without_term_frequencies = estimate_without_term_frequencies
-        self.experimental_optimisation = experimental_optimisation
+        self.experimental_function_reuse_optimisation = (
+            experimental_function_reuse_optimisation
+        )
 
         self._comparison_levels_to_reverse_blocking_rule: list[
             ComparisonAndLevelDict
@@ -201,7 +203,7 @@ class EMTrainingSession:
             input_tablename_r="__splink__df_concat_with_tf",
             source_dataset_input_column=orig_settings.column_info_settings.source_dataset_input_column,
             unique_id_input_column=orig_settings.column_info_settings.unique_id_input_column,
-            experimental_optimisation=self.experimental_optimisation,
+            experimental_function_reuse_optimisation=self.experimental_function_reuse_optimisation,
         )
 
         pipeline.enqueue_list_of_sqls(sqls)

--- a/splink/internals/em_training_session.py
+++ b/splink/internals/em_training_session.py
@@ -57,6 +57,7 @@ class EMTrainingSession:
         fix_m_probabilities: bool = False,
         fix_probability_two_random_records_match: bool = False,
         estimate_without_term_frequencies: bool = False,
+        experimental_optimisation: bool = False,
     ):
         logger.info("\n----- Starting EM training session -----\n")
 
@@ -75,6 +76,7 @@ class EMTrainingSession:
 
         self._blocking_rule_for_training = blocking_rule_for_training
         self.estimate_without_term_frequencies = estimate_without_term_frequencies
+        self.experimental_optimisation = experimental_optimisation
 
         self._comparison_levels_to_reverse_blocking_rule: list[
             ComparisonAndLevelDict
@@ -199,6 +201,7 @@ class EMTrainingSession:
             input_tablename_r="__splink__df_concat_with_tf",
             source_dataset_input_column=orig_settings.column_info_settings.source_dataset_input_column,
             unique_id_input_column=orig_settings.column_info_settings.unique_id_input_column,
+            experimental_optimisation=self.experimental_optimisation,
         )
 
         pipeline.enqueue_list_of_sqls(sqls)

--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -64,7 +64,12 @@ def _proportion_sample_size_link_only(
     return proportion, sample_size
 
 
-def estimate_u_values(linker: Linker, max_pairs: float, seed: int = None) -> None:
+def estimate_u_values(
+    linker: Linker,
+    max_pairs: float,
+    seed: int = None,
+    experimental_optimisation: bool = True,
+) -> None:
     logger.info("----- Estimating u probabilities using random sampling -----")
     pipeline = CTEPipeline()
 
@@ -198,6 +203,7 @@ def estimate_u_values(linker: Linker, max_pairs: float, seed: int = None) -> Non
         input_tablename_r="__splink__df_concat_sample",
         source_dataset_input_column=settings_obj.column_info_settings.source_dataset_input_column,
         unique_id_input_column=settings_obj.column_info_settings.unique_id_input_column,
+        experimental_optimisation=experimental_optimisation,
     )
 
     pipeline.enqueue_list_of_sqls(sqls)

--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -68,7 +68,7 @@ def estimate_u_values(
     linker: Linker,
     max_pairs: float,
     seed: int = None,
-    experimental_optimisation: bool = True,
+    experimental_function_reuse_optimisation: bool = False,
 ) -> None:
     logger.info("----- Estimating u probabilities using random sampling -----")
     pipeline = CTEPipeline()
@@ -203,7 +203,7 @@ def estimate_u_values(
         input_tablename_r="__splink__df_concat_sample",
         source_dataset_input_column=settings_obj.column_info_settings.source_dataset_input_column,
         unique_id_input_column=settings_obj.column_info_settings.unique_id_input_column,
-        experimental_optimisation=experimental_optimisation,
+        experimental_function_reuse_optimisation=experimental_function_reuse_optimisation,
     )
 
     pipeline.enqueue_list_of_sqls(sqls)

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -272,7 +272,6 @@ class LinkerInference:
             input_tablename_r="__splink__df_concat_with_tf",
             source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
             unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
-            include_clerical_match_score=False,
             experimental_function_reuse_optimisation=experimental_function_reuse_optimisation,
         )
         pipeline.enqueue_list_of_sqls(sqls)

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -158,7 +158,7 @@ class LinkerInference:
         threshold_match_weight: float = None,
         materialise_after_computing_term_frequencies: bool = True,
         materialise_blocked_pairs: bool = True,
-        experimental_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = False,
     ) -> SplinkDataFrame:
         """Create a dataframe of scored pairwise comparisons using the parameters
         of the linkage model.
@@ -181,8 +181,9 @@ class LinkerInference:
                 computed as part of a large CTE pipeline.   Defaults to True
             materialise_blocked_pairs: In the blocking phase, materialise the table
                 of pairs of records that will be scored
-            experimental_optimisation (bool): If true, enables experimental SQL
-                optimization that reuses repeated function calls. Defaults to True.
+            experimental_function_reuse_optimisation (bool): If true, enables
+                experimental SQL optimization that reuses repeated function calls.
+                Defaults to False.
 
         Examples:
             ```py
@@ -272,7 +273,7 @@ class LinkerInference:
             source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
             unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
             include_clerical_match_score=False,
-            experimental_optimisation=experimental_optimisation,
+            experimental_function_reuse_optimisation=experimental_function_reuse_optimisation,
         )
         pipeline.enqueue_list_of_sqls(sqls)
 
@@ -303,7 +304,7 @@ class LinkerInference:
         df_predict: SplinkDataFrame = None,
         threshold_match_probability: float = None,
         threshold_match_weight: float = None,
-        experimental_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = False,
     ) -> SplinkDataFrame:
         """
         Given a table of clustered records, create a dataframe of scored
@@ -330,8 +331,9 @@ class LinkerInference:
             threshold_match_weight (float, optional): If specified,
                 filter the results to include only pairwise comparisons with a
                 match_weight above this threshold. Defaults to None.
-            experimental_optimisation (bool): If true, enables experimental SQL
-                optimization that reuses repeated function calls. Defaults to True.
+            experimental_function_reuse_optimisation (bool): If true, enables
+                experimental SQL optimization that reuses repeated function
+                calls. Defaults to False.
 
         Examples:
             ```py
@@ -452,7 +454,7 @@ class LinkerInference:
             input_tablename_r=blocking_input_tablename_r,
             source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
             unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
-            experimental_optimisation=experimental_optimisation,
+            experimental_function_reuse_optimisation=experimental_function_reuse_optimisation,
         )
         pipeline.enqueue_list_of_sqls(sqls)
 
@@ -481,7 +483,7 @@ class LinkerInference:
         | dict[str, Any]
         | str = [],
         match_weight_threshold: float = -4,
-        experimental_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = False,
     ) -> SplinkDataFrame:
         """Given one or more records, find records in the input dataset(s) which match
         and return in order of the Splink prediction score.
@@ -498,8 +500,9 @@ class LinkerInference:
                 provided to the linker when it was instantiated. Defaults to [].
             match_weight_threshold (int, optional): Return matches with a match weight
                 above this threshold. Defaults to -4.
-            experimental_optimisation (bool): If true, enables experimental SQL
-                optimization that reuses repeated function calls. Defaults to True.
+            experimental_function_reuse_optimisation (bool): If true, enables
+                experimental SQL optimization that reuses repeated function calls.
+                Defaults to False.
 
         Examples:
             ```py
@@ -627,7 +630,7 @@ class LinkerInference:
             input_tablename_r="__splink__df_new_records_with_tf",
             source_dataset_input_column=settings.column_info_settings.source_dataset_input_column,
             unique_id_input_column=settings.column_info_settings.unique_id_input_column,
-            experimental_optimisation=experimental_optimisation,
+            experimental_function_reuse_optimisation=experimental_function_reuse_optimisation,
         )
 
         pipeline.enqueue_list_of_sqls(sqls)
@@ -663,7 +666,7 @@ class LinkerInference:
         record_1: dict[str, Any] | AcceptableInputTableType,
         record_2: dict[str, Any] | AcceptableInputTableType,
         include_found_by_blocking_rules: bool = False,
-        experimental_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = False,
     ) -> SplinkDataFrame:
         """Use the linkage model to compare and score a pairwise record comparison
         based on the two input records provided.
@@ -685,8 +688,9 @@ class LinkerInference:
                 indicating whether the record pair would have been found by any of the
                 blocking rules specified in
                 settings.blocking_rules_to_generate_predictions. Defaults to False.
-            experimental_optimisation (bool): If true, enables experimental SQL
-                optimization that reuses repeated function calls. Defaults to True.
+            experimental_function_reuse_optimisation (bool): If true, enables
+                experimental SQL optimization that reuses repeated function calls.
+                Defaults to False.
 
         Examples:
             ```py

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -158,6 +158,7 @@ class LinkerInference:
         threshold_match_weight: float = None,
         materialise_after_computing_term_frequencies: bool = True,
         materialise_blocked_pairs: bool = True,
+        experimental_optimisation: bool = True,
     ) -> SplinkDataFrame:
         """Create a dataframe of scored pairwise comparisons using the parameters
         of the linkage model.
@@ -180,6 +181,8 @@ class LinkerInference:
                 computed as part of a large CTE pipeline.   Defaults to True
             materialise_blocked_pairs: In the blocking phase, materialise the table
                 of pairs of records that will be scored
+            experimental_optimisation (bool): If true, enables experimental SQL
+                optimization that reuses repeated function calls. Defaults to True.
 
         Examples:
             ```py
@@ -268,6 +271,8 @@ class LinkerInference:
             input_tablename_r="__splink__df_concat_with_tf",
             source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
             unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
+            include_clerical_match_score=False,
+            experimental_optimisation=experimental_optimisation,
         )
         pipeline.enqueue_list_of_sqls(sqls)
 
@@ -298,6 +303,7 @@ class LinkerInference:
         df_predict: SplinkDataFrame = None,
         threshold_match_probability: float = None,
         threshold_match_weight: float = None,
+        experimental_optimisation: bool = True,
     ) -> SplinkDataFrame:
         """
         Given a table of clustered records, create a dataframe of scored
@@ -324,6 +330,8 @@ class LinkerInference:
             threshold_match_weight (float, optional): If specified,
                 filter the results to include only pairwise comparisons with a
                 match_weight above this threshold. Defaults to None.
+            experimental_optimisation (bool): If true, enables experimental SQL
+                optimization that reuses repeated function calls. Defaults to True.
 
         Examples:
             ```py
@@ -444,6 +452,7 @@ class LinkerInference:
             input_tablename_r=blocking_input_tablename_r,
             source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
             unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
+            experimental_optimisation=experimental_optimisation,
         )
         pipeline.enqueue_list_of_sqls(sqls)
 
@@ -472,6 +481,7 @@ class LinkerInference:
         | dict[str, Any]
         | str = [],
         match_weight_threshold: float = -4,
+        experimental_optimisation: bool = True,
     ) -> SplinkDataFrame:
         """Given one or more records, find records in the input dataset(s) which match
         and return in order of the Splink prediction score.
@@ -488,6 +498,8 @@ class LinkerInference:
                 provided to the linker when it was instantiated. Defaults to [].
             match_weight_threshold (int, optional): Return matches with a match weight
                 above this threshold. Defaults to -4.
+            experimental_optimisation (bool): If true, enables experimental SQL
+                optimization that reuses repeated function calls. Defaults to True.
 
         Examples:
             ```py
@@ -615,6 +627,7 @@ class LinkerInference:
             input_tablename_r="__splink__df_new_records_with_tf",
             source_dataset_input_column=settings.column_info_settings.source_dataset_input_column,
             unique_id_input_column=settings.column_info_settings.unique_id_input_column,
+            experimental_optimisation=experimental_optimisation,
         )
 
         pipeline.enqueue_list_of_sqls(sqls)
@@ -650,6 +663,7 @@ class LinkerInference:
         record_1: dict[str, Any] | AcceptableInputTableType,
         record_2: dict[str, Any] | AcceptableInputTableType,
         include_found_by_blocking_rules: bool = False,
+        experimental_optimisation: bool = True,
     ) -> SplinkDataFrame:
         """Use the linkage model to compare and score a pairwise record comparison
         based on the two input records provided.
@@ -671,6 +685,8 @@ class LinkerInference:
                 indicating whether the record pair would have been found by any of the
                 blocking rules specified in
                 settings.blocking_rules_to_generate_predictions. Defaults to False.
+            experimental_optimisation (bool): If true, enables experimental SQL
+                optimization that reuses repeated function calls. Defaults to True.
 
         Examples:
             ```py

--- a/splink/internals/linker_components/training.py
+++ b/splink/internals/linker_components/training.py
@@ -169,7 +169,7 @@ class LinkerTraining:
         self,
         max_pairs: float = 1e6,
         seed: int = None,
-        experimental_function_reuse_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = False,
     ) -> None:
         """Estimate the u parameters of the linkage model using random sampling.
 

--- a/splink/internals/linker_components/training.py
+++ b/splink/internals/linker_components/training.py
@@ -166,7 +166,10 @@ class LinkerTraining:
         )
 
     def estimate_u_using_random_sampling(
-        self, max_pairs: float = 1e6, seed: int = None
+        self,
+        max_pairs: float = 1e6,
+        seed: int = None,
+        experimental_optimisation: bool = True,
     ) -> None:
         """Estimate the u parameters of the linkage model using random sampling.
 
@@ -193,6 +196,8 @@ class LinkerTraining:
             seed (int): Seed for random sampling. Assign to get reproducible u
                 probabilities. Note, seed for random sampling is only supported for
                 DuckDB and Spark, for Athena and SQLite set to None.
+            experimental_optimisation (bool): If true, enables experimental SQL
+                optimization that reuses repeated function calls. Defaults to False.
 
         Examples:
             ```py
@@ -212,7 +217,7 @@ class LinkerTraining:
                 "result in more accurate estimates, but with a longer run time."
             )
 
-        estimate_u_values(self._linker, max_pairs, seed)
+        estimate_u_values(self._linker, max_pairs, seed, experimental_optimisation)
         self._linker._populate_m_u_from_trained_values()
 
         self._linker._settings_obj._columns_without_estimated_parameters_message()
@@ -225,6 +230,7 @@ class LinkerTraining:
         fix_m_probabilities: bool = False,
         fix_u_probabilities: bool = True,
         populate_probability_two_random_records_match_from_trained_values: bool = False,
+        experimental_optimisation: bool = True,
     ) -> EMTrainingSession:
         """Estimate the parameters of the linkage model using expectation maximisation.
 
@@ -268,6 +274,8 @@ class LinkerTraining:
             populate_prob... (bool,optional): The full name of this parameter is
                 populate_probability_two_random_records_match_from_trained_values. If
                 True, derive this parameter from the blocked value. Defaults to False.
+            experimental_optimisation (bool): If true, enables experimental SQL
+                optimization that reuses repeated function calls. Defaults to False.
 
         Examples:
             ```py
@@ -308,6 +316,7 @@ class LinkerTraining:
             fix_m_probabilities=fix_m_probabilities,
             fix_probability_two_random_records_match=fix_probability_two_random_records_match,
             estimate_without_term_frequencies=estimate_without_term_frequencies,
+            experimental_optimisation=experimental_optimisation,
         )
 
         core_model_settings = em_training_session._train()

--- a/splink/internals/linker_components/training.py
+++ b/splink/internals/linker_components/training.py
@@ -123,7 +123,7 @@ class LinkerTraining:
                 f"Deterministic matching rules led to more "
                 f"observed matches than is consistent with supplied recall. "
                 f"With these rules, recall must be at least "
-                f"{num_observed_matches/num_total_comparisons:,.2f}."
+                f"{num_observed_matches / num_total_comparisons:,.2f}."
             )
 
         num_expected_matches = num_observed_matches / recall
@@ -138,7 +138,7 @@ class LinkerTraining:
                 f"If this is truly the case then you do not need "
                 f"to run the linkage model.\n"
                 f"However this is usually in error; "
-                f"expected rules to have recall of {100*recall:,.0f}%. "
+                f"expected rules to have recall of {100 * recall:,.0f}%. "
                 f"Consider revising rules as they may have an error."
             )
         if prob == 1:
@@ -155,7 +155,7 @@ class LinkerTraining:
 
         self._linker._settings_obj._probability_two_random_records_match = prob
 
-        reciprocal_prob = "Infinity" if prob == 0 else f"{1/prob:,.2f}"
+        reciprocal_prob = "Infinity" if prob == 0 else f"{1 / prob:,.2f}"
         logger.info(
             f"Probability two random records match is estimated to be  {prob:.3g}.\n"
             f"This means that amongst all possible pairwise record comparisons, one in "
@@ -169,7 +169,7 @@ class LinkerTraining:
         self,
         max_pairs: float = 1e6,
         seed: int = None,
-        experimental_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = True,
     ) -> None:
         """Estimate the u parameters of the linkage model using random sampling.
 
@@ -196,8 +196,9 @@ class LinkerTraining:
             seed (int): Seed for random sampling. Assign to get reproducible u
                 probabilities. Note, seed for random sampling is only supported for
                 DuckDB and Spark, for Athena and SQLite set to None.
-            experimental_optimisation (bool): If true, enables experimental SQL
-                optimization that reuses repeated function calls. Defaults to False.
+            experimental_function_reuse_optimisation (bool): If true, enables
+                experimental SQL optimization that reuses repeated function calls.
+                Defaults to False.
 
         Examples:
             ```py
@@ -217,7 +218,9 @@ class LinkerTraining:
                 "result in more accurate estimates, but with a longer run time."
             )
 
-        estimate_u_values(self._linker, max_pairs, seed, experimental_optimisation)
+        estimate_u_values(
+            self._linker, max_pairs, seed, experimental_function_reuse_optimisation
+        )
         self._linker._populate_m_u_from_trained_values()
 
         self._linker._settings_obj._columns_without_estimated_parameters_message()
@@ -230,7 +233,7 @@ class LinkerTraining:
         fix_m_probabilities: bool = False,
         fix_u_probabilities: bool = True,
         populate_probability_two_random_records_match_from_trained_values: bool = False,
-        experimental_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = True,
     ) -> EMTrainingSession:
         """Estimate the parameters of the linkage model using expectation maximisation.
 
@@ -274,7 +277,7 @@ class LinkerTraining:
             populate_prob... (bool,optional): The full name of this parameter is
                 populate_probability_two_random_records_match_from_trained_values. If
                 True, derive this parameter from the blocked value. Defaults to False.
-            experimental_optimisation (bool): If true, enables experimental SQL
+            experimental_function_reuse_optimisation (bool): If true, enables experimental SQL
                 optimization that reuses repeated function calls. Defaults to False.
 
         Examples:
@@ -316,7 +319,7 @@ class LinkerTraining:
             fix_m_probabilities=fix_m_probabilities,
             fix_probability_two_random_records_match=fix_probability_two_random_records_match,
             estimate_without_term_frequencies=estimate_without_term_frequencies,
-            experimental_optimisation=experimental_optimisation,
+            experimental_function_reuse_optimisation=experimental_function_reuse_optimisation,
         )
 
         core_model_settings = em_training_session._train()

--- a/splink/internals/linker_components/training.py
+++ b/splink/internals/linker_components/training.py
@@ -123,7 +123,7 @@ class LinkerTraining:
                 f"Deterministic matching rules led to more "
                 f"observed matches than is consistent with supplied recall. "
                 f"With these rules, recall must be at least "
-                f"{num_observed_matches / num_total_comparisons:,.2f}."
+                f"{num_observed_matches/num_total_comparisons:,.2f}."
             )
 
         num_expected_matches = num_observed_matches / recall
@@ -138,7 +138,7 @@ class LinkerTraining:
                 f"If this is truly the case then you do not need "
                 f"to run the linkage model.\n"
                 f"However this is usually in error; "
-                f"expected rules to have recall of {100 * recall:,.0f}%. "
+                f"expected rules to have recall of {100*recall:,.0f}%. "
                 f"Consider revising rules as they may have an error."
             )
         if prob == 1:
@@ -155,7 +155,7 @@ class LinkerTraining:
 
         self._linker._settings_obj._probability_two_random_records_match = prob
 
-        reciprocal_prob = "Infinity" if prob == 0 else f"{1 / prob:,.2f}"
+        reciprocal_prob = "Infinity" if prob == 0 else f"{1/prob:,.2f}"
         logger.info(
             f"Probability two random records match is estimated to be  {prob:.3g}.\n"
             f"This means that amongst all possible pairwise record comparisons, one in "

--- a/splink/internals/linker_components/training.py
+++ b/splink/internals/linker_components/training.py
@@ -233,7 +233,7 @@ class LinkerTraining:
         fix_m_probabilities: bool = False,
         fix_u_probabilities: bool = True,
         populate_probability_two_random_records_match_from_trained_values: bool = False,
-        experimental_function_reuse_optimisation: bool = True,
+        experimental_function_reuse_optimisation: bool = False,
     ) -> EMTrainingSession:
         """Estimate the parameters of the linkage model using expectation maximisation.
 

--- a/splink/internals/reusable_function_detection.py
+++ b/splink/internals/reusable_function_detection.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, List, Tuple
+
+from sqlglot import exp, parse_one
+
+
+def _find_repeated_functions(
+    columns_to_select_for_comparison_vector_values: List[str],
+    sqlglot_dialect: str,
+) -> Tuple[List[Dict[str, str]], List[str]]:
+    """
+    Detect function sub-expressions that are used more than once inside CASE
+    expressions and rewrite the columns so they refer to computed aliases.
+
+    Example
+    -------
+    >>> sql = "CASE WHEN foo(a) > 0.5 THEN 2 WHEN foo(a) > 0.2 THEN 1 ELSE 0 END"
+    >>> repeated, modified = _find_repeated_functions([sql], "duckdb")
+    >>> repeated
+    [{'function_sql': 'foo(a)', 'alias': 'rf_1'}]
+    >>> modified
+    ["CASE WHEN rf_1 > 0.5 THEN 2 WHEN rf_1 > 0.2 THEN 1 ELSE 0 END"]
+    """
+
+    case_asts = [
+        parse_one(col, read=sqlglot_dialect)
+        for col in columns_to_select_for_comparison_vector_values
+        if col.lstrip().upper().startswith("CASE")
+    ]
+
+    func_counts: Counter[exp.Expression] = Counter()
+    for ast in case_asts:
+        func_counts.update(fn for fn in ast.find_all(exp.Func))
+
+    # Func counts looks for whether there are multiple identical nodes in the tree
+    # and count them like:
+    #  case when ... count:1
+    #  jaro(...)     count:4
+    # this leverages the fact that the __hash__ of a node allows an __eq__ comparison
+    # and hence we can use a simple counter to find duplicate nodes
+
+    repeated: set[exp.Expression] = {fn for fn, c in func_counts.items() if c > 1}
+
+    # Keep only the root duplicates (not nested inside another dup)
+    def is_nested_in_repeated(fn: exp.Func) -> bool:
+        parent = fn.parent
+        while parent:
+            if isinstance(parent, exp.Func) and parent in repeated:
+                return True
+            parent = parent.parent
+        return False
+
+    # This is just for human readibility - it means the name rf_1 reliably
+    # corresponds to the first duplicate function seen in the sql and so on
+    roots_in_order: list[exp.Func] = []
+    seen: set[exp.Expression] = set()  # protect against re-adding same struct
+    for ast in case_asts:
+        for fn in ast.find_all(exp.Func):
+            if fn in repeated and not is_nested_in_repeated(fn) and fn not in seen:
+                roots_in_order.append(fn)
+                seen.add(fn)
+
+    var_mapping: Dict[exp.Expression, str] = {}
+    repeated_functions: list[dict[str, str]] = []
+
+    for idx, fn in enumerate(roots_in_order, start=1):
+        alias = f"rf_{idx}"
+        var_mapping[fn] = alias
+        repeated_functions.append(
+            {
+                "function_sql": fn.sql(dialect=sqlglot_dialect),
+                "alias": alias,
+            }
+        )
+
+    def _replace(node: exp.Expression) -> exp.Expression:
+        # Only root duplicates are in var_mapping
+        if isinstance(node, exp.Func) and node in var_mapping:
+            return exp.to_identifier(var_mapping[node])
+        return node
+
+    # Modified columns is the old case statements with the repeated
+    # functions replaced by their aliases (i.e. rf_1, rf_2 etc)
+    # which will have been calculated at the previous step
+    modified_columns: list[str] = []
+    for col in columns_to_select_for_comparison_vector_values:
+        if col.lstrip().upper().startswith("CASE"):
+            ast = parse_one(col, read=sqlglot_dialect)
+            modified_columns.append(
+                ast.transform(_replace).sql(dialect=sqlglot_dialect)
+            )
+        else:
+            modified_columns.append(col)
+
+    return repeated_functions, modified_columns
+
+
+def _build_reusable_functions_sql(repeated_functions: List[Dict[str, str]]) -> str:
+    """
+    Build a CTE that selects *, repeated_functions from the `blocked_with_cols` table
+    i.e. it 'precomputes' any repeated functions so they can be used at the next
+    step of the CTE chain
+    """
+    if not repeated_functions:
+        return "SELECT * FROM blocked_with_cols"
+
+    computed_cols = ",\n           ".join(
+        f"{f['function_sql']} AS {f['alias']}" for f in repeated_functions
+    )
+    return f"""SELECT *,
+           {computed_cols}
+    FROM blocked_with_cols"""

--- a/tests/test_sql_optimisation.py
+++ b/tests/test_sql_optimisation.py
@@ -482,4 +482,5 @@ def test_optimisation_with_multiple_complex_comparisons():
 
     # This was calculated on master branch prior to the optimisation
     # so this is a check that the new implementation gives exactly the same result
+    # Note estimate u is deterministic because it creates all pairs
     assert pytest.approx(-64.830722) == predictions_df["match_weight"].sum()

--- a/tests/test_sql_optimisation.py
+++ b/tests/test_sql_optimisation.py
@@ -467,10 +467,8 @@ def test_optimisation_with_multiple_complex_comparisons():
         "max_iterations": 2,
     }
 
-    # Set up linker and run predictions
     linker = Linker(df, settings, db_api=DuckDBAPI(connection=con))
 
-    # Train the model
     linker.training.estimate_u_using_random_sampling(
         max_pairs=10000, experimental_function_reuse_optimisation=True
     )
@@ -478,7 +476,6 @@ def test_optimisation_with_multiple_complex_comparisons():
         block_on("surname"), experimental_function_reuse_optimisation=True
     )
 
-    # Get predictions
     predictions_df = linker.inference.predict(
         experimental_function_reuse_optimisation=True
     ).as_pandas_dataframe()

--- a/tests/test_sql_optimisation.py
+++ b/tests/test_sql_optimisation.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import duckdb
+import pandas as pd
+import pytest
+from sqlglot import parse_one
+
+import splink.comparison_level_library as cll
+from splink.internals.blocking_rule_library import block_on
+from splink.internals.comparison_library import (
+    ArrayIntersectAtSizes,
+    CustomComparison,
+    ExactMatch,
+    JaroWinklerAtThresholds,
+)
+from splink.internals.duckdb.database_api import DuckDBAPI
+from splink.internals.linker import Linker
+from splink.internals.reusable_function_detection import _find_repeated_functions
+from tests.decorator import mark_with_dialects_excluding, mark_with_dialects_including
+
+
+def create_test_data(
+    con: duckdb.DuckDBPyConnection | None = None, return_as_ddb_table=False
+):
+    con = con or duckdb.connect(":memory:")
+    data = [
+        {
+            "unique_id": 1,
+            "first_name": "John",
+            "surname": "Smith",
+            "name_tokens": ["john", "j", "johnny"],
+            "name_tokens_with_freq": [
+                {"token": "john", "rel_freq": 0.001},
+                {"token": "j", "rel_freq": 0.01},
+            ],
+            "postcode": "AB12 3CD",
+        },
+        {
+            "unique_id": 2,
+            "first_name": "Johnny",
+            "surname": "Smith",
+            "name_tokens": ["johnny", "john", "j"],
+            "name_tokens_with_freq": [
+                {"token": "johnny", "rel_freq": 0.002},
+                {"token": "j", "rel_freq": 0.01},
+            ],
+            "postcode": "AB12 3CD",
+        },
+        {
+            "unique_id": 3,
+            "first_name": "Jon",
+            "surname": "Smith",
+            "name_tokens": ["jon", "j"],
+            "name_tokens_with_freq": [
+                {"token": "jon", "rel_freq": 0.003},
+                {"token": "j", "rel_freq": 0.01},
+            ],
+            "postcode": "AB12 3CD",
+        },
+        {
+            "unique_id": 4,
+            "first_name": "Jon",
+            "surname": "Smyth",
+            "name_tokens": ["jane", "j"],
+            "name_tokens_with_freq": [
+                {"token": "jon", "rel_freq": 0.004},
+                {"token": "j", "rel_freq": 0.01},
+            ],
+            "postcode": "AB12 3CD",
+        },
+    ]
+
+    # Impose explicit schema
+    con.execute("""
+        CREATE TABLE df (
+            unique_id INTEGER,
+            first_name VARCHAR,
+            surname VARCHAR,
+            name_tokens VARCHAR[],
+            name_tokens_with_freq STRUCT(token VARCHAR, rel_freq FLOAT)[],
+            postcode VARCHAR
+        )
+    """)
+
+    con.executemany(
+        """
+        INSERT INTO df
+        (unique_id, first_name, surname, name_tokens, name_tokens_with_freq, postcode)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """,
+        [
+            (
+                d["unique_id"],
+                d["first_name"],
+                d["surname"],
+                d["name_tokens"],
+                d["name_tokens_with_freq"],
+                d["postcode"],
+            )
+            for d in data
+        ],
+    )
+
+    if return_as_ddb_table:
+        return con.table("df")
+    else:
+        return pd.DataFrame(data)
+
+
+def calculate_tf_product_array_sql(token_rel_freq_array_name):
+    sql = f"""
+    list_reduce(
+        list_prepend(
+            1.0::FLOAT,
+            list_transform(
+                list_intersect(
+                    {token_rel_freq_array_name}_l,
+                    {token_rel_freq_array_name}_r
+                ),
+                x -> x.rel_freq::float
+            )
+        ),
+        (p, q) -> p * q
+    )"""
+    # Removing all newlines and spaces
+    return "".join(sql.split())
+
+
+@mark_with_dialects_including("duckdb")
+def test_optimisation_with_custom_comparison():
+    """Test that the SQL optimization works with complex term frequency comparisons"""
+    # Set up DuckDB specific test data
+    con = duckdb.connect(":memory:")
+    df = create_test_data(con, return_as_ddb_table=True)
+
+    # Complex comparison with term frequencies - DuckDB specific syntax
+    custom_rel_freq_comparison = {
+        "output_column_name": "name_tokens_with_freq",
+        "comparison_levels": [
+            cll.NullLevel("name_tokens_with_freq"),
+            {
+                "sql_condition": f"""
+                    {calculate_tf_product_array_sql("name_tokens_with_freq")} < 1e-12
+                """,
+                "label_for_charts": "Array product is less than 1e-12",
+            },
+            {
+                "sql_condition": f"""
+                    {calculate_tf_product_array_sql("name_tokens_with_freq")} < 1e-8
+                """,
+                "label_for_charts": "Array product is less than 1e-8",
+            },
+            {"sql_condition": "ELSE", "label_for_charts": "All other comparisons"},
+        ],
+    }
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            JaroWinklerAtThresholds("first_name", [0.9, 0.8, 0.7]),
+            ExactMatch("surname"),
+            custom_rel_freq_comparison,
+        ],
+        "blocking_rules_to_generate_predictions": [block_on("surname")],
+    }
+
+    db_api_1 = DuckDBAPI(connection=con)
+    linker_no_opt = Linker(df, settings, db_api=db_api_1)
+    df_no_opt = linker_no_opt.inference.predict(
+        experimental_optimisation=False
+    ).as_pandas_dataframe()
+
+    # Run with optimization
+    db_api_2 = DuckDBAPI(connection=con)
+    linker_opt = Linker(df, settings, db_api=db_api_2)
+    df_opt = linker_opt.inference.predict(
+        experimental_optimisation=True
+    ).as_pandas_dataframe()
+
+    assert (
+        pytest.approx(df_no_opt["match_weight"].sum()) == df_opt["match_weight"].sum()
+    )
+
+
+@mark_with_dialects_excluding("postgres", "sqlite")
+def test_optimisation_with_em_training(test_helpers, dialect):
+    """Test that the SQL optimization works correctly with EM training"""
+    # This works because estimate u is not random on a small dataset because
+    # it creates all possible pairs
+    helper = test_helpers[dialect]
+    df = create_test_data()
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            JaroWinklerAtThresholds("first_name", [0.9, 0.8, 0.7]),
+            CustomComparison(
+                output_column_name="surname",
+                comparison_levels=[
+                    cll.NullLevel("surname"),
+                    cll.ExactMatchLevel("surname"),
+                    cll.JaroWinklerLevel("surname", distance_threshold=0.98),
+                    cll.LevenshteinLevel("surname", distance_threshold=1),
+                    cll.JaroWinklerLevel("surname", distance_threshold=0.9),
+                    cll.LevenshteinLevel("surname", distance_threshold=2),
+                ],
+            ),
+        ],
+        "blocking_rules_to_generate_predictions": [block_on("surname")],
+    }
+
+    linker_no_opt = Linker(df, settings, **helper.extra_linker_args())
+    linker_no_opt.training.estimate_u_using_random_sampling(
+        max_pairs=1e3, experimental_optimisation=False
+    )
+    linker_no_opt.training.estimate_parameters_using_expectation_maximisation(
+        block_on("surname"), experimental_optimisation=False
+    )
+    df_no_opt = linker_no_opt.inference.predict(
+        experimental_optimisation=False
+    ).as_pandas_dataframe()
+
+    linker_opt = Linker(df, settings, **helper.extra_linker_args())
+    linker_opt.training.estimate_u_using_random_sampling(
+        max_pairs=1e3, experimental_optimisation=True
+    )
+    linker_opt.training.estimate_parameters_using_expectation_maximisation(
+        block_on("surname"), experimental_optimisation=True
+    )
+    df_opt = linker_opt.inference.predict(
+        experimental_optimisation=True
+    ).as_pandas_dataframe()
+
+    assert (
+        pytest.approx(df_no_opt["match_weight"].sum()) == df_opt["match_weight"].sum()
+    )
+
+
+def test_find_repeated_functions_nested():
+    """Test that _find_repeated_functions only returns outermost repeated functions"""
+
+    # The function we expect to be identified as repeated
+    expected_fn = calculate_tf_product_array_sql("name_tokens_with_freq")
+    expected_ast = parse_one(expected_fn, read="duckdb")
+
+    expected_fn_fmt_diff = expected_fn.replace("\n", "").replace(" ", "")
+
+    # The full SQL with the repeated function
+    sql = f"""CASE
+    WHEN {expected_fn} < 1e-12 then 2
+    WHEN {expected_fn_fmt_diff} < 1e-12 then 1
+    ELSE 0
+    END"""
+
+    repeated_functions, _ = _find_repeated_functions([sql], "duckdb")
+
+    # Should find exactly one repeated function
+    assert len(repeated_functions) == 1
+
+    # Parse the found function and compare with expected
+    found_ast = parse_one(repeated_functions[0]["function_sql"], read="duckdb")
+    assert found_ast.sql("duckdb") == expected_ast.sql("duckdb")
+
+
+def test_find_repeated_functions_multiple():
+    expected_fns = ["fn1(a, b)", "fn2(c, d)"]
+    expected_asts = [parse_one(fn, read="duckdb") for fn in expected_fns]
+
+    sql = """CASE
+    WHEN fn1(a, b) > 0.9 AND fn2(c, d) < 3 THEN 3
+    WHEN fn1(a, b) > 0.8 AND fn2(c, d) < 4 THEN 2
+    ELSE 0
+    END"""
+
+    repeated_functions, _ = _find_repeated_functions([sql], "duckdb")
+
+    # Should find exactly two repeated functions
+    assert len(repeated_functions) == 2
+
+    # Compare found functions with expected
+    found_asts = [
+        parse_one(func["function_sql"], read="duckdb") for func in repeated_functions
+    ]
+    found_sqls = {ast.sql("duckdb") for ast in found_asts}
+    expected_sqls = {ast.sql("duckdb") for ast in expected_asts}
+    assert found_sqls == expected_sqls
+
+
+def test_find_repeated_functions_single_use():
+    """Test that _find_repeated_functions ignores non-repeated functions"""
+
+    sql = """CASE
+    WHEN fn1(a, b) > 0.9 AND fn2(c, d) < 3 THEN 3
+    WHEN fn3(a, b) < 2 THEN 2
+    ELSE 0
+    END"""
+
+    repeated_functions, _ = _find_repeated_functions([sql], "duckdb")
+    assert len(repeated_functions) == 0
+
+
+def test_find_repeated_functions_with_different_args():
+    """Test that functions with diff arguments are treated as diff functions"""
+
+    expected_fns = ["fn(a, b)", "fn(c, d)"]
+    expected_asts = [parse_one(fn, read="duckdb") for fn in expected_fns]
+
+    sql = """CASE
+    WHEN fn(a, b) > 5 AND fn(c, d) > 10 THEN 3
+    WHEN fn(a, b) > 3 AND fn(c, d) > 8 THEN 2
+    ELSE 0
+    END"""
+
+    repeated_functions, _ = _find_repeated_functions([sql], "duckdb")
+
+    # Compare found functions with expected
+    found_asts = [
+        parse_one(func["function_sql"], read="duckdb") for func in repeated_functions
+    ]
+    found_sqls = {ast.sql("duckdb") for ast in found_asts}
+    expected_sqls = {ast.sql("duckdb") for ast in expected_asts}
+    assert found_sqls == expected_sqls
+
+
+@mark_with_dialects_including("duckdb")
+def test_optimisation_with_multiple_complex_comparisons():
+    """Test matches the result when running the model pre-optimisation
+    i.e. on master before the optimisation PR was merged
+    """
+    # Set up DuckDB specific test data
+    con = duckdb.connect(":memory:")
+    df = create_test_data(con, return_as_ddb_table=True)
+
+    # Define complex comparisons
+    custom_tf_comparison = {
+        "output_column_name": "name_tokens_with_freq",
+        "comparison_levels": [
+            cll.NullLevel("name_tokens_with_freq"),
+            {
+                "sql_condition": f"""
+                    {calculate_tf_product_array_sql('name_tokens_with_freq')} < 1e-12
+                """,
+                "label_for_charts": "Array product is less than 1e-12",
+            },
+            {
+                "sql_condition": f"""
+                    {calculate_tf_product_array_sql('name_tokens_with_freq')} < 1e-8
+                """,
+                "label_for_charts": "Array product is less than 1e-8",
+            },
+            {"sql_condition": "ELSE", "label_for_charts": "All other comparisons"},
+        ],
+    }
+
+    surname_comparison = CustomComparison(
+        output_column_name="surname",
+        comparison_levels=[
+            cll.NullLevel("surname"),
+            cll.ExactMatchLevel("surname"),
+            cll.JaroWinklerLevel("surname", distance_threshold=0.98),
+            cll.LevenshteinLevel("surname", distance_threshold=1),
+            cll.JaroWinklerLevel("surname", distance_threshold=0.9),
+            cll.LevenshteinLevel("surname", distance_threshold=2),
+        ],
+    )
+
+    custom_postcode_comparison = CustomComparison(
+        output_column_name="postcode",
+        comparison_levels=[
+            cll.NullLevel("postcode"),
+            {
+                "sql_condition": """
+            LEVENSHTEIN(substr(postcode_l,1,3),substr(postcode_r,1,3)) <= 1
+            AND
+            JARO_WINKLER_SIMILARITY(postcode_l, postcode_r) >= 0.9
+            """,
+                "label_for_charts": "lev and jaro 1",
+            },
+            {
+                "sql_condition": """
+            LEVENSHTEIN(substr(postcode_l,1,3),substr(postcode_r,1,4)) <= 2
+            AND
+            JARO_WINKLER_SIMILARITY(postcode_l, postcode_r) >= 0.8
+            """,
+                "label_for_charts": "lev and jaro 2",
+            },
+        ],
+    )
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            JaroWinklerAtThresholds("first_name", [0.9, 0.8, 0.7]),
+            surname_comparison,
+            custom_tf_comparison,
+            ArrayIntersectAtSizes("name_tokens", [3, 2, 1]),
+            custom_postcode_comparison,
+        ],
+        "blocking_rules_to_generate_predictions": [block_on("surname")],
+        "max_iterations": 2,
+    }
+
+    # Set up linker and run predictions
+    linker = Linker(df, settings, db_api=DuckDBAPI(connection=con))
+
+    # Train the model
+    linker.training.estimate_u_using_random_sampling(
+        max_pairs=10000, experimental_optimisation=True
+    )
+    linker.training.estimate_parameters_using_expectation_maximisation(
+        block_on("surname"), experimental_optimisation=True
+    )
+
+    # Get predictions
+    predictions_df = linker.inference.predict(
+        experimental_optimisation=True
+    ).as_pandas_dataframe()
+
+    # This was calculated on master branch prior to the optimisation
+    # so this is a check that the new implementation gives exactly the same result
+    assert pytest.approx(-64.830722) == predictions_df["match_weight"].sum()

--- a/tests/test_sql_optimisation.py
+++ b/tests/test_sql_optimisation.py
@@ -167,14 +167,14 @@ def test_optimisation_with_custom_comparison():
     db_api_1 = DuckDBAPI(connection=con)
     linker_no_opt = Linker(df, settings, db_api=db_api_1)
     df_no_opt = linker_no_opt.inference.predict(
-        experimental_optimisation=False
+        experimental_function_reuse_optimisation=False
     ).as_pandas_dataframe()
 
     # Run with optimization
     db_api_2 = DuckDBAPI(connection=con)
     linker_opt = Linker(df, settings, db_api=db_api_2)
     df_opt = linker_opt.inference.predict(
-        experimental_optimisation=True
+        experimental_function_reuse_optimisation=True
     ).as_pandas_dataframe()
 
     assert (
@@ -211,24 +211,24 @@ def test_optimisation_with_em_training(test_helpers, dialect):
 
     linker_no_opt = Linker(df, settings, **helper.extra_linker_args())
     linker_no_opt.training.estimate_u_using_random_sampling(
-        max_pairs=1e3, experimental_optimisation=False
+        max_pairs=1e3, experimental_function_reuse_optimisation=False
     )
     linker_no_opt.training.estimate_parameters_using_expectation_maximisation(
-        block_on("surname"), experimental_optimisation=False
+        block_on("surname"), experimental_function_reuse_optimisation=False
     )
     df_no_opt = linker_no_opt.inference.predict(
-        experimental_optimisation=False
+        experimental_function_reuse_optimisation=False
     ).as_pandas_dataframe()
 
     linker_opt = Linker(df, settings, **helper.extra_linker_args())
     linker_opt.training.estimate_u_using_random_sampling(
-        max_pairs=1e3, experimental_optimisation=True
+        max_pairs=1e3, experimental_function_reuse_optimisation=True
     )
     linker_opt.training.estimate_parameters_using_expectation_maximisation(
-        block_on("surname"), experimental_optimisation=True
+        block_on("surname"), experimental_function_reuse_optimisation=True
     )
     df_opt = linker_opt.inference.predict(
-        experimental_optimisation=True
+        experimental_function_reuse_optimisation=True
     ).as_pandas_dataframe()
 
     assert (
@@ -338,13 +338,13 @@ def test_optimisation_with_multiple_complex_comparisons():
             cll.NullLevel("name_tokens_with_freq"),
             {
                 "sql_condition": f"""
-                    {calculate_tf_product_array_sql('name_tokens_with_freq')} < 1e-12
+                    {calculate_tf_product_array_sql("name_tokens_with_freq")} < 1e-12
                 """,
                 "label_for_charts": "Array product is less than 1e-12",
             },
             {
                 "sql_condition": f"""
-                    {calculate_tf_product_array_sql('name_tokens_with_freq')} < 1e-8
+                    {calculate_tf_product_array_sql("name_tokens_with_freq")} < 1e-8
                 """,
                 "label_for_charts": "Array product is less than 1e-8",
             },
@@ -405,15 +405,15 @@ def test_optimisation_with_multiple_complex_comparisons():
 
     # Train the model
     linker.training.estimate_u_using_random_sampling(
-        max_pairs=10000, experimental_optimisation=True
+        max_pairs=10000, experimental_function_reuse_optimisation=True
     )
     linker.training.estimate_parameters_using_expectation_maximisation(
-        block_on("surname"), experimental_optimisation=True
+        block_on("surname"), experimental_function_reuse_optimisation=True
     )
 
     # Get predictions
     predictions_df = linker.inference.predict(
-        experimental_optimisation=True
+        experimental_function_reuse_optimisation=True
     ).as_pandas_dataframe()
 
     # This was calculated on master branch prior to the optimisation


### PR DESCRIPTION
## Why this is closed (update 26 June 2026)

The core idea — compute an expensive function once instead of once per `CASE`
branch — is sound and does give a real speedup on DuckDB. But after revisiting
it, I'm closing this PR rather than merging it: implementing the rewrite as
an automatic, under-the-hood optimisation is very hard to make correct in
general, and DuckDB's decision not to hoist these expressions by default turns
out to be the right one.

### Why a general hoist is unsafe

In a Splink comparison the earlier `CASE` branches frequently **protect** the
later ones. The canonical example is the null / invalid-input guard:

```sql
CASE
    WHEN "email_l" IS NULL OR "email_r" IS NULL THEN -1
    WHEN jaccard("email_l", "email_r") >= 0.9 THEN 3
    WHEN jaccard("email_l", "email_r") >= 0.7 THEN 2
    ELSE 0
END
```

DuckDB intentionally does not reuse the repeated `jaccard(...)` calls here,
because the first branch short-circuits and stops the function ever being
evaluated on the rows it guards. Hoisting the call into a single up-front
computation evaluates it on every row — including the ones the guard exists
to exclude — and for some functions that raises an error rather than returning a
value:

```python
import duckdb
duckdb.sql("SELECT jaccard('', 'abc')")
# InvalidInputException: Jaccard Function: An argument too short!
```

So a blanket AST-level hoist changes *which rows a function is evaluated on*, and
can turn a previously-working model into one that errors. That is the main reason
the generic `experimental_function_reuse_optimisation` approach in this PR is hard
to justify as universally semantics-preserving.

### Recommended alternative: an opt-in pattern, documented

Rather than rewrite user SQL silently, the cleaner approach is to **document a
small, explicit pattern** users can apply when they know their function is safe
to evaluate eagerly — i.e. deterministic and safe on the guarded rows. This holds
for `jaro_winkler_similarity` and `levenshtein` (which return a value on `NULL`
and `''`), but **not** for `jaccard` (which errors on `''`).

The trick is to write the null level so the function appears in the **first**
branch. A sentinel comparison such as `= -100` never matches (Jaro-Winkler is in
`[0, 1]`, Levenshtein is `>= 0`), so the rows captured are identical to a plain
`IS NULL` check — but DuckDB now computes the function once and reuses it across
every threshold:

```python
import splink.comparison_level_library as cll
import splink.comparison_library as cl

name_comparison = cl.CustomComparison(
    output_column_name="name",
    comparison_levels=[
        # The function appears in the first branch, so DuckDB hoists it.
        # `= -100` never matches, so the null semantics are unchanged.
        cll.CustomLevel(
            "jaro_winkler_similarity(name_l, name_r) = -100 "
            "OR name_l IS NULL OR name_r IS NULL",
            label_for_charts="name is NULL",
        ).configure(is_null_level=True),
        cll.ExactMatchLevel("name"),
        cll.JaroWinklerLevel("name", 0.9),
        cll.JaroWinklerLevel("name", 0.8),
        cll.JaroWinklerLevel("name", 0.7),
        cll.ElseLevel(),
    ],
)
```

This produces **identical comparison vectors** to the standard
`cl.JaroWinklerAtThresholds("name", [0.9, 0.8, 0.7])` (verified), but with the
function lifted into a single computation.

### Proof that DuckDB reuses the computation

Comparing the two shapes over 3M name pairs on DuckDB 1.5.1 with
`EXPLAIN ANALYZE`:

**Default (null guard first)** — a single projection evaluates the `CASE` inline,
recomputing `jaro_winkler_similarity` at each threshold:

```text
│         PROJECTION        │   g
│       3,000,000 rows      │
│           0.64s           │
```

**Optimised (function first)** — DuckDB lifts the function into its own
projection (computed once), and the `CASE` projection just reads the result:

```text
│         PROJECTION        │   g
│       3,000,000 rows      │
│           0.08s           │
│         PROJECTION        │   jaro_winkler_similarity(name_l, name_r)
│       3,000,000 rows      │
│           0.27s           │
```

End-to-end this was a **~2x speedup** (best of 4 runs: `0.053s → 0.027s`) with an
identical aggregate result. A call-counting UDF confirms the mechanism exactly:
the default shape calls the function **4.0×** per non-null row, the optimised
shape **1.0×**.

### Conclusion

- The speedup is real, but only safe for functions that are deterministic and
  safe to evaluate on the rows the guard would otherwise skip.
- A general, automatic AST-level hoist can't guarantee that, so we're closing this
  PR in favour of **documenting the opt-in pattern above**.
- Longer term, a narrower backend-specific rewrite limited to known-safe,
  Splink-generated comparisons would give a cleaner correctness story than a fully
  general hoist.


## Old notes

This is a clean rewrite of #2630.  The rationale is explained further in https://github.com/moj-analytical-services/splink/issues/2580, but in a nutshell it eliminates repeated computations of potentially expensive functions in some backends, e.g

```sql
CASE
    WHEN cosine_sim(l, r) > 0.9 THEN 1
    WHEN cosine_sim(l, r) > 0.8 THEN 2
    WHEN cosine_sim(l, r) > 0.7 THEN 3
    ...
END
```

can be rewritten as:

```sql
WITH precomputed_cosine AS (
    SELECT cosine_sim(l, r) AS precompute_cosine_value, ...
)
SELECT
    CASE
        WHEN precompute_cosine_value > 0.9 THEN 1
        WHEN precompute_cosine_value > 0.8 THEN 2
        WHEN precompute_cosine_value > 0.7 THEN 3
        ...
    END
```
Note this optimisation happens 'under the hood' in some engines such as Spark, but not in others like Duckdb, see discussion with devs [here](https://github.com/duckdb/duckdb/discussions/16338).  

NOTE:  A _similar_ optimisation is implemented in DuckDB, but unfortunately our null protection means it does not work see https://github.com/moj-analytical-services/splink/issues/2929



## Implementation notes

The 'meat' of the implementation is in [reusable_function_detection.py](https://github.com/moj-analytical-services/splink/blob/optimise_reusable_functions/splink/internals/reusable_function_detection.py).

`sqlglot` has a `__hash__` function on nodes of the AST, which allows us to compare two different nodes of an AST with the equality operator (`=`).  The `=` operator therefore checks whether the two nodes are _semantically equivalent_ (i.e. they perform the same calculation, irrespective of formatting, whitespace etc).

We therefore are looking for nodes that occur more than once across the case statements.  The final step is to remove nested dupes - for the greatest speed gain we want to compute and reuse the 'largest' common expressions (e.g. if we have two instances of `fn_1(a, fn2(b,c))` then `fn2(b,c)` is duplicated, but it can be ignored because it's part of the larger `fn_1(a, fn2(b,c))` repeated expression).  The tests have coverage of this scenario.

To note: one drawback of this approach is that it means `sqlglot` rewrites the user-provided sql (i.e. parses it using their chosen dialect and then re-writes it using `.sql()`.  In some cases, this changes the sql (e.g. in sqlite the `levenshtein ` function changes to `editdist3` which is not always available ).  Hence we probably always want a flag for this feature so users can opt out.

### `experimental_function_reuse_optimisation` flag

I have currently implemented this feature behind a flag, which is off by default.  

If we use this for a few months and it seems to work fine, we'll probably want set the default on a per-backend basis e.g. on for duckdb and off for Spark (because it doesn't offer a speedup in spark).


We can observe the effect of the optimisation on the SQL and execution times with the following script

<details>
<summary>Click to expand</summary>

```python
import splink.comparison_library as cl
import pandas as pd
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets


db_api = DuckDBAPI()

df = splink_datasets.fake_1000
df = pd.concat([df] * 5)
df.reset_index(drop=True, inplace=True)
df["unique_id"] = df.index

thresholds = list([n / 100 for n in range(50, 20, -10)])
lev_thresholds = list(range(1, 4, 1))

settings = SettingsCreator(
    link_type="dedupe_only",
    comparisons=[
        cl.JaroWinklerAtThresholds("first_name", thresholds),
        cl.JaccardAtThresholds("surname", thresholds),
        cl.LevenshteinAtThresholds("email", lev_thresholds),
    ],
    blocking_rules_to_generate_predictions=[
        "1=1",
    ],
    max_iterations=2,
)

linker = Linker(df, settings, db_api)

pairwise_predictions = linker.inference.predict(
    threshold_match_weight=-10, experimental_function_reuse_optimisation=True
)

# Display all columns from prediction dataframe where first_name matches
sql = f"""
SELECT sum(match_probability)
FROM {pairwise_predictions.physical_name}
"""

display(linker.misc.query_sql(sql))


db_api2 = DuckDBAPI()
linker2 = Linker(df, settings, db_api2)

pairwise_predictions2 = linker2.inference.predict(
    threshold_match_weight=-10, experimental_function_reuse_optimisation=False
)
sql = f"""
SELECT sum(match_probability)
FROM {pairwise_predictions2.physical_name}
"""

display(linker2.misc.query_sql(sql))

```
</details>


>Blocking time: 0.26 seconds
> Predict time: 0.61 seconds

vs

> Blocking time: 0.25 seconds
> Predict time: 1.47 seconds

See also
https://github.com/duckdb/duckdb/discussions/16338