### PR TITLE
Depandas modes of operation tests

### DIFF
--- a/tests/test_compare_two_records.py
+++ b/tests/test_compare_two_records.py
@@ -1,7 +1,5 @@
 import datetime
 
-import numpy as np
-import pandas as pd
 import pytest
 
 import splink.internals.comparison_library as cl
@@ -12,15 +10,11 @@ from .decorator import mark_with_dialects_excluding
 
 
 @mark_with_dialects_excluding("sqlite")
-def test_compare_two_records_1(test_helpers, dialect):
+def test_compare_two_records_1(test_helpers, dialect, fake_1000):
     # This one tests the following cases
     # - User provides a city tf tble
     # - But first_name tf table derived from input data
     helper = test_helpers[dialect]
-
-    df = helper.load_frame_from_parquet(
-        "./tests/datasets/fake_1000_from_splink_demos_strip_datetypes.parquet"
-    )
 
     settings = SettingsCreator(
         link_type="dedupe_only",
@@ -40,19 +34,20 @@ def test_compare_two_records_1(test_helpers, dialect):
         retain_matching_columns=True,
     )
 
-    linker = helper.linker_with_registration(df, settings)
+    linker = helper.linker_with_registration(fake_1000, settings)
+    # linker._debug_mode = True
 
-    city_tf = pd.DataFrame(
-        [
-            {"city": "London", "tf_city": 0.2},
-            {"city": "Liverpool", "tf_city": 0.8},
-        ]
-    )
+    city_tf = [
+        {"city": "London", "tf_city": 0.2},
+        {"city": "Liverpool", "tf_city": 0.8},
+    ]
+
     linker.table_management.register_term_frequency_lookup(city_tf, "city")
 
     # Test with dictionary inputs
+    # need to include spaces in first name as that is how they appear in csv file
     r1 = {
-        "first_name": "Julia",
+        "first_name": "Julia ",
         "surname": "Taylor",
         "dob": datetime.date(2015, 10, 29),
         "city": "London",
@@ -60,7 +55,7 @@ def test_compare_two_records_1(test_helpers, dialect):
     }
 
     r2 = {
-        "first_name": "Julia",
+        "first_name": "Julia ",
         "surname": "Taylor",
         "dob": datetime.date(2015, 10, 29),
         "city": "London",
@@ -68,31 +63,24 @@ def test_compare_two_records_1(test_helpers, dialect):
     }
 
     res = linker.inference.compare_two_records(r1, r2)
-    res_pd = res.as_pandas_dataframe()
+    res_dict = res.as_dict()
 
     # Verify term frequencies match in the comparison result
-    assert res_pd["tf_city_l"].iloc[0] == 0.2
-    assert res_pd["tf_city_r"].iloc[0] == 0.2
+    assert res_dict["tf_city_l"][0] == 0.2
+    assert res_dict["tf_city_r"][0] == 0.2
     # This is the tf value as derived from the input data
-    assert pytest.approx(res_pd["tf_first_name_l"].iloc[0]) == np.float64(
-        0.00444444444444
-    )
-    assert pytest.approx(res_pd["tf_first_name_r"].iloc[0]) == np.float64(
-        0.00444444444444
-    )
+    assert pytest.approx(res_dict["tf_first_name_l"][0]) == 0.00444444444444
+
+    assert pytest.approx(res_dict["tf_first_name_r"][0]) == 0.00444444444444
 
 
 @mark_with_dialects_excluding("sqlite")
-def test_compare_two_records_2(test_helpers, dialect):
+def test_compare_two_records_2(test_helpers, dialect, fake_1000):
     # This one tests the following cases
     # - User provides a city and first_name tf tables
     # - But specific values provided in input data, which take precedence
 
     helper = test_helpers[dialect]
-
-    df = helper.load_frame_from_parquet(
-        "./tests/datasets/fake_1000_from_splink_demos_strip_datetypes.parquet"
-    )
 
     settings = SettingsCreator(
         link_type="dedupe_only",
@@ -112,22 +100,18 @@ def test_compare_two_records_2(test_helpers, dialect):
         retain_matching_columns=True,
     )
 
-    linker = helper.linker_with_registration(df, settings)
+    linker = helper.linker_with_registration(fake_1000, settings)
 
-    city_tf = pd.DataFrame(
-        [
-            {"city": "London", "tf_city": 0.2},
-            {"city": "Liverpool", "tf_city": 0.8},
-        ]
-    )
+    city_tf = [
+        {"city": "London", "tf_city": 0.2},
+        {"city": "Liverpool", "tf_city": 0.8},
+    ]
     linker.table_management.register_term_frequency_lookup(city_tf, "city")
 
-    first_name_tf = pd.DataFrame(
-        [
-            {"first_name": "Julia", "tf_first_name": 0.3},
-            {"first_name": "Robert", "tf_first_name": 0.8},
-        ]
-    )
+    first_name_tf = [
+        {"first_name": "Julia", "tf_first_name": 0.3},
+        {"first_name": "Robert", "tf_first_name": 0.8},
+    ]
     linker.table_management.register_term_frequency_lookup(first_name_tf, "first_name")
 
     # Test with dictionary inputs
@@ -150,10 +134,10 @@ def test_compare_two_records_2(test_helpers, dialect):
     }
 
     res = linker.inference.compare_two_records(r1, r2)
-    res_pd = res.as_pandas_dataframe()
+    res_dict = res.as_dict()
 
     # Verify term frequencies match in the comparison result
-    assert res_pd["tf_city_l"].iloc[0] == 0.5
-    assert res_pd["tf_city_r"].iloc[0] == 0.2
-    assert res_pd["tf_first_name_l"].iloc[0] == 0.3
-    assert res_pd["tf_first_name_r"].iloc[0] == 0.4
+    assert res_dict["tf_city_l"][0] == 0.5
+    assert res_dict["tf_city_r"][0] == 0.2
+    assert res_dict["tf_first_name_l"][0] == 0.3
+    assert res_dict["tf_first_name_r"][0] == 0.4

--- a/tests/test_compound_comparison_levels.py
+++ b/tests/test_compound_comparison_levels.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 import splink.internals.comparison_level_library as cll
 import splink.internals.comparison_library as cl
 from splink.internals.duckdb.database_api import DuckDBAPI
@@ -7,66 +5,64 @@ from splink.internals.linker import Linker
 
 
 def test_compound_comparison_level():
-    df = pd.DataFrame(
-        [
-            {
-                "unique_id": 1,
-                "first_name": "John",
-                "middle_name": "James",
-                "surname": "Smith",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 2,
-                "first_name": "Mary",
-                "middle_name": "Harriet",
-                "surname": "Jones",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 3,
-                "first_name": "Jane",
-                "middle_name": "Joan",
-                "surname": "Taylor",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 4,
-                "first_name": "John",
-                "middle_name": "Blake",
-                "surname": "Jones",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 5,
-                "first_name": "Jane",
-                "middle_name": "Joan",
-                "surname": "Taylor",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 6,
-                "first_name": "Gill",
-                "middle_name": "Harriet",
-                "surname": "Greene",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 7,
-                "first_name": "Owen",
-                "middle_name": "James",
-                "surname": "Smith",
-                "city": "Brighton",
-            },
-            {
-                "unique_id": 8,
-                "first_name": "Sarah",
-                "middle_name": "Simone",
-                "surname": "Williams",
-                "city": "Brighton",
-            },
-        ]
-    )
+    data = [
+        {
+            "unique_id": 1,
+            "first_name": "John",
+            "middle_name": "James",
+            "surname": "Smith",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 2,
+            "first_name": "Mary",
+            "middle_name": "Harriet",
+            "surname": "Jones",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 3,
+            "first_name": "Jane",
+            "middle_name": "Joan",
+            "surname": "Taylor",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 4,
+            "first_name": "John",
+            "middle_name": "Blake",
+            "surname": "Jones",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 5,
+            "first_name": "Jane",
+            "middle_name": "Joan",
+            "surname": "Taylor",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 6,
+            "first_name": "Gill",
+            "middle_name": "Harriet",
+            "surname": "Greene",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 7,
+            "first_name": "Owen",
+            "middle_name": "James",
+            "surname": "Smith",
+            "city": "Brighton",
+        },
+        {
+            "unique_id": 8,
+            "first_name": "Sarah",
+            "middle_name": "Simone",
+            "surname": "Williams",
+            "city": "Brighton",
+        },
+    ]
 
     def col_is_match(col):
         return f"({col}_l = {col}_r)"
@@ -119,7 +115,7 @@ def test_compound_comparison_level():
     }
 
     db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register(data)
 
     linker = Linker(df_sdf, settings)
     all_cols_match_level = linker._settings_obj.comparisons[1].comparison_levels[1]
@@ -137,50 +133,48 @@ def test_compound_comparison_level():
 
 def test_complex_compound_comparison_level():
     # non-realistic example
