### PR TITLE
docs(fix): Remove broken link from 

### DIFF
--- a/docs/demos/tutorials/07_Evaluation.ipynb
+++ b/docs/demos/tutorials/07_Evaluation.ipynb
@@ -135,9 +135,7 @@
       "source": [
         "## Load in labels\n",
         "\n",
-        "The labels file contains a list of pairwise comparisons which represent matches and non-matches.\n",
-        "\n",
-        "The required format of the labels file is described [here](https://moj-analytical-services.github.io/splink/linkerqa.html#splink.linker.Linker.roc_chart_from_labels).\n"
+        "The labels file contains a list of pairwise comparisons which represent matches and non-matches.\n"
       ]
     },
     {


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [ ] MAINT
- [x] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
<!--
  Add links to related issues/prs. For Example "closes #111"
-->



### Give a brief description for the solution you have provided
<!--
  Provide a clear and concise description of what you want to happen.
-->
This PR removes a broken link to the labels file required format. The link does not lead anywhere and I could not find an alternative one, so I am assuming this is safe to remove. If this just needs to be re-pointed LMK and I can change the link instead


### PR Checklist

- [x ] Added documentation for changes
- [x] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [x] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [x] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


