### PR TITLE
Remove duplicated mypy check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install dependencies
         run: uv sync -p 3.12
 
-      - name: Run mypy
-        run: uv run mypy splink
-
       - name: Run Ruff linting
         run: uv run ruff check . --output-format=full
 


### PR DESCRIPTION
In updating the workflows as part of #2775 it seems the `mypy` check got duplicated into the `lint` workflow. We don't need to check it twice, especially as it is a little slow.