-    df = pd.DataFrame(
-        [
-            {
-                "unique_id": 1,
-                "col_1": "a",
-                "col_2": "b",
-                "col_3": "c",
-                "col_4": "d",
-                "col_5": "e",
-                "col_6": "f",
-                "col_7": "g",
-            },
-            {
-                "unique_id": 2,
-                "col_1": "aa",
-                "col_2": "b",
-                "col_3": "cc",
-                "col_4": "d",
-                "col_5": "ee",
-                "col_6": "f",
-                "col_7": "gg",
-            },
-            {
-                "unique_id": 3,
-                "col_1": "a",
-                "col_2": "bb",
-                "col_3": "c",
-                "col_4": "dd",
-                "col_5": "e",
-                "col_6": "ff",
-                "col_7": "g",
-            },
-            {
-                "unique_id": 4,
-                "col_1": "aa",
-                "col_2": "bb",
-                "col_3": "cc",
-                "col_4": "d",
-                "col_5": "ee",
-                "col_6": "ff",
-                "col_7": "gg",
-            },
-        ]
-    )
+    data = [
+        {
+            "unique_id": 1,
+            "col_1": "a",
+            "col_2": "b",
+            "col_3": "c",
+            "col_4": "d",
+            "col_5": "e",
+            "col_6": "f",
+            "col_7": "g",
+        },
+        {
+            "unique_id": 2,
+            "col_1": "aa",
+            "col_2": "b",
+            "col_3": "cc",
+            "col_4": "d",
+            "col_5": "ee",
+            "col_6": "f",
+            "col_7": "gg",
+        },
+        {
+            "unique_id": 3,
+            "col_1": "a",
+            "col_2": "bb",
+            "col_3": "c",
+            "col_4": "dd",
+            "col_5": "e",
+            "col_6": "ff",
+            "col_7": "g",
+        },
+        {
+            "unique_id": 4,
+            "col_1": "aa",
+            "col_2": "bb",
+            "col_3": "cc",
+            "col_4": "d",
+            "col_5": "ee",
+            "col_6": "ff",
+            "col_7": "gg",
+        },
+    ]
     A, B, C, D, E, F, G = (
         "col_1_l = col_1_r",
         "col_2_l = col_2_r",
@@ -218,7 +212,7 @@ def test_complex_compound_comparison_level():
         ],
     }
     db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register(data)
 
     linker = Linker(df_sdf, settings)
 

--- a/tests/test_full_example_deterministic_link.py
+++ b/tests/test_full_example_deterministic_link.py
@@ -1,7 +1,5 @@
 import os
 
-import pandas as pd
-
 from splink.blocking_analysis import (
     cumulative_comparisons_to_be_scored_from_blocking_rules_chart,
 )
@@ -10,9 +8,8 @@ from .decorator import mark_with_dialects_excluding
 
 
 @mark_with_dialects_excluding()
-def test_deterministic_link_full_example(dialect, tmp_path, test_helpers):
+def test_deterministic_link_full_example(fake_1000, dialect, tmp_path, test_helpers):
     helper = test_helpers[dialect]
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     br_for_predict = [
         "l.first_name = r.first_name and l.surname = r.surname and l.dob = r.dob",
@@ -27,7 +24,7 @@ def test_deterministic_link_full_example(dialect, tmp_path, test_helpers):
         "retain_intermediate_calculation_columns": True,
     }
     helper_db_api = helper.db_api()
-    df_sdf = helper_db_api.register(df)
+    df_sdf = helper_db_api.register(fake_1000)
 
     cumulative_comparisons_to_be_scored_from_blocking_rules_chart(
         df_sdf,
@@ -36,7 +33,7 @@ def test_deterministic_link_full_example(dialect, tmp_path, test_helpers):
         unique_id_column_name="unique_id",
     )
 
-    linker = helper.linker_with_registration(df, settings)
+    linker = helper.linker_with_registration(fake_1000, settings)
 
     df_predict = linker.inference.deterministic_link()
 

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -1,25 +1,19 @@
 import os
 
 import duckdb
-import pandas as pd
 import pyarrow as pa
-import pyarrow.csv as pa_csv
+import pyarrow.csv as pv
 import pyarrow.parquet as pq
 import pytest
 
 import splink.internals.comparison_level_library as cll
 import splink.internals.comparison_library as cl
-from splink import DuckDBAPI, Linker, SettingsCreator, block_on
+from splink import ColumnExpression, DuckDBAPI, Linker, SettingsCreator, block_on
 from splink.blocking_analysis import count_comparisons_from_blocking_rule
 from splink.exploratory import completeness_chart, profile_columns
 
 from .basic_settings import get_settings_dict, name_comparison
 from .decorator import mark_with_dialects_including
-from .linker_utils import (
-    _test_table_registration,
-    _test_write_functionality,
-    register_roc_data,
-)
 
 simple_settings = {
     "link_type": "dedupe_only",
@@ -27,9 +21,8 @@ simple_settings = {
 
 
 @mark_with_dialects_including("duckdb")
-def test_full_example_duckdb(tmp_path):
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df = df.rename(columns={"surname": "SUR name"})
+def test_full_example_duckdb(tmp_path, fake_1000):
+    df = fake_1000.rename_columns({"surname": "SUR name"})
     settings_dict = get_settings_dict()
 
     # Overwrite the surname comparison to include duck-db specific syntax
@@ -87,13 +80,27 @@ def test_full_example_duckdb(tmp_path):
         df_predict, os.path.join(tmp_path, "test_scv_duckdb.html"), True, 2
     )
 
-    df_e = df_predict.as_pandas_dataframe(limit=5)
-    records = df_e.to_dict(orient="records")
+    records = df_predict.as_record_dict(limit=5)
     linker.visualisations.waterfall_chart(records)
 
-    register_roc_data(linker)
-
-    linker.evaluation.accuracy_analysis_from_labels_table("labels")
+    labels_sdf = df_sdf.query_sql(
+        """
+        WITH first_10 AS (
+            SELECT * FROM {this} LIMIT 10
+        )
+        SELECT
+            l.unique_id AS unique_id_l,
+            r.unique_id AS unique_id_r,
+            CAST(l.cluster = r.cluster AS float) AS clerical_match_score
+        FROM
+            first_10 l
+        CROSS JOIN
+            first_10 r
+        WHERE
+            unique_id_l < unique_id_r
+        """
+    )
+    linker.evaluation.accuracy_analysis_from_labels_table(labels_sdf.physical_name)
 
     df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
         df_predict, 0.1
@@ -107,8 +114,6 @@ def test_full_example_duckdb(tmp_path):
     )
 
     linker.evaluation.unlinkables_chart(name_of_data_in_title="Testing")
-
-    _test_table_registration(linker)
 
     record = {
         "unique_id": 1,
@@ -130,21 +135,19 @@ def test_full_example_duckdb(tmp_path):
 
     db_api = DuckDBAPI()
     df_sdf2 = db_api.register(df)
-    linker_2 = Linker(df_sdf2, settings=simple_settings)
+    Linker(df_sdf2, settings=simple_settings)
 
-    linker_2 = Linker(df_sdf2, settings=path)
-
-    # Test that writing to files works as expected
-    _test_write_functionality(linker_2, pd.read_csv)
+    Linker(df_sdf2, settings=path)
 
 
 # Create some dummy dataframes for the link only test
-df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-df_l = df.copy()
-df_r = df.copy()
-df_l["source_dataset"] = "my_left_ds"
-df_r["source_dataset"] = "my_right_ds"
-df_final = pd.concat([df_l, df_r])
+df = pv.read_csv(
+    "./tests/datasets/fake_1000_from_splink_demos.csv",
+    convert_options=pv.ConvertOptions(strings_can_be_null=True),
+)
+df_l = df.append_column("source_dataset", pa.array(1000 * ["my_left_ds"]))
+df_r = df.append_column("source_dataset", pa.array(1000 * ["my_right_ds"]))
+df_final = pa.concat_tables([df_l, df_r])
 
 
 # Tests link only jobs under different inputs:
@@ -187,61 +190,12 @@ def test_link_only(input, source_l, source_r):
         input_sdf = db_api.register(input)
 
     linker = Linker(input_sdf, settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    sdf_predict = linker.inference.predict()
+    predict_dict = sdf_predict.as_dict()
 
-    assert len(df_predict) == 7257
-    assert set(df_predict.source_dataset_l.values) == source_l
-    assert set(df_predict.source_dataset_r.values) == source_r
-
-
-@pytest.mark.parametrize(
-    ("df"),
-    [
-        pytest.param(
-            pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv"),
-            id="DuckDB link from pandas df",
-        ),
-        pytest.param(
-            pa.Table.from_pandas(
-                pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-            ),
-            id="DuckDB link - convert pandas to pyarrow df",
-        ),
-        pytest.param(
-            pa_csv.read_csv(
-                "./tests/datasets/fake_1000_from_splink_demos.csv",
-                convert_options=pa_csv.ConvertOptions(
-                    strings_can_be_null=True, null_values=["", "", "NULL"]
-                ),
-            ),
-            id="DuckDB link - read directly from filepath with pyarrow",
-        ),
-    ],
-)
-@mark_with_dialects_including("duckdb")
-def test_duckdb_load_different_tablish_types(df):
-    settings = get_settings_dict()
-
-    db_api = DuckDBAPI()
-    df_sdf = db_api.register(df)
-    linker = Linker(
-        df_sdf,
-        settings,
-    )
-
-    assert len(linker.inference.predict().as_pandas_dataframe()) == 3167
-
-    settings["link_type"] = "link_only"
-
-    db_api = DuckDBAPI()
-    df_sdf1 = db_api.register(df, source_dataset_name="testing1")
-    df_sdf2 = db_api.register(df, source_dataset_name="testing2")
-    linker = Linker(
-        [df_sdf1, df_sdf2],
-        settings,
-    )
-
-    assert len(linker.inference.predict().as_pandas_dataframe()) == 7257
+    assert len(sdf_predict.as_record_dict()) == 7257
+    assert set(predict_dict["source_dataset_l"]) == source_l
+    assert set(predict_dict["source_dataset_r"]) == source_r
 
 
 @mark_with_dialects_including("duckdb")
@@ -271,14 +225,21 @@ def test_duckdb_arrow_array():
             "blocking_rules_to_generate_predictions": ["l.a[1] = r.a[1]"],
         },
     )
