### PR TITLE
Fix issue 1889

### DIFF
--- a/splink/internals/dialects.py
+++ b/splink/internals/dialects.py
@@ -135,6 +135,18 @@ class SplinkDialect(ABC):
             "first array index defined"
         )
 
+    @property
+    def greatest_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.sql_dialect_str}' does not have a " "'Greatest' function"
+        )
+
+    @property
+    def least_function_name(self):
+        raise NotImplementedError(
+            f"Backend '{self.sql_dialect_str}' does not have a " "'Least' function"
+        )
+
     def random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None
     ):
@@ -251,6 +263,14 @@ class DuckDBDialect(SplinkDialect):
     @property
     def array_first_index(self):
         return 1
+
+    @property
+    def greatest_function_name(self):
+        return "greatest"
+
+    @property
+    def least_function_name(self):
+        return "least"
 
     @property
     def default_date_format(self):
@@ -380,6 +400,14 @@ class SparkDialect(SplinkDialect):
         return 0
 
     @property
+    def greatest_function_name(self):
+        return "greatest"
+
+    @property
+    def least_function_name(self):
+        return "least"
+
+    @property
     def default_date_format(self):
         return "yyyy-MM-dd"
 
@@ -480,6 +508,15 @@ class SQLiteDialect(SplinkDialect):
     def infinity_expression(self):
         return "'infinity'"
 
+    @property
+    def greatest_function_name(self):
+        # SQLite uses min/max scalar functions instead of least/greatest
+        return "max"
+
+    @property
+    def least_function_name(self):
+        return "min"
+
     def random_sample_sql(
         self, proportion, sample_size, seed=None, table=None, unique_id=None
     ):
@@ -508,6 +545,14 @@ class PostgresDialect(SplinkDialect):
     @property
     def levenshtein_function_name(self):
         return "levenshtein"
+
+    @property
+    def greatest_function_name(self):
+        return "greatest"
+
+    @property
+    def least_function_name(self):
+        return "least"
 
     def absolute_time_difference(self, clc: AbsoluteTimeDifferenceLevel) -> str:
         # need custom solution as sqlglot gets confused by 'metric', as in Spark
@@ -634,3 +679,11 @@ class AthenaDialect(SplinkDialect):
     @property
     def levenshtein_function_name(self):
         return "levenshtein_distance"
