### PR TITLE
Fix docs build

### DIFF
--- a/docs/api_docs/blocking.md
+++ b/docs/api_docs/blocking.md
@@ -9,12 +9,8 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source
       inherited_members: false
       merge_init_into_class: true
-
-
-
-

--- a/docs/api_docs/blocking_analysis.md
+++ b/docs/api_docs/blocking_analysis.md
@@ -9,7 +9,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
 
 

--- a/docs/api_docs/clustering.md
+++ b/docs/api_docs/clustering.md
@@ -9,7 +9,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
 
 

--- a/docs/api_docs/comparison_level_library.md
+++ b/docs/api_docs/comparison_level_library.md
@@ -9,7 +9,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source
       inherited_members: false
@@ -30,6 +30,6 @@ Note that all comparison levels have a `.configure()` method as follows:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: true
+      show_root_toc_entry: true
       show_source: false
 

--- a/docs/api_docs/comparison_library.md
+++ b/docs/api_docs/comparison_library.md
@@ -9,7 +9,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source
       inherited_members: false
@@ -28,6 +28,6 @@ Note that all comparisons have a `.configure()` method as follows:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: true
+      show_root_toc_entry: true
       show_source: false
 

--- a/docs/api_docs/em_training_session.md
+++ b/docs/api_docs/em_training_session.md
@@ -11,7 +11,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: true
+      show_root_toc_entry: true
       show_source: false
       members_order: source
 

--- a/docs/api_docs/evaluation.md
+++ b/docs/api_docs/evaluation.md
@@ -11,6 +11,6 @@ tags:
       - "!^__init__$"
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source

--- a/docs/api_docs/exploratory.md
+++ b/docs/api_docs/exploratory.md
@@ -9,7 +9,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
 
 # Documentation for`splink.exploratory.similarity_analysis`
@@ -18,7 +18,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
 
 

--- a/docs/api_docs/inference.md
+++ b/docs/api_docs/inference.md
@@ -11,6 +11,6 @@ tags:
       - "!^__init__$"
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source

--- a/docs/api_docs/linker_clustering.md
+++ b/docs/api_docs/linker_clustering.md
@@ -11,6 +11,6 @@ tags:
       - "!^__init__$"
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source

--- a/docs/api_docs/misc.md
+++ b/docs/api_docs/misc.md
@@ -11,6 +11,6 @@ tags:
       - "!^__init__$"
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source

--- a/docs/api_docs/splink_dataframe.md
+++ b/docs/api_docs/splink_dataframe.md
@@ -9,7 +9,7 @@ tags:
     handler: python
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
 
 

--- a/docs/api_docs/table_management.md
+++ b/docs/api_docs/table_management.md
@@ -11,6 +11,6 @@ tags:
       - "!^__init__$"
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source

--- a/docs/api_docs/training.md
+++ b/docs/api_docs/training.md
@@ -11,7 +11,7 @@ tags:
       - "!^__init__$"
     options:
       show_root_heading: false
-      show_root_toc: false
+      show_root_toc_entry: false
       show_source: false
       members_order: source
 

--- a/docs/topic_guides/evaluation/clusters/how_to_compute_metrics.ipynb
+++ b/docs/topic_guides/evaluation/clusters/how_to_compute_metrics.ipynb
@@ -37,7 +37,7 @@
     "    handler: python\n",
     "    options:\n",
     "      show_root_heading: false\n",
-    "      show_root_toc: false\n",
+    "      show_root_toc_entry: false\n",
     "      show_source: false\n",
     "      show_docstring_parameters: true\n",
     "      show_docstring_description: false\n",


### PR DESCRIPTION
Fixes the build of the docs, as per first part of #2839.

It looks like the root issue was in fact way back in #2203, where the python handler option `show_root_toc_entry` was mistakenly included on various pages as `show_root_toc`, which as far as i can tell has never been the correct config value - see for example [this part of the code from mkdocstrings-python==1.10.5](https://github.com/mkdocstrings/python/blob/1.10.5/src/mkdocstrings_handlers/python/handler.py#L73), which is a version we were previously using for the docs - the same seems to be true in even older versions.

What _has_ changed to break the build is that these options are now validated. So up to now these options have not been respected, as any invalid options (as this was) were simply ignored. So in addition to fixing the build, these pages should now render with ToC as desired.