-    df = linker.inference.deterministic_link().as_pandas_dataframe()
+    df = linker.inference.deterministic_link().as_record_dict()
     assert len(df) == 2
 
 
 @mark_with_dialects_including("duckdb")
-def test_small_example_duckdb(tmp_path):
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df["full_name"] = df["first_name"] + df["surname"]
+def test_small_example_duckdb(fake_1000):
+    df = fake_1000.append_column(
+        "full_name",
+        pa.array(
+            [
+                f"{fn}_{sn}"
+                for fn, sn in zip(fake_1000["first_name"], fake_1000["surname"])
+            ]
+        ),
+    )
 
     settings_dict = {
         "link_type": "dedupe_only",
@@ -299,9 +260,9 @@ def test_small_example_duckdb(tmp_path):
                     cll.ElseLevel(),
                 ],
             },
-            cl.DamerauLevenshteinAtThresholds("dob", 2).configure(
-                term_frequency_adjustments=True
-            ),
+            cl.DamerauLevenshteinAtThresholds(
+                ColumnExpression("dob").cast_to_string(), 2
+            ).configure(term_frequency_adjustments=True),
             cl.JaroAtThresholds("email", 0.9).configure(
                 term_frequency_adjustments=True
             ),
@@ -328,9 +289,8 @@ def test_small_example_duckdb(tmp_path):
 
 
 @mark_with_dialects_including("duckdb")
-def test_duckdb_input_is_duckdbpyrelation():
+def test_duckdb_input_is_duckdbpyrelation(fake_1000):
     df1 = duckdb.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-    df2 = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     settings = SettingsCreator(
         link_type="link_and_dedupe",
@@ -339,6 +299,6 @@ def test_duckdb_input_is_duckdbpyrelation():
     )
     db_api = DuckDBAPI(connection=":default:")
     df1_sdf = db_api.register(df1)
-    df2_sdf = db_api.register(df2)
+    df2_sdf = db_api.register(fake_1000)
     linker = Linker([df1_sdf, df2_sdf], settings)
     linker.inference.predict()

--- a/tests/test_full_example_postgres.py
+++ b/tests/test_full_example_postgres.py
@@ -4,8 +4,7 @@ pytest.importorskip("sqlalchemy")
 # ruff: noqa: E402 (module level import not at top of file)
 
 import os
-
-import pandas as pd
+from datetime import datetime
 
 from splink.blocking_analysis import (
     count_comparisons_from_blocking_rule,
@@ -17,16 +16,14 @@ from splink.internals.postgres.database_api import PostgresAPI
 
 from .basic_settings import get_settings_dict
 from .decorator import mark_with_dialects_including
-from .linker_utils import _test_table_registration, register_roc_data
 
 
 @mark_with_dialects_including("postgres")
-def test_full_example_postgres(tmp_path, pg_engine):
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+def test_full_example_postgres(tmp_path, pg_engine, fake_1000):
     settings_dict = get_settings_dict()
 
     db_api = PostgresAPI(engine=pg_engine)
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register(fake_1000)
 
     linker = Linker(
         df_sdf,
@@ -83,13 +80,30 @@ def test_full_example_postgres(tmp_path, pg_engine):
         df_predict, os.path.join(tmp_path, "test_scv_postgres.html"), True, 2
     )
 
-    df_e = df_predict.as_pandas_dataframe(limit=5)
-    records = df_e.to_dict(orient="records")
+    records = df_predict.as_record_dict()
     linker.visualisations.waterfall_chart(records)
 
-    register_roc_data(linker)
-
-    linker.evaluation.accuracy_analysis_from_labels_table("labels")
+    labels_sdf = df_sdf.query_sql(
+        """
+        WITH first_10 AS (
+            SELECT * FROM {this} LIMIT 10
+        )
+        SELECT
+            l.unique_id AS unique_id_l,
+            r.unique_id AS unique_id_r,
+            CASE
+                WHEN l.cluster = r.cluster THEN 1.0
+                ELSE 0.0
+            END AS clerical_match_score
+        FROM
+            first_10 AS l
+        CROSS JOIN
+            first_10 AS r
+        WHERE
+            l.unique_id < r.unique_id
+        """
+    )
+    linker.evaluation.accuracy_analysis_from_labels_table(labels_sdf.physical_name)
 
     df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
         df_predict, 0.1
@@ -104,13 +118,11 @@ def test_full_example_postgres(tmp_path, pg_engine):
 
     linker.evaluation.unlinkables_chart(name_of_data_in_title="Testing")
 
-    _test_table_registration(linker)
-
     record = {
         "unique_id": 1,
         "first_name": "John",
         "surname": "Smith",
-        "dob": "1971-05-24",
+        "dob": datetime(1971, 5, 24),
         "city": "London",
         "email": "john@smith.net",
         "cluster": 10000,
@@ -128,11 +140,10 @@ def test_full_example_postgres(tmp_path, pg_engine):
 
 
 @mark_with_dialects_including("postgres")
-def test_postgres_use_existing_table(tmp_path, pg_engine):
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-
+def test_postgres_use_existing_table(fake_1000, pg_engine):
+    db_api = PostgresAPI(engine=pg_engine)
     table_name = "input_table_test"
-    df.to_sql(table_name, pg_engine)
+    db_api.register(fake_1000, table_name)
 
     settings_dict = get_settings_dict()
 

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -5,7 +5,6 @@ pytest.importorskip("pyspark")
 
 import os
 
-import pandas as pd
 import pyspark.sql.functions as f
 from pyspark.sql.types import StringType, StructField, StructType
 
@@ -17,7 +16,6 @@ from splink.internals.spark.database_api import SparkAPI
 
 from .basic_settings import get_settings_dict, name_comparison
 from .decorator import mark_with_dialects_including
-from .linker_utils import _test_write_functionality, register_roc_data
 
 
 @mark_with_dialects_including("spark")
@@ -38,12 +36,6 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api, break_lineage_
     # accept arrays as inputs, which we are adding to df_spark below
     df_spark_sdf = spark_api.register(df_spark)
     linker = Linker(df_spark_sdf, get_settings_dict())
-
-    # Test that writing to files works as expected
-    def spark_csv_read(x):
-        return linker._db_api.spark.read.csv(x, header=True).toPandas()
-
-    _test_write_functionality(linker, spark_csv_read)
 
     # Convert a column to an array to enable testing intersection
     df_spark = df_spark.withColumn("email", f.array("email"))
@@ -141,9 +133,27 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api, break_lineage_
             StructField("lastname", StringType(), True),
         ]
     )
-    register_roc_data(linker)
 
-    linker.evaluation.accuracy_analysis_from_labels_table("labels")
+    # make a labels table
+    labels_sdf = df_spark_sdf_2.query_sql(
+        """
+        WITH first_10 AS (
+            SELECT * FROM {this} LIMIT 10
+        )
+        SELECT
+            l.unique_id AS unique_id_l,
+            r.unique_id AS unique_id_r,
+            CAST(l.cluster = r.cluster AS float) AS clerical_match_score
+        FROM
+            first_10 l
+        JOIN
+            first_10 r
+        WHERE
+            l.unique_id < r.unique_id
+        """
+    )
+
+    linker.evaluation.accuracy_analysis_from_labels_table(labels_sdf.physical_name)
 
     record = {
         "unique_id": 1,
@@ -168,8 +178,8 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api, break_lineage_
         num_partitions_on_repartition=2,
     )
     df_spark_sdf_3 = spark_api_3.register(df_spark)
-    df_pandas_sdf_3 = spark_api_3.register(df_spark.toPandas())
-    linker = Linker([df_spark_sdf_3, df_pandas_sdf_3], settings)
+    df_spark_sdf_3_alt = spark_api_3.register(df_spark)
+    linker = Linker([df_spark_sdf_3, df_spark_sdf_3_alt], settings)
 
     # Test saving and loading
     path = os.path.join(tmp_path, "model.json")
