### PR TITLE
TF Adjustment chart without pandas + SplinkChart

### DIFF
--- a/splink/internals/charts.py
+++ b/splink/internals/charts.py
@@ -616,6 +616,63 @@ class CumulativeBlockingRuleComparisonsGeneratedChart(SplinkChart[ChartRecord]):
         return "blocking_rule_generated_comparisons.json"
 
 
+class TFAdjustmentChart(SplinkChart[ChartRecord]):
+    def __init__(
+        self,
+        records: Sequence[ChartRecord],
+        hist_records: Sequence[ChartRecord],
+        tf_comparison_records: Sequence[ComparisonLevelDetailedRecord],
+    ):
+        super().__init__(records)
+        self.hist_records = hist_records
+        self.tf_levels = [cl.comparison_vector_value for cl in tf_comparison_records]
+        self.labels = [
+            f"{cl.label_for_charts} (TF col: {cl.tf_adjustment_column})"
+            for cl in tf_comparison_records
+        ]
+
+    @property
+    def chart_spec_file(self) -> str:
+        return "tf_adjustment_chart.json"
+
+    @property
+    def chart_dict(self) -> dict[str, Any]:
+        chart = self.chart_spec
+        chart["datasets"]["data"] = self.raw_records
+        chart["datasets"]["hist"] = self.hist_records
+        return chart
+
+    @staticmethod
+    def alter_spec_directly(chart_spec):
+        # filters = [
+        #     f"datum.most_freq_rank < {n_most_freq}",
+        #     f"datum.least_freq_rank < {n_least_freq}",
+        #     " | ".join([f"datum.value == '{v}'" for v in vals_to_include])
+        # ]
+        # filter_text = " | ".join(filters)
+        # chart["hconcat"][0]["layer"][0]["transform"][2]["filter"] = filter_text
+        # chart["hconcat"][0]["layer"][2]["transform"][2]["filter"] = filter_text
+
+        # PLACEHOLDER (until we work out adding a dynamic title based on the
+        # filtered data)
+        chart_spec["hconcat"][0]["layer"][0]["encoding"]["x"]["title"] = (
+            "TF column value"
+        )
+        chart_spec["hconcat"][0]["layer"][-1]["encoding"]["x"]["title"] = (
+            "TF column value"
+        )
+        chart_spec["hconcat"][0]["layer"][0]["encoding"]["tooltip"][0]["title"] = (
+            "Value"
+        )
+        return chart_spec
+
+    def alter_spec_from_data(self, chart_spec):
+        chart_spec["config"]["params"][0]["value"] = max(self.tf_levels)
+        chart_spec["config"]["params"][0]["bind"]["options"] = self.tf_levels
+        chart_spec["config"]["params"][0]["bind"]["labels"] = self.labels
+        return chart_spec
+
+
 def _comparator_score_chart(similarity_records, distance_records, as_dict=False):
     chart_path = "comparator_score_chart.json"
     chart = load_chart_definition(chart_path)

--- a/splink/internals/linker_components/visualisations.py
+++ b/splink/internals/linker_components/visualisations.py
@@ -26,7 +26,7 @@ from splink.internals.splink_comparison_viewer import (
 )
 from splink.internals.splink_dataframe import SplinkDataFrame
 from splink.internals.term_frequencies import (
-    tf_adjustment_chart,
+    tf_chart_data,
 )
 from splink.internals.waterfall_chart import records_to_waterfall_data
 
@@ -244,13 +244,15 @@ class LinkerVisualisations:
             [] if vals_to_include is None else ensure_is_list(vals_to_include)
         )
 