+
+    @property
+    def greatest_function_name(self):
+        return "greatest"
+
+    @property
+    def least_function_name(self):
+        return "least"

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -284,12 +284,14 @@ def expectation_maximisation(
             sqls = predict_from_agreement_pattern_counts_sqls(
                 core_model_settings.comparisons,
                 probability_two_random_records_match,
+                splink_dialect=db_api.sql_dialect,
                 sql_infinity_expression=db_api.sql_dialect.infinity_expression,
             )
         else:
             sqls = predict_from_comparison_vectors_sqls(
                 unique_id_input_columns=unique_id_input_columns,
                 core_model_settings=core_model_settings,
+                splink_dialect=db_api.sql_dialect,
                 training_mode=True,
                 sql_infinity_expression=sql_infinity_expression,
             )

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -284,14 +284,14 @@ def expectation_maximisation(
             sqls = predict_from_agreement_pattern_counts_sqls(
                 core_model_settings.comparisons,
                 probability_two_random_records_match,
-                splink_dialect=db_api.sql_dialect,
+                sql_dialect=db_api.sql_dialect,
                 sql_infinity_expression=db_api.sql_dialect.infinity_expression,
             )
         else:
             sqls = predict_from_comparison_vectors_sqls(
                 unique_id_input_columns=unique_id_input_columns,
                 core_model_settings=core_model_settings,
-                splink_dialect=db_api.sql_dialect,
+                sql_dialect=db_api.sql_dialect,
                 training_mode=True,
                 sql_infinity_expression=sql_infinity_expression,
             )

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -583,6 +583,7 @@ class Linker:
         sql_infos = predict_from_comparison_vectors_sqls(
             unique_id_input_columns=uid_cols,
             core_model_settings=self._settings_obj.core_model_settings,
+            splink_dialect=self._sql_dialect,
             sql_infinity_expression=self._infinity_expression,
         )
         for sql_info in sql_infos:

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -583,7 +583,7 @@ class Linker:
         sql_infos = predict_from_comparison_vectors_sqls(
             unique_id_input_columns=uid_cols,
             core_model_settings=self._settings_obj.core_model_settings,
-            splink_dialect=self._sql_dialect,
+            sql_dialect=self._sql_dialect,
             sql_infinity_expression=self._infinity_expression,
         )
         for sql_info in sql_infos:

--- a/splink/internals/predict.py
+++ b/splink/internals/predict.py
@@ -27,7 +27,7 @@ def predict_from_comparison_vectors_sqls_using_settings(
     return predict_from_comparison_vectors_sqls(
         unique_id_input_columns=settings_obj.column_info_settings.unique_id_input_columns,
         core_model_settings=settings_obj.core_model_settings,
-        splink_dialect=SplinkDialect.from_string(settings_obj._sql_dialect_str),
+        sql_dialect=SplinkDialect.from_string(settings_obj._sql_dialect_str),
         threshold_match_probability=threshold_match_probability,
         threshold_match_weight=threshold_match_weight,
         retain_matching_columns=settings_obj._retain_matching_columns,
@@ -43,7 +43,7 @@ def predict_from_comparison_vectors_sqls_using_settings(
 def predict_from_comparison_vectors_sqls(
     unique_id_input_columns: List[InputColumn],
     core_model_settings: CoreModelSettings,
-    splink_dialect: SplinkDialect,
+    sql_dialect: SplinkDialect,
     threshold_match_probability: float = None,
     threshold_match_weight: float = None,
     # by default we keep off everything we don't necessarily need
@@ -102,7 +102,7 @@ def predict_from_comparison_vectors_sqls(
         prior,
         bf_terms,
         sql_infinity_expression,
-        splink_dialect,
+        sql_dialect,
     )
 
     threshold_as_mw = threshold_args_to_match_weight(
@@ -135,7 +135,7 @@ def predict_from_comparison_vectors_sqls(
 def predict_from_agreement_pattern_counts_sqls(
     comparisons: List[Comparison],
     probability_two_random_records_match: float,
-    splink_dialect: SplinkDialect,
+    sql_dialect: SplinkDialect,
     sql_infinity_expression: str = "'infinity'",
 ) -> list[dict[str, str]]:
     sqls = []
@@ -177,7 +177,7 @@ def predict_from_agreement_pattern_counts_sqls(
         prior,
         bf_terms,
         sql_infinity_expression,
-        splink_dialect,
+        sql_dialect,
     )
 
     sql = f"""
@@ -201,7 +201,7 @@ def _combine_prior_and_bfs(
     prior: float,
     bf_terms: list[str],
     sql_infinity_expr: str,
-    splink_dialect: SplinkDialect,
+    sql_dialect: SplinkDialect,
 ) -> tuple[str, str]:
     """Compute the combined Bayes factor and match probability expressions"""
     if prior == 1.0:
@@ -212,8 +212,8 @@ def _combine_prior_and_bfs(
     bf_prior = prob_to_bayes_factor(prior)
     bf_expr = f"cast({bf_prior} as float8) * " + " * ".join(bf_terms)
 
-    greatest_name = splink_dialect.greatest_function_name
-    least_name = splink_dialect.least_function_name
+    greatest_name = sql_dialect.greatest_function_name
+    least_name = sql_dialect.least_function_name
     bf_expr = f"{least_name}({greatest_name}({bf_expr}, 1e-300), 1e300)"
 
     mp_raw = f"({bf_expr})/(1+({bf_expr}))"

--- a/splink/internals/predict.py
+++ b/splink/internals/predict.py
@@ -106,13 +106,13 @@ def predict_from_comparison_vectors_sqls(
     )
 
     if threshold_as_mw is not None:
-        threshold_expr = f" where log2(least(greatest({bayes_factor_expr}, 1e-300), 1e300)) >= {threshold_as_mw} "
+        threshold_expr = f" where log2({bayes_factor_expr}) >= {threshold_as_mw} "
     else:
         threshold_expr = ""
 
     sql = f"""
     select
-    log2(least(greatest({bayes_factor_expr}, 1e-300), 1e300)) as match_weight,
+    log2({bayes_factor_expr}) as match_weight,
     {match_prob_expr} as match_probability,
     {select_cols_expr} {clerical_match_score}
     from __splink__df_match_weight_parts

--- a/splink/internals/predict.py
+++ b/splink/internals/predict.py
@@ -5,6 +5,7 @@ import logging
 from typing import List
 
 from splink.internals.comparison import Comparison
+from splink.internals.dialects import SplinkDialect
 from splink.internals.input_column import InputColumn
 from splink.internals.misc import (
     prob_to_bayes_factor,
@@ -26,6 +27,7 @@ def predict_from_comparison_vectors_sqls_using_settings(
     return predict_from_comparison_vectors_sqls(
         unique_id_input_columns=settings_obj.column_info_settings.unique_id_input_columns,
         core_model_settings=settings_obj.core_model_settings,
+        splink_dialect=SplinkDialect.from_string(settings_obj._sql_dialect_str),
         threshold_match_probability=threshold_match_probability,
         threshold_match_weight=threshold_match_weight,
         retain_matching_columns=settings_obj._retain_matching_columns,
@@ -41,6 +43,7 @@ def predict_from_comparison_vectors_sqls_using_settings(
 def predict_from_comparison_vectors_sqls(
     unique_id_input_columns: List[InputColumn],
     core_model_settings: CoreModelSettings,
+    splink_dialect: SplinkDialect,
     threshold_match_probability: float = None,
     threshold_match_weight: float = None,
     # by default we keep off everything we don't necessarily need
@@ -99,6 +102,7 @@ def predict_from_comparison_vectors_sqls(
         prior,
         bf_terms,
         sql_infinity_expression,
+        splink_dialect,
     )
 
     threshold_as_mw = threshold_args_to_match_weight(
@@ -131,6 +135,7 @@ def predict_from_comparison_vectors_sqls(
 def predict_from_agreement_pattern_counts_sqls(
     comparisons: List[Comparison],
     probability_two_random_records_match: float,
+    splink_dialect: SplinkDialect,
     sql_infinity_expression: str = "'infinity'",
 ) -> list[dict[str, str]]:
     sqls = []
@@ -172,6 +177,7 @@ def predict_from_agreement_pattern_counts_sqls(
         prior,
         bf_terms,
         sql_infinity_expression,
+        splink_dialect,
     )
 
     sql = f"""
@@ -192,7 +198,10 @@ def predict_from_agreement_pattern_counts_sqls(
 
 
 def _combine_prior_and_bfs(
-    prior: float, bf_terms: list[str], sql_infinity_expr: str
+    prior: float,
+    bf_terms: list[str],
+    sql_infinity_expr: str,
+    splink_dialect: SplinkDialect,
 ) -> tuple[str, str]:
     """Compute the combined Bayes factor and match probability expressions"""
     if prior == 1.0:
@@ -202,7 +211,10 @@ def _combine_prior_and_bfs(
 
     bf_prior = prob_to_bayes_factor(prior)
     bf_expr = f"cast({bf_prior} as float8) * " + " * ".join(bf_terms)
-    bf_expr = f"least(greatest({bf_expr}, 1e-300), 1e300)"
+
+    greatest_name = splink_dialect.greatest_function_name
+    least_name = splink_dialect.least_function_name
+    bf_expr = f"{least_name}({greatest_name}({bf_expr}, 1e-300), 1e300)"
 
     mp_raw = f"({bf_expr})/(1+({bf_expr}))"
     # if any BF is Infinity then we need to adjust the match probability

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -39,7 +39,7 @@ def row_examples(
         p,
         bf_terms=bf_columns_no_tf,
         sql_infinity_expr=linker._infinity_expression,
-        splink_dialect=linker._db_api.sql_dialect,
+        sql_dialect=linker._db_api.sql_dialect,
     )[0]
 
     sql = f"""

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -36,7 +36,10 @@ def row_examples(
 
     p = linker._settings_obj._probability_two_random_records_match
     bf_final_no_tf = _combine_prior_and_bfs(
-        p, bf_terms=bf_columns_no_tf, sql_infinity_expr=linker._infinity_expression
+        p,
+        bf_terms=bf_columns_no_tf,
+        sql_infinity_expr=linker._infinity_expression,
+        splink_dialect=linker._db_api.sql_dialect,
     )[0]
 
     sql = f"""


### PR DESCRIPTION
See #1889 

See in particular
https://github.com/moj-analytical-services/splink/issues/1889#issuecomment-3204547499

Seemed important to make this more robust since we're going to be using 'very big' bayes factors to implement the override markers, so want to make we avoid 'Out of Range Error: cannot take logarithm of zero' in prod
