### PR TITLE
Fix register tf tables + debug mode interaction

### DIFF
--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -256,8 +256,6 @@ class DatabaseAPI(ABC, Generic[TablishType]):
                 created_physicals,
                 pipeline_completed,
             )
-            # don't want to cache anything in debug mode
-            self._intermediate_table_cache.invalidate_cache()
 
         if splink_dataframe is None:
             raise SplinkException("Debug pipeline execution produced no output tables.")

--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -1,0 +1,40 @@
+from pytest import mark
+
+import splink.comparison_library as cl
+from splink import SettingsCreator
+
+from .decorator import mark_with_dialects_excluding
+
+
+# regression test: https://github.com/moj-analytical-services/splink/issues/3073
+@mark.parametrize("debug_mode", [False, True])
+@mark_with_dialects_excluding()
+def test_pre_registered_tf_tables(dialect, test_helpers, debug_mode):
+    helper = test_helpers[dialect]
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            cl.ExactMatch("first_name").configure(term_frequency_adjustments=True),
+            cl.ExactMatch("city").configure(term_frequency_adjustments=True),
+        ],
+        retain_intermediate_calculation_columns=True,
+    )
+
+    data = [
+        {"unique_id": 1, "first_name": "Andy", "city": "London"},
+        {"unique_id": 2, "first_name": "Andy", "city": "Liverpool"},
+        {"unique_id": 3, "first_name": "Robin", "city": "Liverpool"},
+    ]
+
+    linker = helper.linker_with_registration([data], settings)
+
+    linker._debug_mode = debug_mode
+    city_tf = [
+        {"city": "London", "tf_city": 0.2},
+        {"city": "Liverpool", "tf_city": 0.8},
+    ]
+
+    linker.table_management.register_term_frequency_lookup(city_tf, "city")
+    sdf_pred = linker.inference.predict()
+
+    assert set(sdf_pred.as_dict()["tf_city_l"]) == {0.2, 0.8}


### PR DESCRIPTION
## Background

Currently, when running in debug mode, whenever we execute a SQL pipeline (`DatabaseAPI.sql_pipeline_to_splink_dataframe()`) we invalidate the db-api cache.

However, when we register specific types of tables (`linker.table_management` methods `register_term_frequency_lookup`, `register_table_predict`, and `register_blocked_pairs_for_predict`, as well as when we compute tf tables `compute_tf_table`), the way that we 'remember' that these tables in our backend have a particular semantic meaning in terms of data-linking is by the fact that they live in the `Linker._intermediate_table_cache` with a particular templated name.

Put together, this means that when we run in debug mode, if ever we execute a pipeline then we forget about any manually registered/computed tables. This means we get unexpected results in subsequent calculations. This occurs automatically in `predict` (where we compute blocked pairs and scores separately), but also if we manually run multiple computations.

## Fix

I think we can just remove the code that invalidates the cache in debug mode. This code was originally introduced in #2488 to avoid a bug. The issue at the time is that every time we called `sql_to_splink_dataframe_checking_cache()` we would cache the resulting table, which meant that we got lots of tables populating whenever we computed anything. We also got all intermediate tables when in debug mode, which then interacted in unexpected ways.

However, now we only use the cache for the manual registrations mentioned above (#2847), so there is no issue with the cache being polluted and then interfering with subsequent calculations.

As we are only using the cache for (certain) manually registered tables, we probably shouldn't be invalidating it automatically - that is something that the user should only do manually.

Closes #3073.