@@ -180,7 +190,7 @@ def test_full_example_spark(spark, df_spark, tmp_path, spark_api, break_lineage_
 
 
 @mark_with_dialects_including("spark")
-def test_link_only(spark, df_spark, spark_api):
+def test_link_only(spark, df_spark):
     settings = get_settings_dict()
     settings["link_type"] = "link_only"
     settings["source_dataset_column_name"] = "source_dataset"
@@ -196,27 +206,23 @@ def test_link_only(spark, df_spark, spark_api):
     df_spark_a_sdf = spark_api_link.register(df_spark_a)
     df_spark_b_sdf = spark_api_link.register(df_spark_b)
     linker = Linker([df_spark_a_sdf, df_spark_b_sdf], settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    sdf_predict = linker.inference.predict()
+    predict_dict = sdf_predict.as_dict()
 
-    assert len(df_predict) == 7257
-    assert set(df_predict.source_dataset_l.values) == {"my_left_ds"}
-    assert set(df_predict.source_dataset_r.values) == {"my_right_ds"}
+    assert len(sdf_predict.as_record_dict()) == 7257
+    assert set(predict_dict["source_dataset_l"]) == {"my_left_ds"}
+    assert set(predict_dict["source_dataset_r"]) == {"my_right_ds"}
 
 
-@pytest.mark.parametrize(
-    ("df"),
-    [
-        pytest.param(
-            pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv"),
-            id="Spark load from pandas df",
-        )
-    ],
-)
+@pytest.mark.needs_pandas
 @mark_with_dialects_including("spark")
-def test_spark_load_from_file(df, spark, spark_api):
+def test_spark_load_from_pandas(df, spark_api):
+    import pandas as pd
+
+    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     settings = get_settings_dict()
 
     df_sdf = spark_api.register(df)
     linker = Linker(df_sdf, settings)
 
-    assert len(linker.inference.predict().as_pandas_dataframe()) == 3167
+    assert len(linker.inference.predict().as_record_dict()) == 3167

--- a/tests/test_full_example_spark.py
+++ b/tests/test_full_example_spark.py
@@ -216,7 +216,7 @@ def test_link_only(spark, df_spark):
 
 @pytest.mark.needs_pandas
 @mark_with_dialects_including("spark")
-def test_spark_load_from_pandas(df, spark_api):
+def test_spark_load_from_pandas(spark_api):
     import pandas as pd
 
     df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -64,6 +64,8 @@ def test_full_example_sqlite(tmp_path, fake_1000):
             first_10 l
         JOIN
             first_10 r
+        WHERE
+            unique_id_l < unique_id_r
         """
     )
 

--- a/tests/test_full_example_sqlite.py
+++ b/tests/test_full_example_sqlite.py
@@ -2,27 +2,22 @@ import os
 import sqlite3
 from math import sqrt
 
-import pandas as pd
-
 from splink.exploratory import profile_columns
 from splink.internals.linker import Linker
 from splink.internals.sqlite.database_api import SQLiteAPI
 
 from .basic_settings import get_settings_dict
 from .decorator import mark_with_dialects_including
-from .linker_utils import _test_table_registration, register_roc_data
 
 
 @mark_with_dialects_including("sqlite")
-def test_full_example_sqlite(tmp_path):
+def test_full_example_sqlite(tmp_path, fake_1000):
     con = sqlite3.connect(":memory:")
     con.create_function("sqrt", 1, sqrt)
 
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-
     settings_dict = get_settings_dict()
     db_api = SQLiteAPI(con)
-    df_sdf = db_api.register(df, source_dataset_name="fake_data_1")
+    df_sdf = db_api.register(fake_1000, source_dataset_name="fake_data_1")
     linker = Linker(
         df_sdf,
         settings_dict,
@@ -55,25 +50,37 @@ def test_full_example_sqlite(tmp_path):
 
     linker.evaluation.unlinkables_chart(name_of_data_in_title="Testing")
 
-    _test_table_registration(linker)
+    # make a labels table
+    labels_sdf = df_sdf.query_sql(
+        """
+        WITH first_10 AS (
+            SELECT * FROM {this} LIMIT 10
+        )
+        SELECT
+            l.unique_id AS unique_id_l,
+            r.unique_id AS unique_id_r,
+            CAST(l.cluster = r.cluster AS float) AS clerical_match_score
+        FROM
+            first_10 l
+        JOIN
+            first_10 r
+        """
+    )
 
-    register_roc_data(linker)
-
-    linker.evaluation.accuracy_analysis_from_labels_table("labels")
+    linker.evaluation.accuracy_analysis_from_labels_table(labels_sdf.physical_name)
 
 
 @mark_with_dialects_including("sqlite")
-def test_small_link_example_sqlite():
+def test_small_link_example_sqlite(fake_1000):
     con = sqlite3.connect(":memory:")
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
 
     settings_dict = get_settings_dict()
 
     settings_dict["link_type"] = "link_only"
 
     db_api = SQLiteAPI(con)
-    df_1_sdf = db_api.register(df, source_dataset_name="fake_data_1")
-    df_2_sdf = db_api.register(df, source_dataset_name="fake_data_2")
+    df_1_sdf = db_api.register(fake_1000, source_dataset_name="fake_data_1")
+    df_2_sdf = db_api.register(fake_1000, source_dataset_name="fake_data_2")
     linker = Linker(
         [df_1_sdf, df_2_sdf],
         settings_dict,
@@ -83,13 +90,11 @@ def test_small_link_example_sqlite():
 
 
 @mark_with_dialects_including("sqlite")
-def test_default_conn_sqlite(tmp_path):
-    df = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-
+def test_default_conn_sqlite(tmp_path, fake_1000):
     settings_dict = get_settings_dict()
 
     db_api = SQLiteAPI()
-    df_sdf = db_api.register(df)
+    df_sdf = db_api.register(fake_1000)
     linker = Linker(df_sdf, settings_dict)
 
     linker.inference.predict()

--- a/tests/test_linker_variants.py
+++ b/tests/test_linker_variants.py
@@ -1,7 +1,5 @@
 from copy import deepcopy
 
-import pandas as pd
-
 from splink.internals.comparison_library import ExactMatch
 from splink.internals.duckdb.database_api import DuckDBAPI
 from splink.internals.linker import Linker
@@ -22,6 +20,7 @@ settings_template = {
     "retain_intermediate_calculation_columns": True,
 }
 
+dummy_demo_data = {"first_name": "John", "surname": "Smith", "dob": "01/01/1980"}
 data = [
     {"id": 1, "source_ds": "d"},
     {"id": 2, "source_ds": "d"},
@@ -32,16 +31,26 @@ data = [
 ]
 
 
-df = pd.DataFrame(data)
-df["first_name"] = "John"
-df["surname"] = "Smith"
-df["dob"] = "01/01/1980"
+def dropkey(data_dict, key):
+    del data_dict[key]
+    return data_dict
 
-sds_b_only = df.query("source_ds == 'b'").drop(columns=["source_ds"])
 
-sds_c_only = df.query("source_ds == 'c'").drop(columns=["source_ds"])
-
-sds_d_only = df.query("source_ds == 'd'").drop(columns=["source_ds"])
+sds_b_only = [
+    dropkey({**row, **dummy_demo_data}, "source_ds")
+    for row in data
+    if row["source_ds"] == "b"
+]
+sds_c_only = [
+    dropkey({**row, **dummy_demo_data}, "source_ds")
+    for row in data
+    if row["source_ds"] == "c"
+]
+sds_d_only = [
+    dropkey({**row, **dummy_demo_data}, "source_ds")
+    for row in data
+    if row["source_ds"] == "d"
+]
 
 
 def test_dedupe_only_join_condition():
@@ -54,23 +63,18 @@ def test_dedupe_only_join_condition():
         {"id": 6},
     ]
 
-    df = pd.DataFrame(data)
-    df["first_name"] = "John"
-    df["surname"] = "Smith"
-    df["dob"] = "01/01/1980"
-
     settings = deepcopy(settings_template)
     settings["link_type"] = "dedupe_only"
 
     db_api = DuckDBAPI()
-    df_sdf = db_api.register(df.copy())
+    df_sdf = db_api.register([{**row, **dummy_demo_data} for row in data])
     linker = Linker(df_sdf, settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    predict_rows = linker.inference.predict().as_record_dict()
 
-    assert len(df_predict) == (6 * 5) / 2
+    assert len(predict_rows) == (6 * 5) / 2
 
     # Check that the lower ID is always on the left hand side
-    assert all(df_predict["id_l"] < df_predict["id_r"])
+    assert all(row["id_l"] < row["id_r"] for row in predict_rows)
 
 
 def test_link_only_two_join_condition():
@@ -81,18 +85,20 @@ def test_link_only_two_join_condition():
     sds_d_sdf = db_api.register(sds_d_only)
     sds_b_sdf = db_api.register(sds_b_only)
     linker = Linker([sds_d_sdf, sds_b_sdf], settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    predict_rows = linker.inference.predict().as_record_dict()
 
-    assert len(df_predict) == 4
+    assert len(predict_rows) == 4
 
     # Check that the lower ID is always on the left hand side
-    df_predict["id_concat_l"] = (
-        df_predict["source_dataset_l"] + "-__-" + df_predict["id_l"].astype(str)
-    )
-    df_predict["id_concat_r"] = (
-        df_predict["source_dataset_r"] + "-__-" + df_predict["id_r"].astype(str)
-    )
-    assert all(df_predict["id_concat_l"] < df_predict["id_concat_r"])
+    predict_rows = [
+        {
+            **row,
+            "id_concat_l": f"{row['source_dataset_l']}-__-{row['id_l']}",
+            "id_concat_r": f"{row['source_dataset_r']}-__-{row['id_r']}",
+        }
+        for row in predict_rows
+    ]
+    assert all(row["id_concat_l"] < row["id_concat_r"] for row in predict_rows)
 
 
 def test_link_only_three_join_condition():
@@ -104,18 +110,20 @@ def test_link_only_three_join_condition():
     sds_b_sdf = db_api.register(sds_b_only)
     sds_c_sdf = db_api.register(sds_c_only)
     linker = Linker([sds_d_sdf, sds_b_sdf, sds_c_sdf], settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    predict_rows = linker.inference.predict().as_record_dict()
 
-    assert len(df_predict) == 12
+    assert len(predict_rows) == 12
 
     # Check that the lower ID is always on the left hand side
-    df_predict["id_concat_l"] = (
-        df_predict["source_dataset_l"] + "-__-" + df_predict["id_l"].astype(str)
-    )
-    df_predict["id_concat_r"] = (
-        df_predict["source_dataset_r"] + "-__-" + df_predict["id_r"].astype(str)
-    )
-    assert all(df_predict["id_concat_l"] < df_predict["id_concat_r"])
+    predict_rows = [
+        {
+            **row,
+            "id_concat_l": f"{row['source_dataset_l']}-__-{row['id_l']}",
+            "id_concat_r": f"{row['source_dataset_r']}-__-{row['id_r']}",
+        }
+        for row in predict_rows
+    ]
+    assert all(row["id_concat_l"] < row["id_concat_r"] for row in predict_rows)
 
 
 def test_link_and_dedupe_two_join_condition():
@@ -126,18 +134,20 @@ def test_link_and_dedupe_two_join_condition():
     sds_d_sdf = db_api.register(sds_d_only)
     sds_b_sdf = db_api.register(sds_b_only)
     linker = Linker([sds_d_sdf, sds_b_sdf], settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    predict_rows = linker.inference.predict().as_record_dict()
 
-    assert len(df_predict) == (4 * 3) / 2
+    assert len(predict_rows) == (4 * 3) / 2
 
     # Check that the lower ID is always on the left hand side
-    df_predict["id_concat_l"] = (
-        df_predict["source_dataset_l"] + "-__-" + df_predict["id_l"].astype(str)
-    )
-    df_predict["id_concat_r"] = (
-        df_predict["source_dataset_r"] + "-__-" + df_predict["id_r"].astype(str)
-    )
-    assert all(df_predict["id_concat_l"] < df_predict["id_concat_r"])
+    predict_rows = [
+        {
+            **row,
+            "id_concat_l": f"{row['source_dataset_l']}-__-{row['id_l']}",
+            "id_concat_r": f"{row['source_dataset_r']}-__-{row['id_r']}",
+        }
+        for row in predict_rows
+    ]
+    assert all(row["id_concat_l"] < row["id_concat_r"] for row in predict_rows)
 
 
 def test_link_and_dedupe_three_join_condition():
@@ -149,15 +159,17 @@ def test_link_and_dedupe_three_join_condition():
     sds_b_sdf = db_api.register(sds_b_only)
     sds_c_sdf = db_api.register(sds_c_only)
     linker = Linker([sds_d_sdf, sds_b_sdf, sds_c_sdf], settings)
-    df_predict = linker.inference.predict().as_pandas_dataframe()
+    predict_rows = linker.inference.predict().as_record_dict()
 
-    assert len(df_predict) == (6 * 5) / 2
+    assert len(predict_rows) == (6 * 5) / 2
 
     # Check that the lower ID is always on the left hand side
-    df_predict["id_concat_l"] = (
-        df_predict["source_dataset_l"] + "-__-" + df_predict["id_l"].astype(str)
-    )
-    df_predict["id_concat_r"] = (
-        df_predict["source_dataset_r"] + "-__-" + df_predict["id_r"].astype(str)
-    )
-    assert all(df_predict["id_concat_l"] < df_predict["id_concat_r"])
+    predict_rows = [
+        {
+            **row,
+            "id_concat_l": f"{row['source_dataset_l']}-__-{row['id_l']}",
+            "id_concat_r": f"{row['source_dataset_r']}-__-{row['id_r']}",
+        }
+        for row in predict_rows
+    ]
+    assert all(row["id_concat_l"] < row["id_concat_r"] for row in predict_rows)

--- a/tests/test_postgres_udfs.py
+++ b/tests/test_postgres_udfs.py
@@ -3,10 +3,6 @@ import pytest
 pytest.importorskip("sqlalchemy")
 # ruff: noqa: E402 (module level import not at top of file)
 
-import pandas as pd
-from sqlalchemy.dialects import postgresql
-from sqlalchemy.types import INTEGER
-
 from splink.internals.postgres.database_api import PostgresAPI
 
 from .decorator import mark_with_dialects_including
@@ -15,42 +11,51 @@ from .decorator import mark_with_dialects_including
 @mark_with_dialects_including("postgres")
 def test_log2(pg_engine):
     db_api = PostgresAPI(engine=pg_engine)
-    df = pd.DataFrame({"x": [2, 8, 0.5, 1]})
-    expected_log2_vals = [1, 3, -1, 0]
-    db_api._create_backend_table(df, "log_values")
-    sql = """SELECT log2("x") AS logs FROM log_values"""
-    frame = db_api._execute_sql(sql, "test_log_table").as_pandas_dataframe()
 
-    for log_result, expected in zip(frame["logs"], expected_log2_vals):
-        assert log_result == expected
+    data = [
+        {"x": 8, "expected_log2_value": 3},
+        {"x": 2, "expected_log2_value": 1},
+        {"x": 1, "expected_log2_value": 0},
+        {"x": 0.5, "expected_log2_value": -1},
+    ]
+    log_values = db_api.register(data)
+
+    sql = "SELECT log2(x) AS actual_log2_value, expected_log2_value FROM {this}"
+    result = log_values.query_sql(sql)
+
+    for result_row in result.as_record_dict():
+        assert result_row["actual_log2_value"] == result_row["expected_log2_value"]
 
 
 @mark_with_dialects_including("postgres")
 def test_array_intersect(pg_engine):
     db_api = PostgresAPI(engine=pg_engine)
-    df = pd.DataFrame(
-        [
-            {"arr_l": [1, 2, 3], "arr_r": [1, 5, 6], "expected": [1]},
-            {"arr_l": [1, 2, 3], "arr_r": [10, 1, -2], "expected": [1]},
-            {"arr_l": [1, 2, 3], "arr_r": [4, 5, 6], "expected": []},
-            {"arr_l": [1, 2, 3], "arr_r": [2, 1, 7, 10], "expected": [1, 2]},
-            {"arr_l": [1, 2, 3], "arr_r": [1, 1, 1], "expected": [1]},
-            {"arr_l": [1, 1, 1], "arr_r": [1, 2, 3], "expected": [1]},
-            {"arr_l": [3, 5, 7], "arr_r": [3, 5, 7], "expected": [3, 5, 7]},
-            {"arr_l": [1, 2, 3, 4, 5], "arr_r": [3, 5, 7], "expected": [3, 5]},
-        ]
-    )
-    expected_intersect_vals = df["expected"]
-    df.to_sql(
-        "intersect_vals",
-        pg_engine,
-        dtype={"arr_l": postgresql.ARRAY(INTEGER), "arr_r": postgresql.ARRAY(INTEGER)},
-    )
-    sql = "SELECT array_intersect(arr_l, arr_r) AS intersects FROM intersect_vals"
-    frame = db_api._execute_sql(sql, "test_intersect_table").as_pandas_dataframe()
+    data = [
+        {"arr_l": [1, 2, 3], "arr_r": [1, 5, 6], "expected": [1]},
+        {"arr_l": [1, 2, 3], "arr_r": [10, 1, -2], "expected": [1]},
+        {"arr_l": [1, 2, 3], "arr_r": [4, 5, 6], "expected": []},
+        {"arr_l": [1, 2, 3], "arr_r": [2, 1, 7, 10], "expected": [1, 2]},
+        {"arr_l": [1, 2, 3], "arr_r": [1, 1, 1], "expected": [1]},
+        {"arr_l": [1, 1, 1], "arr_r": [1, 2, 3], "expected": [1]},
+        {"arr_l": [3, 5, 7], "arr_r": [3, 5, 7], "expected": [3, 5, 7]},
+        {"arr_l": [1, 2, 3, 4, 5], "arr_r": [3, 5, 7], "expected": [3, 5]},
+    ]
 
-    for int_result, expected in zip(frame["intersects"], expected_intersect_vals):
+    data_sdf = db_api.register(data)
+    sql = """
+        SELECT
+            array_intersect(arr_l, arr_r) AS actual_intersection,
+            expected AS expected_intersection
+        FROM {this}
+    """
+    result = data_sdf.query_sql(sql)
+
+    for result_row in result.as_record_dict():
         # don't care about order
-        assert set(int_result) == set(expected)
+        assert set(result_row["actual_intersection"]) == set(
+            result_row["expected_intersection"]
+        )
         # should check we don't have duplicates
-        assert len(int_result) == len(expected)
+        assert len(result_row["actual_intersection"]) == len(
+            result_row["expected_intersection"]
+        )

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pandas as pd
 import pytest
 
 import splink.comparison_library as cl
@@ -19,49 +18,43 @@ def test_realtime_cache_two_records(test_helpers, dialect):
 
     db_api = helper.db_api()
 
-    df1 = pd.DataFrame(
-        [
-            {
-                "unique_id": 0,
-                "first_name": "Julia ",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "hannah88@powers.com",
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            }
-        ]
-    )
+    data_1 = [
+        {
+            "unique_id": 0,
+            "first_name": "Julia ",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "hannah88@powers.com",
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        }
+    ]
 
-    df2 = pd.DataFrame(
-        [
-            {
-                "unique_id": 2,
-                "first_name": "Julia ",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "hannah88@powers.com",
-                "cluster": 0,
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-        ]
-    )
+    data_2 = [
+        {
+            "unique_id": 2,
+            "first_name": "Julia ",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "hannah88@powers.com",
+            "cluster": 0,
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+    ]
 
-    df3 = pd.DataFrame(
-        [
-            {
-                "unique_id": 4,
-                "first_name": "Noah",
-                "surname": "Watson",
-                "city": "Bolton",
-                "email": "matthew78@ballard-mcdonald.net",
-                "cluster": 1,
-                "tf_city": 0.01,
-                "tf_first_name": 0.01,
-            },
-        ]
-    )
+    data_3 = [
+        {
+            "unique_id": 4,
+            "first_name": "Noah",
+            "surname": "Watson",
+            "city": "Bolton",
+            "email": "matthew78@ballard-mcdonald.net",
+            "cluster": 1,
+            "tf_city": 0.01,
+            "tf_first_name": 0.01,
+        },
+    ]
 
     settings = SettingsCreator(
         link_type="dedupe_only",
@@ -81,28 +74,28 @@ def test_realtime_cache_two_records(test_helpers, dialect):
     )
 
     res1_2_first = compare_records(
-        df1, df2, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
+        data_1, data_2, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     res1_2_not_from_cache = compare_records(
-        df1, df2, settings, db_api, sql_cache_key=None
+        data_1, data_2, settings, db_api, sql_cache_key=None
     ).as_record_dict()[0]["match_weight"]
 
     res1_2_from_cache = compare_records(
-        df1, df2, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
+        data_1, data_2, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1_2_first == pytest.approx(res1_2_not_from_cache)
     assert res1_2_first == pytest.approx(res1_2_from_cache)
 
     res1_3_first = compare_records(
-        df1, df3, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
+        data_1, data_3, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
     ).as_record_dict()[0]["match_weight"]
     res1_3_not_from_cache = compare_records(
-        df1, df3, settings, db_api, sql_cache_key=None
+        data_1, data_3, settings, db_api, sql_cache_key=None
     ).as_record_dict()[0]["match_weight"]
     res1_3_from_cache = compare_records(
-        df1, df3, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
+        data_1, data_3, settings, db_api, sql_cache_key=f"model_c2r_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1_3_first == pytest.approx(res1_3_not_from_cache)
@@ -119,97 +112,91 @@ def test_realtime_cache_multiple_records(test_helpers, dialect):
     helper = test_helpers[dialect]
     db_api = helper.db_api()
 
-    df1 = pd.DataFrame(
-        [
-            {
-                "unique_id": 0,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "hannah88@powers.com",
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-            {
-                "unique_id": 1,
-                "first_name": "John",
-                "surname": "Smith",
-                "city": "Manchester",
-                "email": "john.smith@email.com",
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-        ]
-    )
+    df1 = [
+        {
+            "unique_id": 0,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "hannah88@powers.com",
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+        {
+            "unique_id": 1,
+            "first_name": "John",
+            "surname": "Smith",
+            "city": "Manchester",
+            "email": "john.smith@email.com",
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+    ]
 
-    df2 = pd.DataFrame(
-        [
-            {
-                "unique_id": 2,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "hannah88@powers.com",
-                "cluster": 0,
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-            {
-                "unique_id": 3,
-                "first_name": "Jane",
-                "surname": "Wilson",
-                "city": "Birmingham",
-                "email": "jane.w@example.com",
-                "cluster": 1,
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-        ]
-    )
+    df2 = [
+        {
+            "unique_id": 2,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "hannah88@powers.com",
+            "cluster": 0,
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+        {
+            "unique_id": 3,
+            "first_name": "Jane",
+            "surname": "Wilson",
+            "city": "Birmingham",
+            "email": "jane.w@example.com",
+            "cluster": 1,
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+    ]
 
-    df3 = pd.DataFrame(
-        [
-            {
-                "unique_id": 4,
-                "first_name": "Noah",
-                "surname": "Watson",
-                "city": "Bolton",
-                "email": "matthew78@ballard-mcdonald.net",
-                "cluster": 2,
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-            {
-                "unique_id": 5,
-                "first_name": "Emma",
-                "surname": "Brown",
-                "city": "Leeds",
-                "email": "emma.b@test.com",
-                "cluster": 3,
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-            {
-                "unique_id": 6,
-                "first_name": "Oliver",
-                "surname": "Davies",
-                "city": "Bristol",
-                "email": "oliver.d@example.net",
-                "cluster": 4,
-                "tf_city": 0.2,
-                "tf_first_name": 0.1,
-            },
-        ]
-    )
+    df3 = [
+        {
+            "unique_id": 4,
+            "first_name": "Noah",
+            "surname": "Watson",
+            "city": "Bolton",
+            "email": "matthew78@ballard-mcdonald.net",
+            "cluster": 2,
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+        {
+            "unique_id": 5,
+            "first_name": "Emma",
+            "surname": "Brown",
+            "city": "Leeds",
+            "email": "emma.b@test.com",
+            "cluster": 3,
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+        {
+            "unique_id": 6,
+            "first_name": "Oliver",
+            "surname": "Davies",
+            "city": "Bristol",
+            "email": "oliver.d@example.net",
+            "cluster": 4,
+            "tf_city": 0.2,
+            "tf_first_name": 0.1,
+        },
+    ]
 
     # Add required columns if they don't exist
-    for frame in [df1, df2, df3]:
-        if "tf_city" not in frame.columns:
-            frame["tf_city"] = 0.2
-        if "tf_first_name" not in frame.columns:
-            frame["tf_first_name"] = 0.1
-        if "cluster" not in frame.columns and frame is not df1:
-            frame["cluster"] = range(len(frame))
+    # for frame in [df1, df2, df3]:
+    #     # if "tf_city" not in frame.columns:
+    #     #     frame["tf_city"] = 0.2
+    #     # if "tf_first_name" not in frame.columns:
+    #     #     frame["tf_first_name"] = 0.1
+    #     if "cluster" not in frame.columns and frame is not df1:
+    #         frame["cluster"] = range(len(frame))
 
     settings = SettingsCreator(
         link_type="dedupe_only",
@@ -229,70 +216,51 @@ def test_realtime_cache_multiple_records(test_helpers, dialect):
     )
 
     # Compare df1 and df2
-    res1_2_first = compare_records(
-        df1, df2, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
-    ).as_pandas_dataframe()
-    res1_2_not_from_cache = compare_records(
-        df1, df2, settings, db_api, sql_cache_key=None
-    ).as_pandas_dataframe()
-    res1_2_from_cache = compare_records(
-        df1, df2, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
-    ).as_pandas_dataframe()
-
-    # Compare match weights using pandas merge
-    merged = res1_2_first.merge(
-        res1_2_not_from_cache,
-        on=["unique_id_l", "unique_id_r"],
-        suffixes=("_first", "_not_cache"),
+    res1_2_first = (
+        compare_records(
+            df1, df2, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
+        )
+        .query_sql("SELECT * FROM {this} ORDER BY unique_id_l, unique_id_r")
+        .as_dict()
     )
-    pd.testing.assert_series_equal(
-        merged["match_weight_first"],
-        merged["match_weight_not_cache"],
-        check_names=False,
+    res1_2_not_from_cache = (
+        compare_records(df1, df2, settings, db_api, sql_cache_key=None)
+        .query_sql("SELECT * FROM {this} ORDER BY unique_id_l, unique_id_r")
+        .as_dict()
+    )
+    res1_2_from_cache = (
+        compare_records(
+            df1, df2, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
+        )
+        .query_sql("SELECT * FROM {this} ORDER BY unique_id_l, unique_id_r")
+        .as_dict()
     )
 
-    merged = res1_2_first.merge(
-        res1_2_from_cache,
-        on=["unique_id_l", "unique_id_r"],
-        suffixes=("_first", "_from_cache"),
+    assert res1_2_first["match_weight"] == res1_2_not_from_cache["match_weight"]
+    assert res1_2_first["match_weight"] == res1_2_from_cache["match_weight"]
+
+    res1_3_first = (
+        compare_records(
+            df1, df3, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
+        )
+        .query_sql("SELECT * FROM {this} ORDER BY unique_id_l, unique_id_r")
+        .as_dict()
     )
-    pd.testing.assert_series_equal(
-        merged["match_weight_first"],
-        merged["match_weight_from_cache"],
-        check_names=False,
+    res1_3_not_from_cache = (
+        compare_records(df1, df3, settings, db_api, sql_cache_key=None)
+        .query_sql("SELECT * FROM {this} ORDER BY unique_id_l, unique_id_r")
+        .as_dict()
+    )
+    res1_3_from_cache = (
+        compare_records(
+            df1, df3, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
+        )
+        .query_sql("SELECT * FROM {this} ORDER BY unique_id_l, unique_id_r")
+        .as_dict()
     )
 
-    res1_3_first = compare_records(
-        df1, df3, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
-    ).as_pandas_dataframe()
-    res1_3_not_from_cache = compare_records(
-        df1, df3, settings, db_api, sql_cache_key=None
-    ).as_pandas_dataframe()
-    res1_3_from_cache = compare_records(
-        df1, df3, settings, db_api, sql_cache_key=f"model_cmr_{dialect}"
-    ).as_pandas_dataframe()
-
-    merged = res1_3_first.merge(
-        res1_3_not_from_cache,
-        on=["unique_id_l", "unique_id_r"],
-        suffixes=("_first", "_not_cache"),
-    )
-    pd.testing.assert_series_equal(
-        merged["match_weight_first"],
-        merged["match_weight_not_cache"],
-        check_names=False,
-    )
-
-    merged = res1_3_first.merge(
-        res1_3_from_cache,
-        on=["unique_id_l", "unique_id_r"],
-        suffixes=("_first", "_from_cache"),
-    )
-    pd.testing.assert_series_equal(
-        merged["match_weight_first"],
-        merged["match_weight_from_cache"],
-        check_names=False,
-    )
+    assert res1_3_first["match_weight"] == res1_3_not_from_cache["match_weight"]
+    assert res1_3_first["match_weight"] == res1_3_from_cache["match_weight"]
 
 
 @mark_with_dialects_excluding()
@@ -300,29 +268,25 @@ def test_realtime_cache_different_settings(test_helpers, dialect):
     helper = test_helpers[dialect]
     db_api = helper.db_api()
 
-    df1 = pd.DataFrame(
-        [
-            {
-                "unique_id": 0,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "julia@email.com",
-            }
-        ]
-    )
+    data1 = [
+        {
+            "unique_id": 0,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "julia@email.com",
+        }
+    ]
 
-    df2 = pd.DataFrame(
-        [
-            {
-                "unique_id": 1,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "bad@address.com",
-            }
-        ]
-    )
+    data2 = [
+        {
+            "unique_id": 1,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "bad@address.com",
+        }
+    ]
 
     settings_1 = SettingsCreator(
         link_type="dedupe_only",
@@ -345,17 +309,17 @@ def test_realtime_cache_different_settings(test_helpers, dialect):
     )
 
     res1 = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_{dialect}"
+        data1, data2, settings_1, db_api, sql_cache_key=f"first_model_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     res2 = compare_records(
-        df1, df2, settings_2, db_api, sql_cache_key=f"second_model_{dialect}"
+        data1, data2, settings_2, db_api, sql_cache_key=f"second_model_{dialect}"
     ).as_record_dict()[0]["match_weight"]
 
     assert res1 != pytest.approx(res2)
 
     res1_again = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_{dialect}"
+        data1, data2, settings_1, db_api, sql_cache_key=f"first_model_{dialect}"
     ).as_record_dict()[0]["match_weight"]
     assert res1 == pytest.approx(res1_again)
 
@@ -365,29 +329,25 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
     helper = test_helpers[dialect]
     db_api = helper.db_api()
 
-    df1 = pd.DataFrame(
-        [
-            {
-                "unique_id": 0,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "julia@email.com",
-            }
-        ]
-    )
+    data1 = [
+        {
+            "unique_id": 0,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "julia@email.com",
+        }
+    ]
 
-    df2 = pd.DataFrame(
-        [
-            {
-                "unique_id": 1,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "bad@address.com",
-            }
-        ]
-    )
+    data2 = [
+        {
+            "unique_id": 1,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "bad@address.com",
+        }
+    ]
 
     settings_1 = {
         "link_type": "dedupe_only",
@@ -410,12 +370,12 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
     }
 
     res1 = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_dict_{dialect}"
+        data1, data2, settings_1, db_api, sql_cache_key=f"first_model_dict_{dialect}"
     )
     res1 = res1.as_record_dict()[0]["match_weight"]
 
     res2 = compare_records(
-        df1, df2, settings_2, db_api, sql_cache_key=f"second_model_dict_{dialect}"
+        data1, data2, settings_2, db_api, sql_cache_key=f"second_model_dict_{dialect}"
     )
     res2 = res2.as_record_dict()[0]["match_weight"]
 
@@ -423,7 +383,7 @@ def test_realtime_cache_different_settings_dict(test_helpers, dialect):
     assert res1 != pytest.approx(res2)
 
     res1_again = compare_records(
-        df1, df2, settings_1, db_api, sql_cache_key=f"first_model_dict_{dialect}"
+        data1, data2, settings_1, db_api, sql_cache_key=f"first_model_dict_{dialect}"
     )
     res1_again = res1_again.as_record_dict()[0]["match_weight"]
     # using cache
@@ -435,18 +395,16 @@ def test_realtime_custom_join(test_helpers, dialect):
     helper = test_helpers[dialect]
     db_api = helper.db_api()
 
-    df = pd.DataFrame(
-        [
-            {
-                "unique_id": i,
-                "first_name": "Julia",
-                "surname": "Taylor",
-                "city": "London",
-                "email": "julia@email.com",
-            }
-            for i in range(5)
-        ]
-    )
+    data = [
+        {
+            "unique_id": i,
+            "first_name": "Julia",
+            "surname": "Taylor",
+            "city": "London",
+            "email": "julia@email.com",
+        }
+        for i in range(5)
+    ]
 
     settings = {
         "link_type": "dedupe_only",
@@ -459,8 +417,8 @@ def test_realtime_custom_join(test_helpers, dialect):
     }
 
     res = compare_records(
-        df,
-        df,
+        data,
+        data,
         settings,
         db_api,
         sql_cache_key=None,
@@ -469,8 +427,8 @@ def test_realtime_custom_join(test_helpers, dialect):
     assert len(res.as_record_dict()) == 25
 
     res = compare_records(
-        df,
-        df,
+        data,
+        data,
         settings,
         db_api,
         sql_cache_key=None,

--- a/tests/test_score_missing_edges.py
+++ b/tests/test_score_missing_edges.py
@@ -1,16 +1,18 @@
-import pandas as pd
-from pytest import mark
+import pyarrow as pa
+from pytest import fixture, mark
 
 import splink.comparison_library as cl
 from splink import SettingsCreator, block_on
 
 from .decorator import mark_with_dialects_excluding
 
-df_pd = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
-# we don't need full data to check this logic - a smallish subset will do
-# as long as it's large enough to contain missed intra-cluster edges
-# when predicted with default parameters
-df_pd = df_pd[0:200]
+
+@fixture(scope="module")
+def fake_200(fake_1000):
+    # we don't need full data to check this logic - a smallish subset will do
+    # as long as it's large enough to contain missed intra-cluster edges
+    # when predicted with default parameters
+    yield fake_1000[0:200]
 
 
 @mark_with_dialects_excluding()
@@ -18,7 +20,7 @@ df_pd = df_pd[0:200]
     ["link_type", "copies_of_df"],
     [["dedupe_only", 1], ["link_only", 2], ["link_and_dedupe", 2], ["link_only", 3]],
 )
-def test_score_missing_edges(test_helpers, dialect, link_type, copies_of_df):
+def test_score_missing_edges(test_helpers, dialect, link_type, copies_of_df, fake_200):
     helper = test_helpers[dialect]
 
     settings = SettingsCreator(
@@ -36,7 +38,7 @@ def test_score_missing_edges(test_helpers, dialect, link_type, copies_of_df):
         retain_intermediate_calculation_columns=True,
     )
 
-    linker_input = df_pd if copies_of_df == 1 else [df_pd for _ in range(copies_of_df)]
+    linker_input = [fake_200 for _ in range(copies_of_df)]
     linker = helper.linker_with_registration(linker_input, settings)
 
     df_predict = linker.inference.predict()
@@ -44,14 +46,14 @@ def test_score_missing_edges(test_helpers, dialect, link_type, copies_of_df):
         df_predict, 0.95
     )
 
-    df_missing_edges = linker.inference._score_missing_cluster_edges(
+    missing_edges = linker.inference._score_missing_cluster_edges(
         df_clusters,
         df_predict,
-    ).as_pandas_dataframe()
+    ).as_record_dict()
 
-    assert not df_missing_edges.empty, "No missing edges found"
-    assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
-    assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
+    assert len(missing_edges) > 0, "No missing edges found"
+    assert not any(edge["surname_l"] == edge["surname_r"] for edge in missing_edges)
+    assert not any(edge["dob_l"] == edge["dob_r"] for edge in missing_edges)
 
 
 @mark_with_dialects_excluding()
@@ -59,7 +61,9 @@ def test_score_missing_edges(test_helpers, dialect, link_type, copies_of_df):
     ["link_type", "copies_of_df"],
     [["dedupe_only", 1], ["link_only", 2]],
 )
-def test_score_missing_edges_all_edges(test_helpers, dialect, link_type, copies_of_df):
+def test_score_missing_edges_all_edges(
+    test_helpers, dialect, link_type, copies_of_df, fake_200
+):
     helper = test_helpers[dialect]
 
     settings = SettingsCreator(
@@ -77,7 +81,7 @@ def test_score_missing_edges_all_edges(test_helpers, dialect, link_type, copies_
         retain_intermediate_calculation_columns=True,
     )
 
-    linker_input = df_pd if copies_of_df == 1 else [df_pd for _ in range(copies_of_df)]
+    linker_input = [fake_200 for _ in range(copies_of_df)]
     linker = helper.linker_with_registration(linker_input, settings)
 
     df_predict = linker.inference.predict()
@@ -85,14 +89,14 @@ def test_score_missing_edges_all_edges(test_helpers, dialect, link_type, copies_
         df_predict, 0.95
     )
 
-    df_missing_edges = linker.inference._score_missing_cluster_edges(
+    missing_edges = linker.inference._score_missing_cluster_edges(
         df_clusters,
-    ).as_pandas_dataframe()
+    ).as_record_dict()
 
-    assert not df_missing_edges.empty, "No missing edges found"
+    assert len(missing_edges) > 0, "No missing edges found"
     # some of these should be present now, as we are scoring all intracluster edges
-    assert any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
-    assert any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
+    assert any(edge["surname_l"] == edge["surname_r"] for edge in missing_edges)
+    assert any(edge["dob_l"] == edge["dob_r"] for edge in missing_edges)
 
 
 @mark_with_dialects_excluding()
@@ -100,13 +104,13 @@ def test_score_missing_edges_all_edges(test_helpers, dialect, link_type, copies_
     ["link_type"],
     [["dedupe_only"], ["link_only"]],
 )
-def test_score_missing_edges_changed_column_names(test_helpers, dialect, link_type):
+def test_score_missing_edges_changed_column_names(
+    test_helpers, dialect, link_type, fake_200
+):
     helper = test_helpers[dialect]
 
-    df = df_pd.copy()
-    df["record_id"] = df["unique_id"]
-    del df["unique_id"]
-    df["sds"] = "frame_1"
+    df = fake_200.rename_columns({"unique_id": "record_id"})
+    df = df.append_column("sds", pa.array(200 * ["frame_1"]))
     settings = SettingsCreator(
         link_type=link_type,
         comparisons=[
@@ -124,10 +128,10 @@ def test_score_missing_edges_changed_column_names(test_helpers, dialect, link_ty
         source_dataset_column_name="sds",
     )
     if link_type == "dedupe_only":
-        linker_input = df
+        linker_input = [df]
     else:
-        df_2 = df.copy()
-        df_2["sds"] = "frame_2"
+        df_2 = df.drop_columns("sds")
+        df_2 = df_2.append_column("sds", pa.array(200 * ["frame_2"]))
         linker_input = [df, df_2]
     linker = helper.linker_with_registration(linker_input, settings)
 
@@ -136,11 +140,11 @@ def test_score_missing_edges_changed_column_names(test_helpers, dialect, link_ty
         df_predict, 0.95
     )
 
-    df_missing_edges = linker.inference._score_missing_cluster_edges(
+    missing_edges = linker.inference._score_missing_cluster_edges(
         df_clusters,
         df_predict,
-    ).as_pandas_dataframe()
+    ).as_record_dict()
 
-    assert not df_missing_edges.empty, "No missing edges found"
-    assert not any(df_missing_edges["surname_l"] == df_missing_edges["surname_r"])
-    assert not any(df_missing_edges["dob_l"] == df_missing_edges["dob_r"])
+    assert len(missing_edges) > 0, "No missing edges found"
+    assert not any(edge["surname_l"] == edge["surname_r"] for edge in missing_edges)
+    assert not any(edge["dob_l"] == edge["dob_r"] for edge in missing_edges)

--- a/tests/test_settings_options.py
+++ b/tests/test_settings_options.py
@@ -1,6 +1,6 @@
 import os
 
-import pandas as pd
+import pyarrow as pa
 
 import splink.internals.comparison_library as cl
 from splink import block_on
@@ -9,26 +9,15 @@ from .decorator import mark_with_dialects_excluding
 
 
 @mark_with_dialects_excluding()
-def test_model_heavily_customised_settings(test_helpers, dialect, tmp_path):
+def test_model_heavily_customised_settings(test_helpers, dialect, tmp_path, fake_1000):
     helper = test_helpers[dialect]
 
-    df_l = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
     # modify the frame to have source dataset column + different unique id name
     uid = "uid_col"
     source_ds_col = "dataset_name"
-    df_l = df_l.rename(columns={"unique_id": uid})
-    df_r = df_l.copy()
-    df_l[source_ds_col] = "left_set"
-    df_r[source_ds_col] = "right_set"
-
-    # save temporarily to csv + read in again
-    # older pyspark has issues with inferring types directly from pandas
-    tmp_path_df_l = os.path.join(tmp_path, "df_l.csv")
-    tmp_path_df_r = os.path.join(tmp_path, "df_r.csv")
-    df_l.to_csv(tmp_path_df_l)
-    df_r.to_csv(tmp_path_df_r)
-    df_l = helper.load_frame_from_csv(tmp_path_df_l)
-    df_r = helper.load_frame_from_csv(tmp_path_df_r)
+    df_l = fake_1000.rename_columns({"unique_id": uid})
+    df_r = df_l.append_column(source_ds_col, pa.array(1000 * ["right_set"]))
+    df_l = df_l.append_column(source_ds_col, pa.array(1000 * ["left_set"]))
 
     settings = {
         "link_type": "link_and_dedupe",

--- a/tests/test_term_frequencies.py
+++ b/tests/test_term_frequencies.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 
 from splink.internals.duckdb.database_api import DuckDBAPI
@@ -20,8 +19,7 @@ def get_data():
             data.append({"unique_id": counter, "city": city})
             counter += 1
 
-    df = pd.DataFrame(data)
-    return df
+    return data
 
 
 def get_city_comparison():
@@ -50,21 +48,16 @@ def get_city_comparison():
 
 
 def filter_results(df_predict):
-    df_e_pd = df_predict.as_pandas_dataframe()
-
-    f_london = df_e_pd["city_l"] == "London"
-    df_london = df_e_pd[f_london].head(1)
-
-    f_birmingham = df_e_pd["city_l"] == "Birmingham"
-    df_birmingham = df_e_pd[f_birmingham].head(1)
-
-    f_truro = df_e_pd["city_l"] == "Truro"
-    df_truro = df_e_pd[f_truro].head(1)
-
     return {
-        "London": df_london.to_dict(orient="records")[0],
-        "Birmingham": df_birmingham.to_dict(orient="records")[0],
-        "Truro": df_truro.to_dict(orient="records")[0],
+        "London": df_predict.query_sql(
+            "SELECT * FROM {this} WHERE city_l = 'London'"
+        ).as_record_dict()[0],
+        "Birmingham": df_predict.query_sql(
+            "SELECT * FROM {this} WHERE city_l = 'Birmingham'"
+        ).as_record_dict()[0],
+        "Truro": df_predict.query_sql(
+            "SELECT * FROM {this} WHERE city_l = 'Truro'"
+        ).as_record_dict()[0],
     }
 
 
@@ -235,14 +228,12 @@ def test_tf_missing_values_in_lookup():
     and fall back to no adjustment (mw_tf_adj = 0.0)"""
 
     # Create data with cities where Paris won't be in the TF table
-    data = pd.DataFrame(
-        [
-            {"unique_id": 1, "city": "London"},
-            {"unique_id": 2, "city": "London"},
-            {"unique_id": 3, "city": "Paris"},
-            {"unique_id": 4, "city": "Paris"},
-        ]
-    )
+    data = [
+        {"unique_id": 1, "city": "London"},
+        {"unique_id": 2, "city": "London"},
+        {"unique_id": 3, "city": "Paris"},
+        {"unique_id": 4, "city": "Paris"},
+    ]
 
     city_comparison = get_city_comparison()
 
@@ -260,30 +251,24 @@ def test_tf_missing_values_in_lookup():
 
     # Register only London in the TF table - Paris is intentionally missing
     # u_base = 0.2, tf_london = 0.1 (half u_base), so adj mw = log2(0.2/0.1) = 1.0
-    tf_data = pd.DataFrame(
-        [
-            {
-                "city": "London",
-                "tf_city": 0.1,  # Half the u_base value of 0.2
-            },
-        ]
-    )
+    tf_data = [
+        {
+            "city": "London",
+            "tf_city": 0.1,  # Half the u_base value of 0.2
+        },
+    ]
+
     linker.table_management.register_term_frequency_lookup(tf_data, "city")
 
     df_predict = linker.inference.predict()
-    df_e_pd = df_predict.as_pandas_dataframe()
 
     # Get results for each city
-    london_result = (
-        df_e_pd[(df_e_pd["city_l"] == "London") & (df_e_pd["city_r"] == "London")]
-        .head(1)
-        .to_dict(orient="records")[0]
-    )
-    paris_result = (
-        df_e_pd[(df_e_pd["city_l"] == "Paris") & (df_e_pd["city_r"] == "Paris")]
-        .head(1)
-        .to_dict(orient="records")[0]
-    )
+    london_result = df_predict.query_sql(
+        "SELECT * FROM {this} WHERE city_l = 'London' AND city_r = 'London'"
+    ).as_record_dict()[0]
+    paris_result = df_predict.query_sql(
+        "SELECT * FROM {this} WHERE city_l = 'Paris' AND city_r = 'Paris'"
+    ).as_record_dict()[0]
 
     # London should have TF adjustment of 1.0 (log2(0.2/0.1) = log2(2) = 1.0)
     assert pytest.approx(london_result["mw_tf_adj_city"]) == 1.0


### PR DESCRIPTION
Remove pandas from tests relating to different modes of operations.

Branched from #3084, but only independent up to #3083.