### PR TITLE
Fix sqlglot compatibility

### DIFF
--- a/tests/test_sql_transform.py
+++ b/tests/test_sql_transform.py
@@ -42,13 +42,6 @@ def test_move_l_r_table_prefix_to_column_suffix():
     )
     move_l_r_test(br, expected)
 
-    br = "len(list_filter(l.name_list, x -> list_contains(r.name_list, x))) >= 1"
-    res = move_l_r_table_prefix_to_column_suffix(br)
-    expected = (
-        "length(list_filter(name_list_l, x -> list_contains(name_list_r, x))) >= 1"
-    )
-    assert res.lower() == expected.lower()
-
 
 def test_cast_concat_as_varchar():
     output = """


### PR DESCRIPTION
`sqlglot == 27.2.0` introduced changes that broke how we transform `l`/`r` identifiers.

This introduces a fix for this. I have also updated a test, such that it only works with versions at least this recent. `sqlglot` changed the canonical form of a function, so we get a different value in our test. It's peripheral to what we are interested in, so I think this is okay. Devs should probably just run against package versions in the lockfile unless there is a compelling reason not to - I don't think it is worth the effort to rewrite the test to accommodate multiple versions of sqlglot, as this is happening outside Splink.

I also killed off a duplicate test - looked like it got introduced in error during the merge of [this](https://github.com/moj-analytical-services/splink/pull/979#pullrequestreview-1251263980).

NB this is a separate issue to #2773, which will require a separate fix.