### PR TITLE
Fix repeated numbering in tutorials/04_Estimating_model_parameters docs

### DIFF
--- a/docs/demos/tutorials/04_Estimating_model_parameters.ipynb
+++ b/docs/demos/tutorials/04_Estimating_model_parameters.ipynb
@@ -153,7 +153,7 @@
         "\n",
         "Splink includes a library of comparison functions at `splink.comparison_library` to make it simple to get started. These are split into two categories:\n",
         "\n",
-        "1. Generic `Comparison` functions which apply a particular fuzzy matching function. For example, levenshtein distance.\n"
+        "**Category 1: Generic `Comparison` functions** which apply a particular fuzzy matching function. For example, levenshtein distance.\n"
       ]
     },
     {
@@ -196,7 +196,7 @@
       "id": "f0a6cc8b",
       "metadata": {},
       "source": [
-        "2. `Comparison` functions tailored for specific data types. For example, email."
+        "**Category 2: `Comparison` functions tailored for specific data types**. For example, email."
       ]
     },
     {


### PR DESCRIPTION
### Type of PR

- [ x] DOC

## Summary
Fixes repeated numbering in the "Specifying the model using comparisons" section of the estimating model parameters tutorial.

## Change
Replaces ordered-list numbering with explicit category labels so the docs page does not restart numbering after intervening code cells.

