### PR TITLE
Publish via Trusted Publishing

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Publish to PyPI
         id: publish_to_pypi
-        run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -11,6 +11,8 @@ permissions: {}
 jobs:
   publish-to-pypi:
     runs-on: ubuntu-latest
+    environment:
+      name: release
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
See [uv docs](https://docs.astral.sh/uv/guides/package/#publishing-your-package):

> Set a PyPI token with --token or UV_PUBLISH_TOKEN, or set a username with --username or UV_PUBLISH_USERNAME and password with --password or UV_PUBLISH_PASSWORD. **For publishing to PyPI from GitHub Actions or another Trusted Publisher, you don't need to set any credentials**. Instead, [add a trusted publisher to the PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

I believe I have configured things okay on the PyPI side to match this, but could possibly require some fiddling at next release.