### PR TITLE
added filtered neighbours table to list of tables for Spark to persist

### DIFF
--- a/splink/internals/spark/database_api.py
+++ b/splink/internals/spark/database_api.py
@@ -296,6 +296,7 @@ class SparkAPI(DatabaseAPI[spark_df]):
             r"__splink__clusters_at_all_thresholds",
             r"__splink__clustering_output_final",
             r"__splink__stable_nodes_at_new_threshold",
+            r"__splink__filtered_neighbours.*",
         ]
 
         if re.fullmatch(r"|".join(regex_to_persist), templated_name):


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

Mentioned in #2756, there's an issue in Spark where the connected components algorithm isn't as fast as it should be because the filtered neighbours table is not having its lineage broken. 

### Give a brief description for the solution you have provided

Added the filtered neighbours table to the list of tables that will be persisted/checkpointed/written etc. in the Spark backend. 

It's possible that the best solution is to just not have that list at all, and to apply the break_lineage_method to every table that passes through. I wasn't sure of the effect that would have on performance, I think plausibly it could waste time with some of the smaller tables having to write them out to a parquet file. None of the other backends have this quirk though, and they all work well enough. In the end I just decided to stick with adding the single table name to the list. 



### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [ ] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


