### PR TITLE
Depandas estimate u

### DIFF
--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -175,13 +175,7 @@ class DatabaseAPI(ABC, Generic[TablishType]):
                 output_tablename_templated, table_name_hash
             )
 
-            df_pd = splink_dataframe.as_pandas_dataframe()
-            try:
-                from IPython.display import display
-
-                display(df_pd)
-            except ModuleNotFoundError:
-                print(df_pd)  # noqa: T201
+            splink_dataframe.as_duckdbpyrelation().show()
 
         else:
             splink_dataframe = self._sql_to_splink_dataframe(

--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -49,7 +49,7 @@ class _MUCountsAccumulator:
         self._output_column_name = comparison.output_column_name
         self._label_by_cvv: dict[int, str] = {}
         self._counts_by_cvv: dict[int, list[float]] = {
-            int(cl.comparison_vector_value): [0.0, 0.0]
+            int(cl.comparison_vector_value): [0.0]
             for cl in comparison._comparison_levels_excluding_null
         }
 
@@ -59,21 +59,18 @@ class _MUCountsAccumulator:
             label = cl._label_for_charts_no_duplicates(comparison_levels)
             self._label_by_cvv[cvv] = str(label)
 
-    def update_from_chunk_counts(
-        self, chunk_counts: list[dict[str, Any]]
-    ) -> None:
+    def update_from_chunk_counts(self, chunk_counts: list[dict[str, Any]]) -> None:
         for r in chunk_counts:
             cvv = int(r["comparison_vector_value"])
             totals = self._counts_by_cvv.get(cvv)
             if totals is None:
                 continue
-            totals[0] += float(r["m_count"])
-            totals[1] += float(r["u_count"])
+            totals[0] += float(r["u_count"])
 
     def min_u_count(self) -> float:
         if not self._counts_by_cvv:
             return 0.0
-        return min(totals[1] for totals in self._counts_by_cvv.values())
+        return min(totals[0] for totals in self._counts_by_cvv.values())
 
     def min_u_count_level(self) -> tuple[float, int | None, str | None]:
         """Return (min_u_count, cvv, label) for the current accumulator."""
@@ -82,7 +79,7 @@ class _MUCountsAccumulator:
         min_cvv: int | None = None
         min_u: float | None = None
         for cvv in sorted(self._counts_by_cvv):
-            u_count = float(self._counts_by_cvv[cvv][1])
+            u_count = float(self._counts_by_cvv[cvv][0])
             if (min_u is None) or (u_count < min_u):
                 min_u = u_count
                 min_cvv = cvv

--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -88,13 +88,19 @@ class _MUCountsAccumulator:
     def all_levels_meet_min_u_count(self, min_count: int) -> bool:
         return self.min_u_count() >= min_count
 
-    def to_record_list(self, with_dummy_m_count: bool = True) -> list[dict[str, Any]]:
+    def to_record_list(self, with_extra_columns: bool = True) -> list[dict[str, Any]]:
         return [
             {
-                "output_column_name": self._output_column_name,
                 "comparison_vector_value": cvv,
-                "m_count": 0.0 if with_dummy_m_count else None,
                 "u_count": totals[0],
+                **(
+                    {
+                        "output_column_name": self._output_column_name,
+                        "m_count": 0.0,
+                    }
+                    if with_extra_columns
+                    else {}
+                ),
             }
             for cvv, totals in sorted(self._counts_by_cvv.items())
         ]
@@ -103,10 +109,9 @@ class _MUCountsAccumulator:
         """
         Nice display, for debugging purposes.
         """
-        recs = self.to_record_list()
+        recs = self.to_record_list(with_extra_columns=False)
         if not recs:
             return ""
-        recs = [r for r in recs]
         try:
             import pyarrow as pa
 

--- a/splink/internals/spark/dataframe.py
+++ b/splink/internals/spark/dataframe.py
@@ -50,10 +50,7 @@ class SparkDataFrame(SplinkDataFrame):
             sql += f" limit {limit}"
 
         spark_df = self.db_api._execute_sql_against_backend(sql)
-        return {
-            col: spark_df.select(col).rdd.collect()
-            for col in spark_df.columns
-        }
+        return {col: spark_df.select(col).rdd.collect() for col in spark_df.columns}
 
     def as_pyarrow_table(self, limit: int = None) -> PyArrowTable:
         # spark 3 doesn't have native arrow support, so use our fallback method instead

--- a/splink/internals/spark/dataframe.py
+++ b/splink/internals/spark/dataframe.py
@@ -44,6 +44,17 @@ class SparkDataFrame(SplinkDataFrame):
 
         return [r.asDict(recursive=True) for r in spark_df.collect()]
 
+    def as_dict(self, limit=None):
+        sql = f"select * from {self.physical_name}"
+        if limit:
+            sql += f" limit {limit}"
+
+        spark_df = self.db_api._execute_sql_against_backend(sql)
+        return {
+            col: spark_df.select(col).rdd.collect()
+            for col in spark_df.columns
+        }
+
     def as_pyarrow_table(self, limit: int = None) -> PyArrowTable:
         # spark 3 doesn't have native arrow support, so use our fallback method instead
         if get_spark_major_version() == 3:

--- a/splink/internals/sqlite/dataframe.py
+++ b/splink/internals/sqlite/dataframe.py
@@ -64,7 +64,7 @@ class SQLiteDataFrame(SplinkDataFrame):
         cur = self.db_api.con.cursor()
         cur.execute(drop_sql)
 
-    def as_record_dict(self, limit=None):
+    def _limit_table_as_result(self, limit):
         sql = f"""
         select *
         from {self.physical_name}
@@ -73,4 +73,14 @@ class SQLiteDataFrame(SplinkDataFrame):
             sql += f" limit {limit}"
         sql += ";"
         cur = self.db_api.con.cursor()
-        return cur.execute(sql).fetchall()
+        return cur.execute(sql)
+
+    def as_record_dict(self, limit=None):
+        return self._limit_table_as_result(limit).fetchall()
+
+    def as_dict(self, limit=None):
+        res = self._limit_table_as_result(limit)
+        row_records = res.fetchall()
+        column_names = [desc[0] for desc in res.description]
+        res_dict = {col: [row[col] for row in row_records] for col in column_names}
+        return res_dict


### PR DESCRIPTION
More work on #2917.

This removes the dependency on `pandas` from the u-training code, as well as the corresponding tests.

I have also removed the code tracking accumulation of m-counts, as this is always 0 by construction, and so is superfluous.