### PR TITLE
Make docs build run again by removing simiarity functions from API docs

### DIFF
--- a/docs/api_docs/exploratory.md
+++ b/docs/api_docs/exploratory.md
@@ -12,13 +12,3 @@ tags:
       show_root_toc_entry: false
       show_source: false
 
-# Documentation for`splink.exploratory.similarity_analysis`
-
-::: splink.exploratory.similarity_analysis
-    handler: python
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false
-      show_source: false
-
-


### PR DESCRIPTION
These functions were removed from the code but not the docs build 