### PR TITLE
Fix docs code blocks in admonitions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,6 +52,7 @@ To get a basic Splink model up and running, use the following code. It demonstra
 3. Use clustering to generate an estimated unique person ID.
 
 ???+ note "Simple Splink Model Example"
+
     ```py
     import splink.comparison_library as cl
     from splink import DuckDBAPI, Linker, SettingsCreator, block_on, splink_datasets

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,8 @@ markdown_extensions:
   # pymdown-extensions
   - pymdownx.arithmatex:
       generic: true
+  # code markdown in admonitions, e.g. docs/getting_started.md
+  - pymdownx.superfences
   # tabbed sections with === - e.g. docs/index.md
   # pymdown-extensions
   - pymdownx.tabbed:


### PR DESCRIPTION
Fixes #2823 (and other pages with same issue, such as [editing charts page](https://moj-analytical-services.github.io/splink/dev_guides/charts/understanding_and_editing_charts.html)).

In #2813 amongst other changes I dropped `pymdownx.superfences`, not realising it is required for rendering code blocks in admonitions, which we make use of (see [docs for other features](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/)).
This PR re-instates this - we already have the package, so only need this extra bit of config.