### PR TITLE
Simplify exclude preceding for exploding blocking rules

### DIFF
--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -11,7 +11,6 @@ from sqlglot.optimizer.simplify import flatten
 
 from splink.internals.database_api import DatabaseAPISubClass
 from splink.internals.dialects import SplinkDialect
-from splink.internals.exceptions import SplinkException
 from splink.internals.input_column import InputColumn
 from splink.internals.misc import ensure_is_list
 from splink.internals.pipeline import CTEPipeline
@@ -427,7 +426,6 @@ class ExplodingBlockingRule(BlockingRule):
         """
 
         return "false"
-
 
     def create_blocked_pairs_sql(
         self,

--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -426,23 +426,6 @@ class ExplodingBlockingRule(BlockingRule):
         so that subsequent statements do not produce duplicate pairs
         """
 
-        unique_id_column = unique_id_input_column
-
-        unique_id_input_columns = combine_unique_id_input_columns(
-            source_dataset_input_column, unique_id_input_column
-        )
-
-        if (splink_df := self.exploded_id_pair_table) is None:
-            raise SplinkException(
-                "Must use `materialise_exploded_id_table(linker)` "
-                "to set `exploded_id_pair_table` before calling "
-                "exclude_pairs_generated_by_this_rule_sql()."
-            )
-        ids_to_compare_sql = f"select * from {splink_df.physical_name}"
-
-        id_expr_l = _composite_unique_id_from_nodes_sql(unique_id_input_columns, "l")
-        id_expr_r = _composite_unique_id_from_nodes_sql(unique_id_input_columns, "r")
-
         return "false"
 
 

--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -591,18 +591,19 @@ def block_using_rules_sqls(
 
     sql = " UNION ALL ".join(br_sqls)
 
-    sqls.append(
-        {"sql": sql, "output_table_name": "__splink__blocked_id_pairs_non_unique"}
-    )
+    if any(isinstance(br, ExplodingBlockingRule) for br in blocking_rules):
+        sqls.append(
+            {"sql": sql, "output_table_name": "__splink__blocked_id_pairs_non_unique"}
+        )
 
-    sql = """
-    SELECT
-        min(match_key) as match_key,
-        join_key_l,
-        join_key_r
-    FROM __splink__blocked_id_pairs_non_unique
-    GROUP BY join_key_l, join_key_r
-    """
+        sql = """
+        SELECT
+            min(match_key) as match_key,
+            join_key_l,
+            join_key_r
+        FROM __splink__blocked_id_pairs_non_unique
+        GROUP BY join_key_l, join_key_r
+        """
 
     sqls.append({"sql": sql, "output_table_name": "__splink__blocked_id_pairs"})
 


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Alternative approach for #2751, more discussion in that thread. 

### Give a brief description for the solution you have provided

When we create the blocked id pairs table, add an extra step to group by the left and right join keys and take the minimum match_key that appears for that pair. Then, for exploding blocking rules set the sql to exclude pairs generated by that rule to just "false", so that we avoid all the joins that the existing approach has. 

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


