### PR TITLE
Remove uv cache from all workflows

### DIFF
--- a/.github/workflows/demo-examples.yml
+++ b/.github/workflows/demo-examples.yml
@@ -33,15 +33,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-          cache-suffix: "${{ runner.os }}-${{ matrix.python-version }}"
+          enable-cache: false
 
       - name: Install Python ${{ matrix.python-version }}
         id: install_python

--- a/.github/workflows/demo-tutorials.yml
+++ b/.github/workflows/demo-tutorials.yml
@@ -31,15 +31,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-          cache-suffix: "${{ runner.os }}-${{ matrix.python-version }}"
+          enable-cache: false
 
       - name: Install Python ${{ matrix.python-version }}
         id: install_python

--- a/.github/workflows/dependency-canary.yml
+++ b/.github/workflows/dependency-canary.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install Python 3.13
         id: install_python313

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,14 +32,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          enable-cache: false
 
       - name: Install Python 3.13
         id: install_python313

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,14 +24,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          enable-cache: false
 
       - name: Install Python 3.12
         id: install_python312

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -25,14 +25,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          enable-cache: false
 
       - name: Install Python 3.12
         id: install_python312

--- a/.github/workflows/pytest-duckdb.yml
+++ b/.github/workflows/pytest-duckdb.yml
@@ -30,15 +30,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-          cache-suffix: "${{ runner.os }}-${{ matrix.python-version }}"
+          enable-cache: false
 
       - name: Install Python ${{ matrix.python-version }}
         id: install_python

--- a/.github/workflows/pytest-postgres.yml
+++ b/.github/workflows/pytest-postgres.yml
@@ -44,15 +44,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-          cache-suffix: "${{ runner.os }}-${{ matrix.python-version }}"
+          enable-cache: false
 
       - name: Install Python ${{ matrix.python-version }}
         id: install_python

--- a/.github/workflows/pytest-spark.yml
+++ b/.github/workflows/pytest-spark.yml
@@ -30,15 +30,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-          cache-suffix: "${{ runner.os }}-${{ matrix.python-version }}"
+          enable-cache: false
 
       - name: Install Python ${{ matrix.python-version }}
         id: install_python

--- a/.github/workflows/pytest-sqlite.yml
+++ b/.github/workflows/pytest-sqlite.yml
@@ -28,15 +28,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv (with cache)
+      - name: Setup uv
         id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-          cache-suffix: "${{ runner.os }}-${{ matrix.python-version }}"
+          enable-cache: false
 
       - name: Install Python ${{ matrix.python-version }}
         id: install_python


### PR DESCRIPTION
This removes the use of the `uv` caching from all workflows, to mitigate the risks of a cache poisoning attack.

Probably this is overkill across the board, but it seems best to be cautious, and it only adds ~20s per job (and only in cases where we actually _use_ it, where there are many instances in which we don't anyway). In my [rough testing](https://github.com/ADBond/splink/pull/95) it did not make things noticeably slower (in fact the actual instance was _quicker_ than a comparable run - just showing that this extra time is within the margin of variability).