### PR TITLE
Feature/query sql

### DIFF
--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Literal,
     Optional,
     TypeVar,
     Union,
@@ -175,6 +176,33 @@ class DatabaseAPI(ABC, Generic[TablishType]):
         splink_dataframe.sql_used_to_create = sql
 
         return splink_dataframe
+
+    def query_sql(
+        self,
+        sql: str,
+        output_type: Literal["splink_df", "splinkdf", "pandas"] = "splink_df",
+    ) -> SplinkDataFrame | PandasDataFrame:
+        """
+        Execute a supplied SQL query against backend directly.
+        """
+        output_tablename_templated = "__splink__df_sql_query"
+
+        pipeline = CTEPipeline()
+        pipeline.enqueue_sql(sql, output_tablename_templated)
+        splink_dataframe = self.sql_pipeline_to_splink_dataframe(pipeline)
+
+        if output_type in ("splink_df", "splinkdf"):
+            return splink_dataframe
+        elif output_type == "pandas":
+            out = splink_dataframe.as_pandas_dataframe()
+            # If pandas, drop the table to cleanup the db
+            splink_dataframe.drop_table_from_database_and_remove_from_cache()
+            return out
+        else:
+            raise ValueError(
+                f"output_type '{output_type}' is not supported.",
+                "Must be one of 'splink_df'/'splinkdf' or 'pandas'",
+            )
 
     def sql_pipeline_to_splink_dataframe(
         self,

--- a/splink/internals/linker_components/misc.py
+++ b/splink/internals/linker_components/misc.py
@@ -4,8 +4,6 @@ import json
 import os
 from typing import TYPE_CHECKING, Any
 
-from splink.internals.pipeline import CTEPipeline
-
 if TYPE_CHECKING:
     from splink.internals.linker import Linker
 
@@ -68,24 +66,4 @@ class LinkerMisc:
             output_type (str): One of splink_df/splinkdf or pandas.
                 This determines the type of table that your results are output in.
         """
-
-        output_tablename_templated = "__splink__df_sql_query"
-
-        pipeline = CTEPipeline()
-        pipeline.enqueue_sql(sql, output_tablename_templated)
-        splink_dataframe = self._linker._db_api.sql_pipeline_to_splink_dataframe(
-            pipeline
-        )
-
-        if output_type in ("splink_df", "splinkdf"):
-            return splink_dataframe
-        elif output_type == "pandas":
-            out = splink_dataframe.as_pandas_dataframe()
-            # If pandas, drop the table to cleanup the db
-            splink_dataframe.drop_table_from_database_and_remove_from_cache()
-            return out
-        else:
-            raise ValueError(
-                f"output_type '{output_type}' is not supported.",
-                "Must be one of 'splink_df'/'splinkdf' or 'pandas'",
-            )
+        return self._linker._db_api.query_sql(sql, output_type)

--- a/splink/internals/splink_dataframe.py
+++ b/splink/internals/splink_dataframe.py
@@ -111,6 +111,34 @@ class SplinkDataFrame(ABC):
         self.db_api.remove_splinkdataframe_from_cache(self)
         self.db_api._created_tables.discard(self.physical_name)
 
+    def query_sql(self, sql: str) -> "SplinkDataFrame":
+        """
+        Query this frame in the backend in which this table lives.
+        You can refer to the table represented by this SplinkDataFrame as {this}.
+        If using an f-string to construct SQL you may escape the braces as {{this}}
+
+        Examples:
+            ```py
+            df_predict = linker.inference.predict()
+            df_predict.query_sql("SELECT * FROM {this} WHERE match_weight > 10")
+
+            # need to escape the braces if using an f-string
+            low_mw = -5
+            df_predict.query_sql(
+                f'''
+                SELECT unique_id_l, unique_id_r
+                FROM {{this}}
+                WHERE match_weight > {low_ml}
+                '''
+            )
+            ```
+        Args:
+            sql (string): The SQL to query against the backend. This table can be
+                referred to as {{this}}
+        """
+        sql = sql.format(this=self.physical_name)
+        return self.db_api.query_sql(sql)
+
     def as_record_dict(self, limit: Optional[int] = None) -> list[dict[str, Any]]:
         """Return the dataframe as a list of record dictionaries.
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,13 +7,12 @@ def assert_number_of_rows_with_gamma_value(
     gamma_value: int,
     expected_number_of_rows: int,
 ):
-    db_api = df_pred.db_api
-    num_gamma_values_sdf = db_api.query_sql(
+    num_gamma_values_sdf = df_pred.query_sql(
         f"""
         SELECT
             COUNT(*) AS count
         FROM
-            {df_pred.physical_name}
+            {{this}}
         WHERE
             {gamma_col_name} = {gamma_value}
         """
@@ -32,13 +31,12 @@ def assert_id_pair_has_gamma_value(
     expected_gamma_level: int,
     id_pair: tuple[int, int],
 ):
-    db_api = df_pred.db_api
-    num_gamma_values_sdf = db_api.query_sql(
+    num_gamma_values_sdf = df_pred.query_sql(
         f"""
         SELECT
             {gamma_col_name} AS gamma_level
         FROM
-            {df_pred.physical_name}
+            {{this}}
         WHERE
             unique_id_l = {id_pair[0]}
         AND

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,53 @@
+from splink.internals.splink_dataframe import SplinkDataFrame
+
+
+def assert_number_of_rows_with_gamma_value(
+    df_pred: SplinkDataFrame,
+    gamma_col_name: str,
+    gamma_value: int,
+    expected_number_of_rows: int,
+):
+    db_api = df_pred.db_api
+    num_gamma_values_sdf = db_api.query_sql(
+        f"""
+        SELECT
+            COUNT(*) AS count
+        FROM
+            {df_pred.physical_name}
+        WHERE
+            {gamma_col_name} = {gamma_value}
+        """
+    )
+    actual_number_of_rows = num_gamma_values_sdf.as_dict()["count"][0]
+    assert_failure_string = (
+        f"Gamma level '{gamma_value}' expected {expected_number_of_rows} rows, "
+        f"but found {actual_number_of_rows}"
+    )
+    assert actual_number_of_rows == expected_number_of_rows, assert_failure_string
+
+
+def assert_id_pair_has_gamma_value(
+    df_pred: SplinkDataFrame,
+    gamma_col_name: str,
+    expected_gamma_level: int,
+    id_pair: tuple[int, int],
+):
+    db_api = df_pred.db_api
+    num_gamma_values_sdf = db_api.query_sql(
+        f"""
+        SELECT
+            {gamma_col_name} AS gamma_level
+        FROM
+            {df_pred.physical_name}
+        WHERE
+            unique_id_l = {id_pair[0]}
+        AND
+            unique_id_r = {id_pair[1]}
+        """
+    )
+    actual_gamma_level = num_gamma_values_sdf.as_dict()["gamma_level"][0]
+    assert_failure_string = (
+        f"ID pair {id_pair} expected gamma level '{expected_gamma_level}', "
+        f"but found level '{actual_gamma_level}'"
+    )
+    assert actual_gamma_level == expected_gamma_level, assert_failure_string


### PR DESCRIPTION
Built on #3079, but the only relevant part is skipping the dataset test.

This moves the core logic of `.query_sql` from `Linker` to `DatabaseAPI`, leaving the former as a wrapper, so that we can easily run simple queries without setting up a linker.

In addition this provides a convenience function `SplinkDataFrame.query_sql`, which allows doing the same from a splink dataframe (without having to access the db api explicitly), and conveniently referring to the dataframe itself as `{this}`. This sugar makes it easy to run quick queries against a splink dataframe without fiddling about with `physical_name`. Example code:

```python
...
sdf_pred = linker.inference.predict()

sdf_unsure_results = sdf.query_sql(
    """
    SELECT * FROM {this}
    WHERE match_probability > 0.9 AND match_probability < 0.95
    ORDER BY match_probability
    """
)
```