### PR TITLE
changing match_weight field to sort_avg_match_weight for the distribu…

### DIFF
--- a/splink/internals/files/splink_vis_utils/splink_vis_utils.js
+++ b/splink/internals/files/splink_vis_utils/splink_vis_utils.js
@@ -10323,7 +10323,7 @@ ${splink_vis_utils.comparison_column_table(selected_edge, ss)}`;
 						title: "Match probability"
 					},
 					{
-						field: "match_weight",
+						field: "sort_avg_match_weight",
 						type: "quantitative",
 						format: ",.2f",
 						title: "Match weight"


### PR DESCRIPTION
…tion chart

### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Closes #2742 



### Give a brief description for the solution you have provided
Use the `sort_avg_match_weight` field rather than `match_weight`. This is already calculated in `splink_comparison_viewer.py` as the product of the bayes factors excluding any tf adjustments. 



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


