### PR TITLE
Remove obsolete Spark 4 warning

### DIFF
--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -35,30 +35,6 @@ if (installed_minor_version := version_info.minor) < _LOWEST_SUPPORTED_MINOR_VER
     )
 
 
-# custom warning class, so that users can filter if they need to
-class SparkCompatibilityWarning(UserWarning):
-    pass
-
-
-# warning for Spark 4
-try:
-    import pyspark
-
-    major, _, _ = pyspark.__version__.split(".")
-    if int(major) >= 4:
-        warn(
-            (
-                "You are using Spark 4. Some small amount of functionality in Splink "
-                "may be unavailable - in-built UDFs, and automatic date-parsing for "
-                "malformed dates.  Core functionality should remain unaffected."
-            ),
-            category=SparkCompatibilityWarning,
-            stacklevel=2,
-        )
-except ModuleNotFoundError:
-    pass
-
-
 # Use getarr to make the error appear at the point of use
 def __getattr__(name):
     try:


### PR DESCRIPTION
Fixed this (#2718) but forgot to take out the compatibility warning.