### PR TITLE
Waterfall cache

### DIFF
--- a/splink/internals/waterfall_chart.py
+++ b/splink/internals/waterfall_chart.py
@@ -47,9 +47,7 @@ def _comparison_records(
     record_as_dict: dict[str, Any],
     comparison: Comparison,
     hide_details: bool = False,
-    _cols_cache: (
-        dict[Comparison, tuple[tuple[str, ...], tuple[str, ...]]] | None
-    ) = None,
+    _cols_cache: (dict[Comparison, tuple[list[str], list[str]]] | None) = None,
 ) -> list[dict[str, Any]]:
     output_records = []
 


### PR DESCRIPTION
Flamegraph profiling showed that the call to `c._input_columns_used_by_case_statement` in `_comparison_records` dominated runtime.  [here](https://github.com/moj-analytical-services/splink/blob/8497f575a6bcbba015204fd1458768a344790c20/splink/internals/waterfall_chart.py#L74)

This was called once for each input record, despite the calculation relying only on the comparison defitions and therefore being invariant to the specific record.  

This code caches it once and reuses


<details><summary>Code run to profile</summary>
<p>

```python
import splink.comparison_library as cl
from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets
from splink.internals.waterfall_chart import records_to_waterfall_data
import time

db_api = DuckDBAPI()

df = splink_datasets.fake_1000

settings = SettingsCreator(
    link_type="dedupe_only",
    comparisons=[
        cl.ExactMatch("first_name"),
        cl.ExactMatch("surname"),
        cl.ExactMatch("dob"),
        cl.ExactMatch("city").configure(term_frequency_adjustments=True),
        cl.ExactMatch("email"),
    ],
    blocking_rules_to_generate_predictions=[
        block_on("first_name"),
        block_on("surname"),
    ],
    max_iterations=2,
).get_settings("duckdb")


recs = [
    {
        "match_weight": 0.3798646777467505,
        "match_probability": 0.5654478546351863,
        "unique_id_l": 4,
        "unique_id_r": 5,
        "first_name_l": "Grace",
        "first_name_r": "Grace",
        "gamma_first_name": 1,
        "surname_l": None,
        "surname_r": "Kelly",
        "gamma_surname": -1,
        "dob_l": "1997-04-26",
        "dob_r": "1991-04-26",
        "gamma_dob": 0,
        "city_l": "Hull",
        "city_r": None,
        "gamma_city": -1,
        "email_l": "grace.kelly52@jones.com",
        "email_r": "grace.kelly52@jones.com",
        "gamma_email": 1,
        "match_key": "0",
    },
    {
        "match_weight": -8.96480144771644,
        "match_probability": 0.0019973655121588683,
        "unique_id_l": 18,
        "unique_id_r": 475,
        "first_name_l": "Caleb",
        "first_name_r": "Caleb",
        "gamma_first_name": 1,
        "surname_l": "Rwoe",
        "surname_r": "Scott",
        "gamma_surname": 0,
        "dob_l": "1992-11-20",
        "dob_r": "2000-12-10",
        "gamma_dob": 0,
        "city_l": "Liverpool",
        "city_r": None,
        "gamma_city": -1,
        "email_l": None,
        "email_r": "c.scott@brooks.com",
        "gamma_email": -1,
        "match_key": "0",
    },
]

recs = recs * 500

start_time = time.perf_counter()

records_to_waterfall_data(recs, settings, False)

end_time = time.perf_counter()
print(f"Elapsed time: {end_time - start_time} seconds")

```

```
sudo uv run --with py-spy py-spy record \       
  --format flamegraph \
  -o profile.svg \
  -- python above_file.py
```

</p>
</details> 