-        return tf_adjustment_chart(
+        main_chart_data, hist_data = tf_chart_data(
             self._linker,
             tf_comparison_records,
             n_most_freq,
             n_least_freq,
             vals_to_include,
         )
+
+        return TFAdjustmentChart(main_chart_data, hist_data, tf_comparison_records)
 
     def waterfall_chart(
         self,

--- a/splink/internals/linker_components/visualisations.py
+++ b/splink/internals/linker_components/visualisations.py
@@ -227,16 +227,18 @@ class LinkerVisualisations:
         Returns:
             altair_chart: An Altair chart
         """
-
-        # Comparisons with TF adjustments
-        tf_comparisons = [
-            c.output_column_name
-            for c in self._linker._settings_obj.comparisons
-            if any([cl._has_tf_adjustments for cl in c.comparison_levels])
+        comparison = self._linker._settings_obj._get_comparison_by_output_column_name(
+            output_column_name
+        )
+        # Select levels with TF adjustments
+        tf_comparison_records = [
+            detailed_rec
+            for detailed_rec in comparison._as_detailed_records
+            if detailed_rec.has_tf_adjustments
         ]
-        if output_column_name not in tf_comparisons:
+        if not tf_comparison_records:
             raise ValueError(
-                f"{output_column_name} is not a valid comparison column, or does not"
+                f"Comparison with output_column_name {output_column_name} does not"
                 f" have term frequency adjustment activated"
             )
 
@@ -246,7 +248,7 @@ class LinkerVisualisations:
 
         return tf_adjustment_chart(
             self._linker,
-            output_column_name,
+            tf_comparison_records,
             n_most_freq,
             n_least_freq,
             vals_to_include,

--- a/splink/internals/linker_components/visualisations.py
+++ b/splink/internals/linker_components/visualisations.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from splink.internals.charts import (
-    ChartReturnType,
     MatchWeightsChart,
     MatchWeightsHistogramChart,
     MUParametersInteractiveHistoryChart,
     ParameterEstimateComparisonsChart,
+    TFAdjustmentChart,
     WaterfallChart,
 )
 from splink.internals.cluster_studio import (
@@ -199,8 +199,7 @@ class LinkerVisualisations:
         n_most_freq: int = 10,
         n_least_freq: int = 10,
         vals_to_include: str | list[str] | None = None,
-        as_dict: bool = False,
-    ) -> ChartReturnType:
+    ) -> TFAdjustmentChart:
         """Display a chart showing the impact of term frequency adjustments on a
         specific comparison level.
         Each value
@@ -217,7 +216,6 @@ class LinkerVisualisations:
             vals_to_include (list, optional): Specific values for which to show term
                 frequency adjustments.
                 Defaults to None.
-            as_dict (bool, optional): If True, return the chart as a dictionary.
 
         Examples:
             ```py
@@ -225,7 +223,7 @@ class LinkerVisualisations:
             ```
 
         Returns:
-            altair_chart: An Altair chart
+            TFAdjustmentChart: A SplinkChart object
         """
         comparison = self._linker._settings_obj._get_comparison_by_output_column_name(
             output_column_name
@@ -252,7 +250,6 @@ class LinkerVisualisations:
             n_most_freq,
             n_least_freq,
             vals_to_include,
-            as_dict,
         )
 
     def waterfall_chart(

--- a/splink/internals/splink_dataframe.py
+++ b/splink/internals/splink_dataframe.py
@@ -207,10 +207,10 @@ class SplinkDataFrame(ABC):
         # insert into local duckdb via pyarrow
         arrow_tab = self.as_pyarrow_table(limit)
         self.db_api.duckdb_con.register(
-            self.templated_name,
+            self.physical_name,
             arrow_tab,
         )
-        return self.db_api.duckdb_con.table(self.templated_name)
+        return self.db_api.duckdb_con.table(self.physical_name)
 
     # Spark not guaranteed to be available so return type is not imported
     def as_spark_dataframe(self) -> "SparkDataFrame":  # type: ignore # noqa: F821

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 # https://github.com/moj-analytical-services/splink/pull/107
 import logging
 import warnings
+from functools import reduce
+from math import ceil, floor
 from typing import TYPE_CHECKING, Any, Optional
 
 from splink.internals.charts import (
     ChartReturnType,
     altair_or_json,
     load_chart_definition,
+)
+from splink.internals.duckdb.duckdb_helpers.duckdb_helpers import (
+    record_dicts_from_relation,
 )
 from splink.internals.input_column import InputColumn
 from splink.internals.pipeline import CTEPipeline
@@ -186,44 +191,48 @@ def compute_all_term_frequencies_sqls(
     return sqls
 
 
-def comparison_level_to_tf_chart_data(cl: dict[str, Any]) -> dict[str, Any]:
-    from numpy import log2
-
-    df = cl["df_tf"]
-    df.columns = ["value", "tf"]
-    df = df[df.value.notnull()]
-
-    del cl["df_tf"]
-    df = df.assign(**cl)
-
-    # TF match weight scaled by tf_adjustment_weight
-    df.loc[:, "log2_bf_tf"] = (
-        log2(df.loc[:, "u_probability"] / df.loc[:, "tf"])
-        * df.loc[:, "tf_adjustment_weight"]
+def comparison_level_to_tf_chart_data(
+    cl: dict[str, Any], con, column_info_settings, sqlglot_dialect_str
+) -> dict[str, Any]:
+    # TODO: don't want to have to pass this around everywhere
+    input_col = InputColumn(
+        cl["tf_adjustment_column"],
+        column_info_settings=column_info_settings,
+        sqlglot_dialect_str=sqlglot_dialect_str,
     )
 
-    # Tidy up columns
-    # df = df.drop(columns=["tf", "u_probability", "tf_adjustment_weight"])
-    df.rename(
-        columns={
-            "comparison_vector_value": "gamma",
-            "tf_adjustment_column": "tf_col",
-            "log2_bayes_factor": "log2_bf",
-        },
-        inplace=True,
-    )
-    df["log2_bf_final"] = df["log2_bf_tf"] + df["log2_bf"]
+    sdf = cl["df_tf"]
+    # ensure our duckdb connexion has access to this table
+    sdf.as_duckdbpyrelation()
 
-    # Add ranks for sorting/selecting
-    df = df.sort_values("log2_bf_tf")
-    df["most_freq_rank"] = df.groupby("gamma", observed=False)["log2_bf_tf"].cumcount()
-    df["least_freq_rank"] = df.groupby("gamma", observed=False)["log2_bf_tf"].cumcount(
-        ascending=False
-    )
+    sql = f"""
+    SELECT
+        {input_col.name} AS value,
+        {input_col.tf_name} AS tf,
+        {cl["u_probability"]}::DOUBLE AS u_probability,
+        {cl["tf_adjustment_weight"]}::DOUBLE AS tf_adjustment_weight,
+        -- TF match weight scaled by tf_adjustment_weight
+        log2(u_probability/tf) * tf_adjustment_weight AS log2_bf_tf,
+        -- Tidy up columns
+        {cl["comparison_vector_value"]} AS gamma,
+        '{input_col.unquote().name}' AS tf_col,
+        {cl["log2_bayes_factor"]}::DOUBLE AS log2_bf,
+        log2_bf_tf + log2_bf AS log2_bf_final,
+        row_number() OVER (
+                PARTITION BY gamma
+                ORDER BY log2_bf_tf
+            ) AS most_freq_rank,
+        row_number() OVER (
+                PARTITION BY gamma
+                ORDER BY log2_bf_tf DESC
+            ) AS least_freq_rank,
+    FROM
+        {sdf.physical_name}
+    WHERE
+        value IS NOT NULL
+    """
 
-    cl["df_out"] = df
-
-    return cl
+    return con.sql(sql)
 
 
 def tf_adjustment_chart(
@@ -234,30 +243,26 @@ def tf_adjustment_chart(
     vals_to_include: list[str],
     as_dict: bool,
 ) -> ChartReturnType:
-    from numpy import arange, ceil, floor
-    from pandas import concat, cut
-
     # Data for chart
     comparison = linker._settings_obj._get_comparison_by_output_column_name(col)
-    comparison_records = list(
-        map(lambda rec: rec.as_dict(), comparison._as_detailed_records)
-    )
+    tf_comparison_records = [
+        detailed_rec
+        for detailed_rec in comparison._as_detailed_records
+        if detailed_rec.has_tf_adjustments
+    ]
 
     keys_to_retain = [
         "comparison_vector_value",
         "label_for_charts",
         "tf_adjustment_column",
         "tf_adjustment_weight",
-        "tf_minimum_u_value",
         "u_probability",
         "log2_bayes_factor",
     ]
 
     # Select levels with TF adjustments
     comparison_records = [
-        {k: cl[k] for k in cl.keys() if k in keys_to_retain}
-        for cl in comparison_records
-        if cl["has_tf_adjustments"]
+        {k: getattr(cl, k) for k in keys_to_retain} for cl in tf_comparison_records
     ]
 
     # Add data ("df_tf") to each level
@@ -267,23 +272,32 @@ def tf_adjustment_chart(
             **{
                 "df_tf": linker.table_management.compute_tf_table(
                     cl["tf_adjustment_column"]
-                ).as_pandas_dataframe()
+                )
             },
         )
         for cl in comparison_records
     ]
+    con = linker._db_api.duckdb_con
 
-    c = [comparison_level_to_tf_chart_data(cl) for cl in comparison_records]
-    df = concat([cl["df_out"] for cl in c])
-    # Filter values
-    selected = False if not vals_to_include else df["value"].isin(vals_to_include)
-    least_freq = True if not n_least_freq else df["least_freq_rank"] < n_least_freq
-    most_freq = True if not n_most_freq else df["most_freq_rank"] < n_most_freq
-    mask = selected | least_freq | most_freq
+    column_info_settings = linker._settings_obj.column_info_settings
+    sqlglot_dialect_str = linker._settings_obj._sql_dialect_str
 
-    vals_not_included = [
-        val for val in vals_to_include if val not in df["value"].values
+    levels_chart_data = [
+        comparison_level_to_tf_chart_data(
+            cl, con, column_info_settings, sqlglot_dialect_str
+        )
+        for cl in comparison_records
     ]
+    df = reduce(
+        lambda relation_left, relation_right: relation_left.union(relation_right),
+        levels_chart_data,
+    )
+
+    vals_not_included = (
+        set(vals_to_include) - set(x[0] for x in df.select("value").fetchall())
+        if vals_to_include
+        else {}
+    )
     if vals_not_included:
         warnings.warn(
             f"Values {vals_not_included} from `vals_to_include` were not found in "
@@ -294,42 +308,78 @@ def tf_adjustment_chart(
     # Histogram data
     bin_width = 0.5  # Specify the desired bin width
 
-    min_value = floor(df["log2_bf_final"].min())
-    max_value = ceil(df["log2_bf_final"].max())
-    bin_edges = arange(min_value, max_value + bin_width, bin_width)
-
-    df["bin"] = cut(df["log2_bf_final"], bins=bin_edges)
-    binned_df = (
-        df.groupby(["gamma", "bin", "log2_bf"], observed=False)
-        .agg({"log2_bf_final": "count", "log2_bf_tf": "mean"})
-        .reset_index()
-        .rename(columns={"log2_bf_final": "count"})
+    min_value = floor(min(x[0] for x in df["log2_bf_final"].fetchall()))
+    max_value = ceil(max(x[0] for x in df["log2_bf_final"].fetchall()))
+    bin_edges = list(
+        map(
+            lambda x: x / 2, range(min_value * 2, max_value * 2 + 1, int(2 * bin_width))
+        )
     )
-    binned_df["bin_start"] = binned_df["bin"].apply(lambda x: x.left).astype("float")
-    binned_df["bin_end"] = binned_df["bin"].apply(lambda x: x.right).astype("float")
-    binned_df["log2_bf_final"] = (binned_df["bin_start"] + binned_df["bin_end"]) / 2
-    binned_df["log2_bf_desc"] = (
-        binned_df["bin_start"].astype("str") + "-" + binned_df["bin_end"].astype("str")
-    )
-    binned_df = binned_df.drop(columns="bin")
-    binned_df = binned_df[binned_df["count"] > 0]
 
-    df = df.drop(columns="bin")
-    df = df[mask]
+    # TODO: this is circumventing the 'standard' approach when we use duckdb.
+    # Maybe another way?
+    df_table_name = "__splink__df_tmp_tf_table_data"
+    con.register(df_table_name, df)
+
+    reln = con.sql(
+        f"""
+        WITH binned AS (
+            SELECT
+                gamma,
+                log2_bf,
+                unnest(map_entries(histogram(log2_bf_final, {bin_edges}))) AS hist_data,
+                hist_data['key'] AS bin_upper,
+                hist_data['value'] AS count,
+                bin_upper - {bin_width/2} AS log2_bf_final,
+                (bin_upper - {bin_width})::VARCHAR || '-' || (bin_upper)::VARCHAR
+                    AS log2_bf_desc,
+                -- have to repeat ourselves as duckdb can't disambiguate log2_bf_final
+                -- in this relation as opposed to the base table
+                bin_upper - {bin_width/2} - log2_bf AS log2_bf_tf
+            FROM
+                {df_table_name}
+            GROUP BY
+                gamma, log2_bf
+        )
+        -- only fields we need for the chart
+        SELECT
+            gamma,
+            count,
+            log2_bf_desc,
+            log2_bf_tf,
+            log2_bf_final,
+        FROM
+            binned
+        WHERE
+            count > 0
+        """
+    )
+
+    # Filter values
+    df = df.filter(
+        f"least_freq_rank < {n_least_freq} OR most_freq_rank < {n_most_freq}"
+    )
+    if vals_to_include:
+        df = df.filter(f"value IN ('{"', '".join(vals_to_include)}')")
 
     chart_path = "tf_adjustment_chart.json"
     chart = load_chart_definition(chart_path)
 
     # Complete chart schema
-    tf_levels = [cl["comparison_vector_value"] for cl in c]
+    tf_levels = [cl.comparison_vector_value for cl in tf_comparison_records]
     labels = [
-        f'{cl["label_for_charts"]} (TF col: {cl["tf_adjustment_column"]})' for cl in c
+        f"{cl.label_for_charts} (TF col: {cl.tf_adjustment_column})"
+        for cl in tf_comparison_records
     ]
 
-    df = df[df["gamma"].isin(tf_levels)].sort_values("least_freq_rank")
+    # trim down to only the data we need for the chart
+    main_chart_data = record_dicts_from_relation(
+        df.select("gamma", "value", "log2_bf_final", "log2_bf_tf", "log2_bf")
+    )
+    hist_data = record_dicts_from_relation(reln.filter(f"gamma IN {tf_levels}"))
 
-    chart["datasets"]["data"] = df.to_dict("records")
-    chart["datasets"]["hist"] = binned_df.to_dict("records")
+    chart["datasets"]["data"] = main_chart_data
+    chart["datasets"]["hist"] = hist_data
     chart["config"]["params"][0]["value"] = max(tf_levels)
     chart["config"]["params"][0]["bind"]["options"] = tf_levels
     chart["config"]["params"][0]["bind"]["labels"] = labels

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -6,11 +6,8 @@ import logging
 import warnings
 from dataclasses import replace
 from math import ceil, floor
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
-from splink.internals.charts import (
-    TFAdjustmentChart,
-)
 from splink.internals.comparison_level import ComparisonLevelDetailedRecord
 from splink.internals.duckdb.duckdb_helpers.duckdb_helpers import (
     record_dicts_from_relation,
@@ -223,13 +220,13 @@ def comparison_level_to_tf_chart_data_sql(
     return sql
 
 
-def tf_adjustment_chart(
+def tf_chart_data(
     linker: Linker,
     tf_comparison_records: list[ComparisonLevelDetailedRecord],
     n_most_freq: int,
     n_least_freq: int,
     vals_to_include: list[str],
-) -> TFAdjustmentChart:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     # we want a version of column_info_settings that is tied to duckdb, for local use
     # only need this for tf name
     column_info_settings = replace(
@@ -257,6 +254,11 @@ def tf_adjustment_chart(
     full_sql = " UNION ALL ".join(levels_chart_data_sqls)
     chart_data_table = con.sql(full_sql)
 
+    df_table_name = (
+        f"__splink__df_td_adjustment_chart_data_{n_least_freq}_{n_most_freq}"
+    )
+    con.register(df_table_name, chart_data_table)
+
     vals_not_included = (
         set(vals_to_include)
         - set(x[0] for x in chart_data_table.select("value").fetchall())
@@ -280,11 +282,6 @@ def tf_adjustment_chart(
             lambda x: x / 2, range(min_value * 2, max_value * 2 + 1, int(2 * bin_width))
         )
     )
-
-    df_table_name = (
-        f"__splink__df_td_adjustment_chart_data_{n_least_freq}_{n_most_freq}"
-    )
-    con.register(df_table_name, chart_data_table)
 
     histogram_data_table = con.sql(
         f"""
@@ -321,6 +318,7 @@ def tf_adjustment_chart(
     )
 
     # Filter values
+    # important we do this after we have calculated histogram data
     chart_data_table = chart_data_table.filter(
         f"least_freq_rank < {n_least_freq} OR most_freq_rank < {n_most_freq}"
     )
@@ -329,15 +327,13 @@ def tf_adjustment_chart(
             f"value IN ('{"', '".join(vals_to_include)}')"
         )
 
-    # Complete chart schema
-    tf_levels = [cl.comparison_vector_value for cl in tf_comparison_records]
-
     # trim down to only the data we need for the chart
     main_chart_data = record_dicts_from_relation(
         chart_data_table.select(
             "gamma", "value", "log2_bf_final", "log2_bf_tf", "log2_bf"
         )
     )
+    tf_levels = [cl.comparison_vector_value for cl in tf_comparison_records]
     hist_data = record_dicts_from_relation(
         histogram_data_table.filter(f"gamma IN {tf_levels}")
     )
@@ -346,4 +342,4 @@ def tf_adjustment_chart(
     # don't expect long-lived processes with duckdb backend, so probably not crucial
     con.execute(f"DROP VIEW {df_table_name}")
 
-    return TFAdjustmentChart(main_chart_data, hist_data, tf_comparison_records)
+    return main_chart_data, hist_data

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 # https://github.com/moj-analytical-services/splink/pull/107
 import logging
 import warnings
-from functools import reduce
+from dataclasses import replace
 from math import ceil, floor
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -191,14 +191,9 @@ def compute_all_term_frequencies_sqls(
     return sqls
 
 
-def comparison_level_to_tf_chart_data(
-    cl: dict[str, Any], con
-) -> dict[str, Any]:
+def comparison_level_to_tf_chart_data_sql(cl: dict[str, Any]) -> str:
     sdf = cl["df_tf"]
     input_col = cl["input_col"]
-
-    # ensure our duckdb connexion has access to this table
-    sdf.as_duckdbpyrelation()
 
     sql = f"""
     SELECT
@@ -227,7 +222,7 @@ def comparison_level_to_tf_chart_data(
         value IS NOT NULL
     """
 
-    return con.sql(sql)
+    return sql
 
 
 def tf_adjustment_chart(
@@ -259,43 +254,43 @@ def tf_adjustment_chart(
     comparison_records = [
         {k: getattr(cl, k) for k in keys_to_retain} for cl in tf_comparison_records
     ]
-
-    column_info_settings = linker._settings_obj.column_info_settings
-    sqlglot_dialect_str = linker._settings_obj._sql_dialect_str
+    # we want a version of column_info_settings that is tied to duckdb, for local use
+    column_info_settings = replace(
+        linker._settings_obj.column_info_settings, sql_dialect="duckdb"
+    )
 
     # Add data ("df_tf") to each level
     comparison_records = [
         dict(
             cl,
             **{
+                # TODO: need to load it into duckdb...
                 "df_tf": linker.table_management.compute_tf_table(
                     cl["tf_adjustment_column"]
                 ),
                 "input_col": InputColumn(
                     cl["tf_adjustment_column"],
                     column_info_settings=column_info_settings,
-                    sqlglot_dialect_str=sqlglot_dialect_str,
-                )
-
+                    sqlglot_dialect_str="duckdb",
+                ),
             },
         )
         for cl in comparison_records
     ]
     con = linker._db_api.duckdb_con
+    # register tf tables in duckdb
+    for cl in comparison_records:
+        cl["df_tf"].as_duckdbpyrelation()
 
-    levels_chart_data = [
-        comparison_level_to_tf_chart_data(
-            cl, con
-        )
-        for cl in comparison_records
+    levels_chart_data_sqls = [
+        comparison_level_to_tf_chart_data_sql(cl) for cl in comparison_records
     ]
-    df = reduce(
-        lambda relation_left, relation_right: relation_left.union(relation_right),
-        levels_chart_data,
-    )
+    full_sql = " UNION ALL ".join(levels_chart_data_sqls)
+    chart_data_table = con.sql(full_sql)
 
     vals_not_included = (
-        set(vals_to_include) - set(x[0] for x in df.select("value").fetchall())
+        set(vals_to_include)
+        - set(x[0] for x in chart_data_table.select("value").fetchall())
         if vals_to_include
         else {}
     )
@@ -309,8 +304,8 @@ def tf_adjustment_chart(
     # Histogram data
     bin_width = 0.5  # Specify the desired bin width
 
-    min_value = floor(min(x[0] for x in df["log2_bf_final"].fetchall()))
-    max_value = ceil(max(x[0] for x in df["log2_bf_final"].fetchall()))
+    min_value = floor(min(x[0] for x in chart_data_table["log2_bf_final"].fetchall()))
+    max_value = ceil(max(x[0] for x in chart_data_table["log2_bf_final"].fetchall()))
     bin_edges = list(
         map(
             lambda x: x / 2, range(min_value * 2, max_value * 2 + 1, int(2 * bin_width))
@@ -318,12 +313,11 @@ def tf_adjustment_chart(
     )
 
     df_table_name = (
-        f"__splink__df_td_adjustment_chart_"
-        f"data_{col}_{n_least_freq}_{n_most_freq}"
+        f"__splink__df_td_adjustment_chart_data_{col}_{n_least_freq}_{n_most_freq}"
     )
-    con.register(df_table_name, df)
+    con.register(df_table_name, chart_data_table)
 
-    reln = con.sql(
+    histogram_data_table = con.sql(
         f"""
         WITH binned AS (
             SELECT
@@ -358,11 +352,13 @@ def tf_adjustment_chart(
     )
 
     # Filter values
-    df = df.filter(
+    chart_data_table = chart_data_table.filter(
         f"least_freq_rank < {n_least_freq} OR most_freq_rank < {n_most_freq}"
     )
     if vals_to_include:
-        df = df.filter(f"value IN ('{"', '".join(vals_to_include)}')")
+        chart_data_table = chart_data_table.filter(
+            f"value IN ('{"', '".join(vals_to_include)}')"
+        )
 
     chart_path = "tf_adjustment_chart.json"
     chart = load_chart_definition(chart_path)
@@ -376,9 +372,13 @@ def tf_adjustment_chart(
 
     # trim down to only the data we need for the chart
     main_chart_data = record_dicts_from_relation(
-        df.select("gamma", "value", "log2_bf_final", "log2_bf_tf", "log2_bf")
+        chart_data_table.select(
+            "gamma", "value", "log2_bf_final", "log2_bf_tf", "log2_bf"
+        )
     )
-    hist_data = record_dicts_from_relation(reln.filter(f"gamma IN {tf_levels}"))
+    hist_data = record_dicts_from_relation(
+        histogram_data_table.filter(f"gamma IN {tf_levels}")
+    )
 
     # TODO: worth handling the case where we hit an error before and we don't drop?
     # don't expect long-lived processes with duckdb backend, so probably not crucial

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -227,21 +227,12 @@ def comparison_level_to_tf_chart_data_sql(
 
 def tf_adjustment_chart(
     linker: Linker,
-    col: str,
+    tf_comparison_records: list[ComparisonLevelDetailedRecord],
     n_most_freq: int,
     n_least_freq: int,
     vals_to_include: list[str],
     as_dict: bool,
 ) -> ChartReturnType:
-    # Data for chart
-    comparison = linker._settings_obj._get_comparison_by_output_column_name(col)
-    # Select levels with TF adjustments
-    tf_comparison_records = [
-        detailed_rec
-        for detailed_rec in comparison._as_detailed_records
-        if detailed_rec.has_tf_adjustments
-    ]
-
     # we want a version of column_info_settings that is tied to duckdb, for local use
     # only need this for tf name
     column_info_settings = replace(
@@ -294,7 +285,7 @@ def tf_adjustment_chart(
     )
 
     df_table_name = (
-        f"__splink__df_td_adjustment_chart_data_{col}_{n_least_freq}_{n_most_freq}"
+        f"__splink__df_td_adjustment_chart_data_{n_least_freq}_{n_most_freq}"
     )
     con.register(df_table_name, chart_data_table)
 

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -6,13 +6,14 @@ import logging
 import warnings
 from dataclasses import replace
 from math import ceil, floor
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 from splink.internals.charts import (
     ChartReturnType,
     altair_or_json,
     load_chart_definition,
 )
+from splink.internals.comparison_level import ComparisonLevelDetailedRecord
 from splink.internals.duckdb.duckdb_helpers.duckdb_helpers import (
     record_dicts_from_relation,
 )
@@ -191,22 +192,21 @@ def compute_all_term_frequencies_sqls(
     return sqls
 
 
-def comparison_level_to_tf_chart_data_sql(cl: dict[str, Any]) -> str:
-    sdf = cl["df_tf"]
-    input_col = cl["input_col"]
-
+def comparison_level_to_tf_chart_data_sql(
+    cl: ComparisonLevelDetailedRecord, sdf: SplinkDataFrame, input_col: InputColumn
+) -> str:
     sql = f"""
     SELECT
         {input_col.name} AS value,
         {input_col.tf_name} AS tf,
-        {cl["u_probability"]}::DOUBLE AS u_probability,
-        {cl["tf_adjustment_weight"]}::DOUBLE AS tf_adjustment_weight,
+        {cl.u_probability}::DOUBLE AS u_probability,
+        {cl.tf_adjustment_weight}::DOUBLE AS tf_adjustment_weight,
         -- TF match weight scaled by tf_adjustment_weight
         log2(u_probability/tf) * tf_adjustment_weight AS log2_bf_tf,
         -- Tidy up columns
-        {cl["comparison_vector_value"]} AS gamma,
+        {cl.comparison_vector_value} AS gamma,
         '{input_col.unquote().name}' AS tf_col,
-        {cl["log2_bayes_factor"]}::DOUBLE AS log2_bf,
+        {cl.log2_bayes_factor}::DOUBLE AS log2_bf,
         log2_bf_tf + log2_bf AS log2_bf_final,
         row_number() OVER (
                 PARTITION BY gamma
@@ -235,56 +235,37 @@ def tf_adjustment_chart(
 ) -> ChartReturnType:
     # Data for chart
     comparison = linker._settings_obj._get_comparison_by_output_column_name(col)
+    # Select levels with TF adjustments
     tf_comparison_records = [
         detailed_rec
         for detailed_rec in comparison._as_detailed_records
         if detailed_rec.has_tf_adjustments
     ]
 
-    keys_to_retain = [
-        "comparison_vector_value",
-        "label_for_charts",
-        "tf_adjustment_column",
-        "tf_adjustment_weight",
-        "u_probability",
-        "log2_bayes_factor",
-    ]
-
-    # Select levels with TF adjustments
-    comparison_records = [
-        {k: getattr(cl, k) for k in keys_to_retain} for cl in tf_comparison_records
-    ]
     # we want a version of column_info_settings that is tied to duckdb, for local use
+    # only need this for tf name
     column_info_settings = replace(
         linker._settings_obj.column_info_settings, sql_dialect="duckdb"
     )
 
-    # Add data ("df_tf") to each level
-    comparison_records = [
-        dict(
-            cl,
-            **{
-                # TODO: need to load it into duckdb...
-                "df_tf": linker.table_management.compute_tf_table(
-                    cl["tf_adjustment_column"]
-                ),
-                "input_col": InputColumn(
-                    cl["tf_adjustment_column"],
-                    column_info_settings=column_info_settings,
-                    sqlglot_dialect_str="duckdb",
-                ),
-            },
-        )
-        for cl in comparison_records
-    ]
     con = linker._db_api.duckdb_con
-    # register tf tables in duckdb
-    for cl in comparison_records:
-        cl["df_tf"].as_duckdbpyrelation()
+    levels_chart_data_sqls: list[str] = []
+    for comparison_record in tf_comparison_records:
+        # we know this is not None, as we have filtered out records without tf adjs
+        tf_col_name: str = cast(str, comparison_record.tf_adjustment_column)
+        sdf_tf_table = linker.table_management.compute_tf_table(tf_col_name)
+        # register tf table in duckdb
+        sdf_tf_table.as_duckdbpyrelation()
+        input_column = InputColumn(
+            tf_col_name,
+            column_info_settings=column_info_settings,
+            sqlglot_dialect_str="duckdb",
+        )
+        levels_chart_data_sql = comparison_level_to_tf_chart_data_sql(
+            comparison_record, sdf_tf_table, input_column
+        )
+        levels_chart_data_sqls.append(levels_chart_data_sql)
 
-    levels_chart_data_sqls = [
-        comparison_level_to_tf_chart_data_sql(cl) for cl in comparison_records
-    ]
     full_sql = " UNION ALL ".join(levels_chart_data_sqls)
     chart_data_table = con.sql(full_sql)
 

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -192,16 +192,11 @@ def compute_all_term_frequencies_sqls(
 
 
 def comparison_level_to_tf_chart_data(
-    cl: dict[str, Any], con, column_info_settings, sqlglot_dialect_str
+    cl: dict[str, Any], con
 ) -> dict[str, Any]:
-    # TODO: don't want to have to pass this around everywhere
-    input_col = InputColumn(
-        cl["tf_adjustment_column"],
-        column_info_settings=column_info_settings,
-        sqlglot_dialect_str=sqlglot_dialect_str,
-    )
-
     sdf = cl["df_tf"]
+    input_col = cl["input_col"]
+
     # ensure our duckdb connexion has access to this table
     sdf.as_duckdbpyrelation()
 
@@ -265,6 +260,9 @@ def tf_adjustment_chart(
         {k: getattr(cl, k) for k in keys_to_retain} for cl in tf_comparison_records
     ]
 
+    column_info_settings = linker._settings_obj.column_info_settings
+    sqlglot_dialect_str = linker._settings_obj._sql_dialect_str
+
     # Add data ("df_tf") to each level
     comparison_records = [
         dict(
@@ -272,19 +270,22 @@ def tf_adjustment_chart(
             **{
                 "df_tf": linker.table_management.compute_tf_table(
                     cl["tf_adjustment_column"]
+                ),
+                "input_col": InputColumn(
+                    cl["tf_adjustment_column"],
+                    column_info_settings=column_info_settings,
+                    sqlglot_dialect_str=sqlglot_dialect_str,
                 )
+
             },
         )
         for cl in comparison_records
     ]
     con = linker._db_api.duckdb_con
 
-    column_info_settings = linker._settings_obj.column_info_settings
-    sqlglot_dialect_str = linker._settings_obj._sql_dialect_str
-
     levels_chart_data = [
         comparison_level_to_tf_chart_data(
-            cl, con, column_info_settings, sqlglot_dialect_str
+            cl, con
         )
         for cl in comparison_records
     ]

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -316,9 +316,10 @@ def tf_adjustment_chart(
         )
     )
 
-    # TODO: this is circumventing the 'standard' approach when we use duckdb.
-    # Maybe another way?
-    df_table_name = "__splink__df_tmp_tf_table_data"
+    df_table_name = (
+        f"__splink__df_td_adjustment_chart_"
+        f"data_{col}_{n_least_freq}_{n_most_freq}"
+    )
     con.register(df_table_name, df)
 
     reln = con.sql(
@@ -377,6 +378,10 @@ def tf_adjustment_chart(
         df.select("gamma", "value", "log2_bf_final", "log2_bf_tf", "log2_bf")
     )
     hist_data = record_dicts_from_relation(reln.filter(f"gamma IN {tf_levels}"))
+
+    # TODO: worth handling the case where we hit an error before and we don't drop?
+    # don't expect long-lived processes with duckdb backend, so probably not crucial
+    con.execute(f"DROP VIEW {df_table_name}")
 
     chart["datasets"]["data"] = main_chart_data
     chart["datasets"]["hist"] = hist_data

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -9,9 +9,7 @@ from math import ceil, floor
 from typing import TYPE_CHECKING, Optional, cast
 
 from splink.internals.charts import (
-    ChartReturnType,
-    altair_or_json,
-    load_chart_definition,
+    TFAdjustmentChart,
 )
 from splink.internals.comparison_level import ComparisonLevelDetailedRecord
 from splink.internals.duckdb.duckdb_helpers.duckdb_helpers import (
@@ -231,8 +229,7 @@ def tf_adjustment_chart(
     n_most_freq: int,
     n_least_freq: int,
     vals_to_include: list[str],
-    as_dict: bool,
-) -> ChartReturnType:
+) -> TFAdjustmentChart:
     # we want a version of column_info_settings that is tied to duckdb, for local use
     # only need this for tf name
     column_info_settings = replace(
@@ -332,15 +329,8 @@ def tf_adjustment_chart(
             f"value IN ('{"', '".join(vals_to_include)}')"
         )
 
-    chart_path = "tf_adjustment_chart.json"
-    chart = load_chart_definition(chart_path)
-
     # Complete chart schema
     tf_levels = [cl.comparison_vector_value for cl in tf_comparison_records]
-    labels = [
-        f"{cl.label_for_charts} (TF col: {cl.tf_adjustment_column})"
-        for cl in tf_comparison_records
-    ]
 
     # trim down to only the data we need for the chart
     main_chart_data = record_dicts_from_relation(
@@ -356,24 +346,4 @@ def tf_adjustment_chart(
     # don't expect long-lived processes with duckdb backend, so probably not crucial
     con.execute(f"DROP VIEW {df_table_name}")
 
-    chart["datasets"]["data"] = main_chart_data
-    chart["datasets"]["hist"] = hist_data
-    chart["config"]["params"][0]["value"] = max(tf_levels)
-    chart["config"]["params"][0]["bind"]["options"] = tf_levels
-    chart["config"]["params"][0]["bind"]["labels"] = labels
-
-    # filters = [
-    #     f"datum.most_freq_rank < {n_most_freq}",
-    #     f"datum.least_freq_rank < {n_least_freq}",
-    #     " | ".join([f"datum.value == '{v}'" for v in vals_to_include])
-    # ]
-    # filter_text = " | ".join(filters)
-    # chart["hconcat"][0]["layer"][0]["transform"][2]["filter"] = filter_text
-    # chart["hconcat"][0]["layer"][2]["transform"][2]["filter"] = filter_text
-
-    # PLACEHOLDER (until we work out adding a dynamic title based on the filtered data)
-    chart["hconcat"][0]["layer"][0]["encoding"]["x"]["title"] = "TF column value"
-    chart["hconcat"][0]["layer"][-1]["encoding"]["x"]["title"] = "TF column value"
-    chart["hconcat"][0]["layer"][0]["encoding"]["tooltip"][0]["title"] = "Value"
-
-    return altair_or_json(chart, as_dict=as_dict)
+    return TFAdjustmentChart(main_chart_data, hist_data, tf_comparison_records)

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -324,7 +324,7 @@ def tf_chart_data(
     )
     if vals_to_include:
         chart_data_table = chart_data_table.filter(
-            f"value IN ('{"', '".join(vals_to_include)}')"
+            f"""value IN ('{"', '".join(vals_to_include)}')"""
         )
 
     # trim down to only the data we need for the chart


### PR DESCRIPTION
Logic for creating the tf adjustment chart from pandas (#2917 ) and convert to `SplinkChart` - #2941, as well as some light streamlining.

Deliberately not changed any logic, as outside the scope of this PR.