### PR TITLE
Uncap sqlglot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "jsonschema>=3.2",
     "pandas>1.3.5",
     "duckdb>=0.9.2",
-    "sqlglot>=13.0.0,<27.2.0",
+    "sqlglot>=13.0.0",
     "altair>=5.0.1",
     "Jinja2>=3.0.3",
     "numpy>=1.17.3",


### PR DESCRIPTION
#2775 had a cap on sqlglot version due to breaking changes, but subsequently the fixes have already been merged in #2780, so we don't need or want this upper cap any longer.