### PR TITLE
Improve clustering performance

### DIFF
--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -276,10 +276,10 @@ def solve_connected_components(
             n.node_id,
             n.neighbour,
             r.representative as neighbour_rep
-        from {representatives.templated_name} as l
-        join {filtered_neighbours.templated_name} as n
+        from {filtered_neighbours.templated_name} as n
+        left join {representatives.templated_name} as l
         on l.node_id = n.node_id
-        join {representatives.templated_name} as r
+        left join {representatives.templated_name} as r
         on n.neighbour = r.node_id
         where l.representative <> r.representative
         """

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -29,7 +29,7 @@ def _cc_generate_representatives_loop_cond(
 
     Takes the neighbours table for this iteration,
     and uses it to find a new representative for each
-    old representative of the previous iteration. 
+    old representative of the previous iteration.
 
     Because the neighbours table tracks the representative
     of the node and the representative of its neighbour, we
@@ -104,7 +104,7 @@ def _cc_update_representatives_loop_cond(
 
 def _cc_assess_exit_condition(neighbours_name: str) -> str:
     """SQL exit condition for our Connected Components algorithm.
-    
+
     While there are any edges left to process the algorithm should
     continue.
     """
@@ -297,9 +297,7 @@ def solve_connected_components(
 
         # 5. check exit condition
         pipeline = CTEPipeline([filtered_neighbours])
-        sql = _cc_assess_exit_condition(
-            filtered_neighbours.templated_name
-        )
+        sql = _cc_assess_exit_condition(filtered_neighbours.templated_name)
         pipeline.enqueue_sql(sql, "__splink__root_rows")
         root_rows_df = db_api.sql_pipeline_to_splink_dataframe(
             pipeline, use_cache=False

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -48,7 +48,7 @@ def _cc_generate_representatives_loop_cond(
 
     old_rep,
     min(representative) as representative,
-    min(stable) = 1 as stable
+    min(stable) as stable
 
     from
     (
@@ -57,7 +57,7 @@ def _cc_generate_representatives_loop_cond(
 
             node_rep as old_rep,
             neighbour_rep as representative,
-            0 as stable
+            false as stable
 
         from {filtered_neighbours}
 
@@ -67,7 +67,7 @@ def _cc_generate_representatives_loop_cond(
 
             representative as old_rep,
             representative,
-            1 as stable
+            true as stable
 
         from {prev_representatives}
 
@@ -93,7 +93,7 @@ def _cc_update_representatives_loop_cond(
         r.representative,
         r.stable
 
-    from r
+    from __splink__rep_updates as r
 
     left join {prev_representatives} as repr
     on r.old_rep = repr.representative
@@ -238,7 +238,7 @@ def solve_connected_components(
             prev_representatives_table.templated_name,
             filtered_neighbours.templated_name,
         )
-        pipeline.enqueue_sql(sql, "r")
+        pipeline.enqueue_sql(sql, "__splink__rep_updates")
 
         # 2. match node_ids with their new reps
         sql = _cc_update_representatives_loop_cond(
@@ -281,7 +281,7 @@ def solve_connected_components(
         on l.node_id = n.node_id
         join {representatives.templated_name} as r
         on n.neighbour = r.node_id
-        where node_rep <> neighbour_rep
+        where l.representative <> r.representative
         """
 
         pipeline.enqueue_sql(sql, f"__splink__filtered_neighbours_{iteration}")

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -277,7 +277,7 @@ def solve_connected_components(
             n.neighbour,
             r.representative as neighbour_rep
         from {representatives.templated_name} as l
-        join {neighbours.templated_name} as n
+        join {filtered_neighbours.templated_name} as n
         on l.node_id = n.node_id
         join {representatives.templated_name} as r
         on n.neighbour = r.node_id

--- a/splink/internals/connected_components.py
+++ b/splink/internals/connected_components.py
@@ -57,7 +57,7 @@ def _cc_generate_representatives_loop_cond(
 
             node_rep as old_rep,
             neighbour_rep as representative,
-            false as stable
+            0 as stable
 
         from {filtered_neighbours}
 
@@ -67,7 +67,7 @@ def _cc_generate_representatives_loop_cond(
 
             representative as old_rep,
             representative,
-            true as stable
+            1 as stable
 
         from {prev_representatives}
 
@@ -253,7 +253,7 @@ def solve_connected_components(
         sql = f"""
         select *
         from {representatives.templated_name}
-        where stable
+        where stable = 1
         """
         pipeline.enqueue_sql(sql, f"__splink__representatives_stable_{iteration}")
         converged_clusters = db_api.sql_pipeline_to_splink_dataframe(pipeline)
@@ -263,7 +263,7 @@ def solve_connected_components(
         sql = f"""
         select *
         from {representatives.templated_name}
-        where not stable
+        where stable = 0
         """
         pipeline.enqueue_sql(sql, f"__splink__representatives_unstable_{iteration}")
         unstable_clusters = db_api.sql_pipeline_to_splink_dataframe(pipeline)

--- a/tests/test_cluster_at_multiple_thresholds.py
+++ b/tests/test_cluster_at_multiple_thresholds.py
@@ -101,6 +101,7 @@ def test_cluster_at_multiple_thresholds_mw_prob_equivalence(test_helpers, dialec
     )
 
     cc_prob_pd = cc_prob.as_pandas_dataframe()
+    cc_prob_pd = cc_prob_pd.sort_values("my_id")
 
     cc_weight = cluster_pairwise_predictions_at_multiple_thresholds(
         nodes,
@@ -112,6 +113,7 @@ def test_cluster_at_multiple_thresholds_mw_prob_equivalence(test_helpers, dialec
     )
 
     cc_weight_pd = cc_weight.as_pandas_dataframe()
+    cc_weight_pd = cc_weight_pd.sort_values("my_id")
 
     assert "cluster_mw_0" in cc_weight_pd.columns
     assert "cluster_mw_1_22" in cc_weight_pd.columns


### PR DESCRIPTION
### Type of PR

- [ ] BUG
- [ ] FEAT
- [x] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
No.


### Give a brief description for the solution you have provided
While getting my head around the connected components implementation, I realised you could achieve the same filtering out of stable clusters without as many joins. This means you can improve the performance, especially in cases where the number of unstable clusters is reasonably high for a few iterations. It also simplifies the code, almost 200 fewer lines. 

This is the summary of the main loop (commented in the code):
 1. Update the representatives by following links from current reps
    to their neighbours' representatives, and taking the minimum as the
    new rep. This is a concordance of old_reps and new representatives,
    and also includes a stable flag which is true if that cluster has no more
    outgoing links, and false otherwise.
 2. Update the concordance of node_ids and representatives by joining on
    old_rep.
 3. Split out the stable and unstable clusters, the stable ones can be put
    aside until the end, while the unstable clusters progress to the next
    iteration.
 4. Update the neighbours table with the new node and neighbour
    representatives, where we can filter out edges within the same cluster.
    If there are no more edges between different clusters then we can end
    the loop.

Step 1 has only a group by, step 2 has a single join, and step 4 has two joins, meaning 3 joins and 1 aggregation per iteration. I count 7 joins and 1 aggregation in the old implementation (counting each EXISTS as a join, since this is what they should be in the logical plan). 

Also, step 3 is now a simple WHERE clause, so you don't need the more complicated approach with EXISTS statements from #2766.

<details>
<summary>Performance testing script</summary>

```
import pandas as pd
import time
import logging

from splink import Linker, DuckDBAPI, SettingsCreator, block_on
from splink.datasets import splink_datasets
import splink.comparison_library as cl

def setup(num_copies):
    df = splink_datasets.historical_50k
    dfs = []
    for i in range(num_copies):
        tmp = df.copy()
        tmp["source_dataset"] = str(i)
        dfs.append(tmp)

    settings = SettingsCreator(
        link_type="link_and_dedupe",
        comparisons=[
            cl.ExactMatch("postcode_fake"),
            cl.DateOfBirthComparison("dob", input_is_string=True),
            cl.JaroWinklerAtThresholds("full_name", [0.9, 0.7]),
        ],
        blocking_rules_to_generate_predictions=[
            block_on("full_name", "source_dataset"),
            block_on("dob", "source_dataset"),
        ],
    )

    linker = Linker(dfs, settings, db_api=DuckDBAPI())

    logging.getLogger("splink").setLevel(100)

    linker.training.estimate_u_using_random_sampling(1e7)

    df_predict = linker.inference.predict()

    return linker, df_predict


def run(repeats, threshold):
    linker, df_predict = setup(num_copies=1)
    times = []
    for i in range(repeats):
        logging.getLogger("splink").setLevel(20)

        start_time = time.time()

        df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
            df_predict,
            threshold_match_probability=threshold,
        )

        end_time = time.time()

        times.append(end_time - start_time)

        avg_time = sum(times) / repeats

    print(f"At threshold {threshold}, average clustering time: {avg_time}s")
    return times

run(repeats=5, threshold=0.0)
run(repeats=5, threshold=0.01)
run(repeats=5, threshold=0.8)
```
</details>

From master branch: 
```
At threshold 0.0, average clustering time: 8.308948850631714s
At threshold 0.01, average clustering time: 2.585617256164551s
At threshold 0.8, average clustering time: 0.4132252216339111s
```

From PR branch: 
```
At threshold 0.0, average clustering time: 1.1620706081390382s
At threshold 0.01, average clustering time: 0.7192923545837402s
At threshold 0.8, average clustering time: 0.3942802906036377s
```

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


