### PR TITLE
Fix count comparisons for exploding blocking rules

### DIFF
--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -196,6 +196,8 @@ class BlockingRule:
         input_tablename: str,
         input_columns: List[InputColumn],
     ) -> str:
+        """A SQL string that creates the input tables that will be joined
+        for this blocking rule"""
         return f"select * from {input_tablename}"
 
     @property
@@ -489,6 +491,8 @@ class ExplodingBlockingRule(BlockingRule):
         input_tablename: str,
         input_columns: List[InputColumn],
     ) -> str:
+        """A SQL string that creates the input tables that will be joined
+        for this blocking rule"""
         input_colnames = {col.quote().name for col in input_columns}
 
         arrays_to_explode_quoted = [

--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -351,6 +351,7 @@ class SaltedBlockingRule(BlockingRule):
             sqls.append(sql)
         return " UNION ALL ".join(sqls)
 
+
 def _explode_arrays_sql(db_api, tbl_name, columns_to_explode, other_columns_to_retain):
     return db_api.sql_dialect.explode_arrays_sql(
         tbl_name, columns_to_explode, other_columns_to_retain
@@ -491,9 +492,7 @@ class ExplodingBlockingRule(BlockingRule):
         input_colnames = {col.quote().name for col in input_columns}
 
         arrays_to_explode_quoted = [
-            InputColumn(colname, sqlglot_dialect_str=self.sqlglot_dialect)
-            .quote()
-            .name
+            InputColumn(colname, sqlglot_dialect_str=self.sqlglot_dialect).quote().name
             for colname in self.array_columns_to_explode
         ]
 
@@ -506,7 +505,6 @@ class ExplodingBlockingRule(BlockingRule):
         )
 
         return expl_sql
-
 
     def as_dict(self):
         output = super().as_dict()

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -35,58 +35,6 @@ from splink.internals.vertically_concatenate import (
 logger = logging.getLogger(__name__)
 
 
-def _number_of_comparisons_generated_by_blocking_rule_post_filters_sqls(
-    input_data_dict: dict[str, "SplinkDataFrame"],
-    blocking_rule: "BlockingRule",
-    link_type: backend_link_type_options,
-    db_api: DatabaseAPISubClass,
-    unique_id_input_column: InputColumn,
-    source_dataset_input_column: Optional[InputColumn],
-) -> list[dict[str, str]]:
-    input_dataframes = list(input_data_dict.values())
-
-    two_dataset_link_only = link_type == "link_only" and len(input_dataframes) == 2
-    if two_dataset_link_only:
-        link_type = "two_dataset_link_only"
-
-    # If it's a link_only or link_and_dedupe and no source_dataset_column_name is
-    # provided, it will have been set to a default by _process_unique_id_columns
-    if source_dataset_input_column:
-        unique_id_cols = [source_dataset_input_column, unique_id_input_column]
-    else:
-        unique_id_cols = [unique_id_input_column]
-
-    where_condition = _sql_gen_where_condition(link_type, unique_id_cols)
-
-    sqls = []
-
-    if two_dataset_link_only:
-        input_tablename_l = input_dataframes[0].physical_name
-        input_tablename_r = input_dataframes[1].physical_name
-    else:
-        sql = vertically_concatenate_sql(
-            input_data_dict,
-            salting_required=False,
-            source_dataset_input_column=source_dataset_input_column,
-        )
-        sqls.append({"sql": sql, "output_table_name": "__splink__df_concat"})
-
-        input_tablename_l = "__splink__df_concat"
-        input_tablename_r = "__splink__df_concat"
-
-    sql = f"""
-    select count(*) as count_of_pairwise_comparisons_generated
-
-    from {input_tablename_l} as l
-    inner join {input_tablename_r} as r
-    on
-    {blocking_rule.blocking_rule_sql}
-    {where_condition}
-    """
-    sqls.append({"sql": sql, "output_table_name": "__splink__comparions_post_filter"})
-    return sqls
-
-
 def _count_comparisons_from_blocking_rule_pre_filter_conditions_sqls(
     input_data_dict: dict[str, "SplinkDataFrame"],
     blocking_rule: "BlockingRule",
@@ -534,21 +482,17 @@ def _count_comparisons_generated_from_blocking_rule(
         }
 
     if pre_filter_total < max_rows_limit:
-        pipeline = CTEPipeline()
-        sqls = _number_of_comparisons_generated_by_blocking_rule_post_filters_sqls(
-            splink_df_dict,
-            blocking_rule,
-            link_type,
-            db_api,
-            unique_id_input_column,
-            source_dataset_input_column,
+        post_filter_total_df = _cumulative_comparisons_to_be_scored_from_blocking_rules(
+            splink_df_dict=splink_df_dict,
+            blocking_rules=[blocking_rule],
+            link_type=link_type,
+            db_api=db_api,
+            max_rows_limit=max_rows_limit,
+            unique_id_input_column=unique_id_input_column,
+            source_dataset_input_column=source_dataset_input_column,
         )
-        pipeline.enqueue_list_of_sqls(sqls)
-        post_filter_total_df = db_api.sql_pipeline_to_splink_dataframe(pipeline)
-        post_filter_total = post_filter_total_df.as_record_dict()[0][
-            "count_of_pairwise_comparisons_generated"
-        ]
-        post_filter_total_df.drop_table_from_database_and_remove_from_cache()
+
+        post_filter_total = post_filter_total_df.loc[0, "row_count"].item()
     else:
         post_filter_total = "exceeded max_rows_limit, see warning"
 


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Fixes #2737 


### Give a brief description for the solution you have provided

This adds a new method called `create_blocking_input_sql` to the `BlockingRule` classes, which for normal blocking rules does nothing, but for exploding blocking rules returns the exploded table that gets joined in the blocking step.
This method can be used in the blocking analysis code, particularly in `_count_comparisons_from_blocking_rule_pre_filter_conditions_sqls`, to use the right table to count the number of rows in each block and estimate the number of comparisons. 

I also removed the `_number_of_comparisons_generated_by_blocking_rules_post_filters_sqls` because the same thing could be calculated using `_cumulative_comparisons_to_be_scored_from_blocking_rules` with exactly one blocking rule in the list. The latter function is a bit more resilient because it uses the functionality from `splink.internals.blocking` rather than implementing the blocking step itself, e.g. it already works correctly with exploding blocking rules. I added an option to avoid checking the max rows limit so that the pre-filter count wouldn't be computed twice. 

For the pre-filter count it's worth noting that you can't get exactly the right number of comparisons with exploding blocking rules. 

<details>
<summary>Example</summary>

Input before exploding:

| id   | source_dataset | postcode |
| --- | ---                     | ---            |
| 1   | 'a'                      | [2000, 2001] |
| 2   | 'b'                      | [2000, 2001] |      

Input after exploding postcode:

| id  | source_dataset | postcode |
| --- | ---                    | ---            |
| 1   | 'a'                     | 2000 |
| 1   | 'a'                     | 2001 |
| 2   | 'b'                     | 2000 |
| 2   | 'b'                     | 2001 |

So the pair (1,2) is counted twice because they both appear in two separate blocks, while in the post-filter count the pair will only be counted once. 

</details>

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


