### PR TITLE
Register from csv

### DIFF
--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -364,6 +364,19 @@ class DatabaseAPI(ABC, Generic[TablishType]):
     ) -> SplinkDataFrame:
         pass
 
+    def _load_from_csv(self, path: str) -> AcceptableInputTableType:
+        # sensible fallback for backends that don't specialise
+        import pyarrow.csv as pv
+
+        return pv.read_csv(
+            path,
+            convert_options=pv.ConvertOptions(strings_can_be_null=True),
+        )
+
+    @final
+    def register_from_csv(self, path: str) -> SplinkDataFrame:
+        return self.register(self._load_from_csv(path))
+
     @abstractmethod
     def table_exists_in_database(self, table_name: str) -> bool:
         """

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -79,6 +79,11 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
     ) -> DuckDBDataFrame:
         return DuckDBDataFrame(templated_name, physical_name, self)
 
+    def _load_from_csv(self, path: str) -> str:
+        tn = self._new_input_table_name()
+        self._con.execute(f"CREATE TABLE {tn} AS FROM read_csv_auto('{path}')")
+        return tn
+
     def table_exists_in_database(self, table_name):
         sql = f"PRAGMA table_info('{table_name}');"
         from duckdb import CatalogException

--- a/splink/internals/em_training_session.py
+++ b/splink/internals/em_training_session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
 from splink.internals.blocking import BlockingRule, block_using_rules_sqls
 from splink.internals.charts import (
@@ -62,6 +62,9 @@ class ModelParameterIterationDetailedRecord(ModelParameterDetailedRecord):
             **asdict(cl_rec),
             iteration=iteration,
         )
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 class EMTrainingSession:

--- a/splink/internals/spark/database_api.py
+++ b/splink/internals/spark/database_api.py
@@ -85,6 +85,11 @@ class SparkAPI(DatabaseAPI[spark_df]):
     ) -> SparkDataFrame:
         return SparkDataFrame(templated_name, physical_name, self)
 
+    def _load_from_csv(self, path: str) -> spark_df:
+        df = self.spark.read.csv(path, header=True)
+        df.persist()
+        return df
+
     def table_exists_in_database(self, table_name):
         query_result = self._execute_sql_against_backend(
             f"show tables from {self.splink_data_store} like '{table_name}'"

--- a/tests/test_compare_splink2.py
+++ b/tests/test_compare_splink2.py
@@ -1,97 +1,45 @@
-import pandas as pd
 import pytest
 
 from splink.internals.duckdb.database_api import DuckDBAPI
 from splink.internals.linker import Linker
 from splink.internals.misc import bayes_factor_to_prob, prob_to_bayes_factor
-from splink.internals.sqlite.database_api import SQLiteAPI
 
 from .basic_settings import get_settings_dict
-from .decorator import mark_with_dialects_including
+from .decorator import mark_with_dialects_excluding
 
 
-def test_splink_2_predict():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+@mark_with_dialects_excluding()
+def test_splink_2_predict(fake_1000, dialect, test_helpers):
+    helper = test_helpers[dialect]
+    settings_dict = get_settings_dict()
+    db_api = helper.db_api()
+    df_sdf = db_api.register(fake_1000)
+
+    linker = Linker(df_sdf, settings_dict)
+
+    expected_sdf = db_api.register_from_csv("tests/datasets/splink2_479_vs_481.csv")
+
+    df_e = linker.inference.predict()
+
+    actual_record = df_e.query_sql(
+        "SELECT * FROM {this} WHERE unique_id_l = 479 AND unique_id_r = 481"
+    )
+
+    expected_match_weight = float(expected_sdf.as_dict()["match_weight"][0])
+    actual_match_weight = actual_record.as_dict()["match_weight"][0]
+
+    assert actual_match_weight == pytest.approx(expected_match_weight)
+
+
+def test_splink_2_em_fixed_u(fake_1000, test_helpers):
     settings_dict = get_settings_dict()
     db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
-
-    linker = Linker(df_sdf, settings_dict)
-
-    expected_record = pd.read_csv("tests/datasets/splink2_479_vs_481.csv")
-
-    df_e = linker.inference.predict().as_pandas_dataframe()
-
-    f1 = df_e["unique_id_l"] == 479
-    f2 = df_e["unique_id_r"] == 481
-    actual_record = df_e[f1 & f2]
-
-    expected_match_weight = expected_record["match_weight"].iloc[0]
-    actual_match_weight = actual_record["match_weight"].iloc[0]
-
-    assert expected_match_weight == pytest.approx(actual_match_weight)
-
-
-# @pytest.mark.skip(reason="Uses Spark so slow and heavyweight")
-@mark_with_dialects_including("spark")
-def test_splink_2_predict_spark(df_spark, spark_api):
-    settings_dict = get_settings_dict()
-    df_sdf = spark_api.register(df_spark)
-    linker = Linker(df_sdf, settings_dict)
-
-    df_e = linker.inference.predict().as_pandas_dataframe()
-    f1 = df_e["unique_id_l"] == "479"
-    f2 = df_e["unique_id_r"] == "481"
-    actual_record = df_e[f1 & f2]
-    expected_record = pd.read_csv("tests/datasets/splink2_479_vs_481.csv")
-
-    expected_match_weight = expected_record["match_weight"].iloc[0]
-    actual_match_weight = actual_record["match_weight"].iloc[0]
-
-    assert expected_match_weight == pytest.approx(actual_match_weight)
-
-
-@mark_with_dialects_including("sqlite")
-def test_splink_2_predict_sqlite():
-    import sqlite3
-
-    from rapidfuzz.distance.Levenshtein import distance
-
-    con = sqlite3.connect(":memory:")
-    con.create_function("levenshtein", 2, distance)
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df.to_sql("fake_data_1", con, if_exists="replace")
-    settings_dict = get_settings_dict()
-
-    db_api = SQLiteAPI(con)
-    df_sdf = db_api.register("fake_data_1")
-    linker = Linker(df_sdf, settings_dict)
-
-    df_e = linker.inference.predict().as_pandas_dataframe()
-
-    f1 = df_e["unique_id_l"] == 479
-    f2 = df_e["unique_id_r"] == 481
-    actual_record = df_e[f1 & f2]
-    expected_record = pd.read_csv("tests/datasets/splink2_479_vs_481.csv")
-
-    expected_match_weight = expected_record["match_weight"].iloc[0]
-    actual_match_weight = actual_record["match_weight"].iloc[0]
-
-    assert expected_match_weight == pytest.approx(actual_match_weight)
-
-    linker.training.estimate_parameters_using_expectation_maximisation("l.dob=r.dob")
-
-
-def test_splink_2_em_fixed_u():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    settings_dict = get_settings_dict()
-    db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register(fake_1000)
 
     linker = Linker(df_sdf, settings_dict)
 
     # Check lambda history is the same
-    expected_prop_history = pd.read_csv(
+    expected_prop_history = db_api.register_from_csv(
         "tests/datasets/splink2_proportion_of_matches_history_fixed_u.csv"
     )
 
@@ -100,47 +48,64 @@ def test_splink_2_em_fixed_u():
             "l.surname = r.surname"
         )
     )
-    actual_prop_history = pd.DataFrame(training_session._lambda_history_records)
-
-    compare = expected_prop_history.merge(
-        actual_prop_history, left_on="iteration", right_on="iteration"
+    actual_prop_history = db_api.register(training_session._lambda_history_records)
+    actuals = sorted(actual_prop_history.as_record_dict(), key=lambda r: r["iteration"])
+    expecteds = sorted(
+        expected_prop_history.as_record_dict(), key=lambda r: r["iteration"]
     )
 
-    for r in compare.to_dict(orient="records"):
-        assert r["probability_two_random_records_match"] == pytest.approx(r["λ"])
+    for expected, actual in zip(expecteds, actuals):
+        assert expected["λ"] == pytest.approx(
+            actual["probability_two_random_records_match"]
+        )
 
     # Check history of m probabilities is the same for a column
-    expected_m_u_history = pd.read_csv("tests/datasets/splink2_m_u_history_fixed_u.csv")
-    f1 = expected_m_u_history["gamma_column_name"] == "gamma_first_name"
-    f2 = expected_m_u_history["comparison_vector_value"] == "1"
-    expected_first_name_level_1_m = expected_m_u_history[f1 & f2]
-
-    actual_m_u_history = pd.DataFrame(training_session._iteration_history_records)
-    f1 = actual_m_u_history["comparison_name"] == "first_name"
-    f2 = actual_m_u_history["comparison_vector_value"] == 1
-    actual_first_name_level_1_m = actual_m_u_history[f1 & f2]
-
-    compare = expected_first_name_level_1_m.merge(
-        actual_first_name_level_1_m,
-        left_on="iteration",
-        right_on="iteration",
-        suffixes=("_e", "_a"),
+    expected_m_u_history = db_api.register_from_csv(
+        "tests/datasets/splink2_m_u_history_fixed_u.csv"
+    )
+    expected_first_name_level_1_m = expected_m_u_history.query_sql(
+        """
+            SELECT *
+            FROM {this}
+            WHERE gamma_column_name = 'gamma_first_name'
+            AND comparison_vector_value = 1
+        """
     )
 
-    for r in compare.to_dict(orient="records"):
-        assert r["m_probability_e"] == pytest.approx(r["m_probability_a"])
+    actual_m_u_history = db_api.register(
+        list(map(lambda r: r.as_dict(), training_session._iteration_history_records))
+    )
+    actual_first_name_level_1_m = actual_m_u_history.query_sql(
+        """
+            SELECT *
+            FROM {this}
+            WHERE comparison_name = 'first_name'
+            AND comparison_vector_value = 1
+        """
+    )
+
+    actuals = sorted(
+        actual_first_name_level_1_m.as_record_dict(), key=lambda r: r["iteration"]
+    )
+    expecteds = sorted(
+        expected_first_name_level_1_m.as_record_dict(), key=lambda r: r["iteration"]
+    )
+
+    for expected, actual in zip(expecteds, actuals):
+        assert actual["m_probability"] == pytest.approx(expected["m_probability"])
 
 
 def test_splink_2_em_no_fix():
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings_dict = get_settings_dict()
     db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register_from_csv(
+        "./tests/datasets/fake_1000_from_splink_demos.csv"
+    )
 
     linker = Linker(df_sdf, settings_dict)
 
     # Check lambda history is the same
-    expected_prop_history = pd.read_csv(
+    expected_prop_history = db_api.register_from_csv(
         "tests/datasets/splink2_proportion_of_matches_history_no_fix.csv"
     )
 
@@ -149,35 +114,51 @@ def test_splink_2_em_no_fix():
             "l.surname = r.surname", fix_u_probabilities=False
         )
     )
-    actual_prop_history = pd.DataFrame(training_session._lambda_history_records)
-
-    compare = expected_prop_history.merge(
-        actual_prop_history, left_on="iteration", right_on="iteration"
+    actual_prop_history = db_api.register(training_session._lambda_history_records)
+    actuals = sorted(actual_prop_history.as_record_dict(), key=lambda r: r["iteration"])
+    expecteds = sorted(
+        expected_prop_history.as_record_dict(), key=lambda r: r["iteration"]
     )
 
-    for r in compare.to_dict(orient="records"):
-        assert r["probability_two_random_records_match"] == pytest.approx(r["λ"])
+    for expected, actual in zip(expecteds, actuals):
+        assert expected["λ"] == pytest.approx(
+            actual["probability_two_random_records_match"]
+        )
 
     # Check history of m probabilities is the same for a column
-    expected_m_u_history = pd.read_csv("tests/datasets/splink2_m_u_history_no_fix.csv")
-    f1 = expected_m_u_history["gamma_column_name"] == "gamma_first_name"
-    f2 = expected_m_u_history["comparison_vector_value"] == "1"
-    expected_first_name_level_1_m = expected_m_u_history[f1 & f2]
-
-    actual_m_u_history = pd.DataFrame(training_session._iteration_history_records)
-    f1 = actual_m_u_history["comparison_name"] == "first_name"
-    f2 = actual_m_u_history["comparison_vector_value"] == 1
-    actual_first_name_level_1_m = actual_m_u_history[f1 & f2]
-
-    compare = expected_first_name_level_1_m.merge(
-        actual_first_name_level_1_m,
-        left_on="iteration",
-        right_on="iteration",
-        suffixes=("_e", "_a"),
+    expected_m_u_history = db_api.register_from_csv(
+        "tests/datasets/splink2_m_u_history_no_fix.csv"
+    )
+    expected_first_name_level_1_m = expected_m_u_history.query_sql(
+        """
+            SELECT *
+            FROM {this}
+            WHERE gamma_column_name = 'gamma_first_name'
+            AND comparison_vector_value = 1
+        """
     )
 
-    for r in compare.to_dict(orient="records"):
-        assert r["m_probability_e"] == pytest.approx(r["m_probability_a"])
+    actual_m_u_history = db_api.register(
+        list(map(lambda r: r.as_dict(), training_session._iteration_history_records))
+    )
+    actual_first_name_level_1_m = actual_m_u_history.query_sql(
+        """
+            SELECT *
+            FROM {this}
+            WHERE comparison_name = 'first_name'
+            AND comparison_vector_value = 1
+        """
+    )
+
+    actuals = sorted(
+        actual_first_name_level_1_m.as_record_dict(), key=lambda r: r["iteration"]
+    )
+    expecteds = sorted(
+        expected_first_name_level_1_m.as_record_dict(), key=lambda r: r["iteration"]
+    )
+
+    for expected, actual in zip(expecteds, actuals):
+        assert actual["m_probability"] == pytest.approx(expected["m_probability"])
 
 
 def test_lambda():
@@ -191,29 +172,19 @@ def test_lambda():
 
     settings_dict["probability_two_random_records_match"] = glo
 
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-
     db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register_from_csv(
+        "./tests/datasets/fake_1000_from_splink_demos.csv"
+    )
 
     linker = Linker(df_sdf, settings_dict)
 
-    ma = linker.inference.predict().as_pandas_dataframe()
-    f1 = ma["unique_id_l"] == 924
-    f2 = ma["unique_id_r"] == 925
-    ma[f1 & f2]
-    # actual_record
-    ma["match_probability"].mean()
-    training_session = (
+    _ma = linker.inference.predict()
+    _training_session = (
         linker.training.estimate_parameters_using_expectation_maximisation(
             "l.dob = r.dob", fix_u_probabilities=False
         )
     )
-    pd.DataFrame(training_session._lambda_history_records)
-
-    # linker._settings_obj.match_weights_chart()
-    # actual_prop_history
-
     #########
 
     bf_for_first_name = (
@@ -241,7 +212,7 @@ def test_lambda():
 
     linker._settings_obj._probability_two_random_records_match = glo
 
-    training_session = (
+    _training_session = (
         linker.training.estimate_parameters_using_expectation_maximisation(
             "l.first_name = r.first_name and l.surname = r.surname",
             fix_u_probabilities=False,

--- a/tests/test_correctness_of_convergence.py
+++ b/tests/test_correctness_of_convergence.py
@@ -33,9 +33,7 @@
 
 import re
 
-import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
 
 import splink.comparison_library as cl
 from splink import DuckDBAPI, Linker, SettingsCreator
@@ -47,7 +45,6 @@ from splink.internals.predict import predict_from_comparison_vectors_sqls_using_
 
 
 def test_splink_converges_to_known_params():
-    df = pd.read_csv("./tests/datasets/known_params_comparison_vectors.csv")
     rec = [
         {
             "unique_id": 1,
@@ -57,8 +54,6 @@ def test_splink_converges_to_known_params():
             "true_match": 1,
         },
     ]
-    in_df = pd.DataFrame(rec)
-
     settings = SettingsCreator(
         link_type="dedupe_only",
         comparisons=[
@@ -75,7 +70,7 @@ def test_splink_converges_to_known_params():
     )
 
     db_api = DuckDBAPI()
-    in_df_sdf = db_api.register(in_df)
+    in_df_sdf = db_api.register(rec)
 
     linker = Linker(in_df_sdf, settings)
 
@@ -106,8 +101,19 @@ def test_splink_converges_to_known_params():
 
         cvv_hashed_tablename = re.search(pattern, str(e)).group()
 
-    cvv_table = db_api._create_backend_table(df, cvv_hashed_tablename)
-    cvv_table.templated_name = "__splink__df_comparison_vectors"
+    cvv_raw_table = db_api.register_from_csv(
+        "./tests/datasets/known_params_comparison_vectors.csv"
+    )
+    # need to create a backend-level alias
+    db_api._con.execute(
+        f"""
+            CREATE VIEW {cvv_hashed_tablename} AS
+            SELECT * FROM {cvv_raw_table.physical_name}
+        """
+    )
+    cvv_table = db_api.table_to_splink_dataframe(
+        "__splink__df_comparison_vectors", cvv_hashed_tablename
+    )
 
     core_model_settings = em_training_session._train(cvv_table)
     linker._settings_obj.core_model_settings = core_model_settings
@@ -130,18 +136,14 @@ def test_splink_converges_to_known_params():
     pipeline.enqueue_list_of_sqls(sqls)
 
     predictions = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
-    predictions_df = predictions.as_pandas_dataframe()
+    predictions_df = predictions.as_dict()
 
-    assert_series_equal(
-        predictions_df["match_probability"],
-        predictions_df["true_match_probability_l"],
-        check_exact=False,
-        rtol=0.01,
-        check_names=False,
+    assert predictions_df["match_probability"] == pytest.approx(
+        predictions_df["true_match_probability_l"], rel=0.01
     )
 
     s_obj = linker._settings_obj
-    assert s_obj._probability_two_random_records_match == pytest.approx(0.5, 0.01)
+    assert s_obj._probability_two_random_records_match == pytest.approx(0.5, rel=0.01)
 
     param_dict = s_obj.comparisons[0].as_dict()
     cls = param_dict["comparison_levels"]


### PR DESCRIPTION
Register a table directly from a csv. To help with testing, but also useful for small dummy situations.

Part of the work to depandas the test suite.

Branches from #3080.