### PR TITLE
Improve logging

### DIFF
--- a/docs/demos/examples/duckdb/pairwise_labels.nb.py
+++ b/docs/demos/examples/duckdb/pairwise_labels.nb.py
@@ -86,7 +86,7 @@ settings = SettingsCreator(
 # %%
 db_api = DuckDBAPI()
 df_sdf = db_api.register(df)
-linker = Linker(df_sdf, settings, set_up_basic_logging=False)
+linker = Linker(df_sdf, settings, log_level=None)
 deterministic_rules = [
     "l.first_name = r.first_name and levenshtein(r.dob::VARCHAR, l.dob::VARCHAR) <= 1",
     "l.surname = r.surname and levenshtein(r.dob::VARCHAR, l.dob::VARCHAR) <= 1",

--- a/docs/demos/examples/duckdb/quick_and_dirty_persons.nb.py
+++ b/docs/demos/examples/duckdb/quick_and_dirty_persons.nb.py
@@ -73,7 +73,7 @@ from splink import Linker, DuckDBAPI
 
 db_api = DuckDBAPI()
 df_sdf = db_api.register(df)
-linker = Linker(df_sdf, settings, set_up_basic_logging=False)
+linker = Linker(df_sdf, settings, log_level=None)
 deterministic_rules = [
     "l.full_name = r.full_name",
     "l.postcode_fake = r.postcode_fake and l.dob = r.dob",

--- a/docs/dev_guides/debug_modes.md
+++ b/docs/dev_guides/debug_modes.md
@@ -27,7 +27,7 @@ Unlike debug mode, logging doesn't affect the performance of Splink.
 ### Logging levels
 
 You can set the logging level when creating a linker, or by calling
-`splink.enable_logging(desired_level)`.
+`splink.logging.enable(desired_level)`.
 
 The logging levels in Splink are:
 
@@ -62,9 +62,9 @@ linker = Linker(df, settings, log_level=None)
 
 ```python
 import logging
-import splink
+import splink.logging
 
-splink.enable_logging(logging.INFO)
+splink.logging.enable(logging.INFO)
 
 linker = Linker(df, settings)
 ```

--- a/docs/dev_guides/debug_modes.md
+++ b/docs/dev_guides/debug_modes.md
@@ -26,40 +26,59 @@ Unlike debug mode, logging doesn't affect the performance of Splink.
 
 ### Logging levels
 
-You can set the logging level with code like `logging.getLogger("splink").setLevel(desired_level)` although **see notes below about gotchas**.
+You can set the logging level when creating a linker, or by calling
+`splink.enable_logging(desired_level)`.
 
 The logging levels in Splink are:
 
 - `logging.INFO` (`20`): This outputs user facing messages about the training status of Splink models
 - `15`: Outputs additional information about time taken and parameter estimation
 - `logging.DEBUG` (`10`): Outputs information about the names of the SQL statements executed
-- `logging.DEBUG` (`7`): Outputs information about the names of the components of the SQL pipelines
-- `logging.DEBUG` (`5`): Outputs the SQL statements themselves
+- `7`: Outputs information about the names of the components of the SQL pipelines
+- `5`: Outputs the SQL statements themselves
 
 ### How to control logging
 
-Note that by default Splink sets the [logging level to `INFO` on initialisation](https://github.com/moj-analytical-services/splink/blob/44304126acf3a3292810f1bc209f644e3691ee3a/splink/linker.py#L135)
+By default Splink configures its own `splink` logger at `logging.INFO`, without
+calling `logging.basicConfig()` or changing the root logger for the Python process.
+This means normal users see useful progress messages, while applications can still
+control their own logging setup.
 
-#### With basic logging
+#### Configure when creating a linker
 
 ```python
 import logging
-linker = Linker(df, settings, db_api, set_up_basic_logging=False)
 
-# This must come AFTER the linker is intialised, because the logging level
-# will be set to INFO
-logging.getLogger("splink").setLevel(logging.DEBUG)
+linker = Linker(df, settings, log_level=logging.DEBUG)
 ```
 
-#### Without basic logging
+Pass `log_level=None` if you do not want Splink to configure logging:
 
 ```python
+linker = Linker(df, settings, log_level=None)
+```
 
-# This code can be anywhere since set_up_basic_logging is False
+#### Configure outside linker construction
+
+```python
 import logging
-logging.basicConfig(format="%(message)s")
-splink_logger = logging.getLogger("splink")
-splink_logger.setLevel(logging.INFO)
+import splink
 
-linker = Linker(df, settings, db_api, set_up_basic_logging=False)
+splink.enable_logging(logging.INFO)
+
+linker = Linker(df, settings)
+```
+
+#### Use application logging
+
+If your application has already configured logging, Splink will use that existing
+configuration instead of adding its own handler:
+
+```python
+import logging
+
+logging.basicConfig(format="%(message)s")
+logging.getLogger("splink").setLevel(logging.INFO)
+
+linker = Linker(df, settings)
 ```

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -7,6 +7,7 @@ from splink.internals.column_expression import ColumnExpression
 from splink.internals.datasets import splink_datasets
 from splink.internals.linker import Linker
 from splink.internals.settings_creator import SettingsCreator
+from splink.internals.splink_logging import disable_logging, enable_logging
 
 # The following is a workaround for the fact that dependencies of particular backends
 # may not be installed, but we don't want this to prevent import
@@ -62,7 +63,9 @@ __version__ = "5.0.0.dev3"
 __all__ = [
     "block_on",
     "ColumnExpression",
+    "disable_logging",
     "DuckDBAPI",
+    "enable_logging",
     "Linker",
     "SettingsCreator",
     "SparkAPI",

--- a/splink/__init__.py
+++ b/splink/__init__.py
@@ -7,7 +7,6 @@ from splink.internals.column_expression import ColumnExpression
 from splink.internals.datasets import splink_datasets
 from splink.internals.linker import Linker
 from splink.internals.settings_creator import SettingsCreator
-from splink.internals.splink_logging import disable_logging, enable_logging
 
 # The following is a workaround for the fact that dependencies of particular backends
 # may not be installed, but we don't want this to prevent import
@@ -63,9 +62,7 @@ __version__ = "5.0.0.dev3"
 __all__ = [
     "block_on",
     "ColumnExpression",
-    "disable_logging",
     "DuckDBAPI",
-    "enable_logging",
     "Linker",
     "SettingsCreator",
     "SparkAPI",

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -46,7 +46,7 @@ from splink.internals.settings_validation.valid_types import (
     _validate_dialect,
 )
 from splink.internals.splink_dataframe import SplinkDataFrame
-from splink.internals.splink_logging import enable_logging
+from splink.internals.splink_logging import enable as enable_logging
 from splink.internals.splinkdataframe_utils import (
     get_db_api_from_inputs,
     splink_dataframes_to_dict,

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -46,6 +46,7 @@ from splink.internals.settings_validation.valid_types import (
     _validate_dialect,
 )
 from splink.internals.splink_dataframe import SplinkDataFrame
+from splink.internals.splink_logging import enable_logging
 from splink.internals.splinkdataframe_utils import (
     get_db_api_from_inputs,
     splink_dataframes_to_dict,
@@ -77,7 +78,7 @@ class Linker:
         self,
         splink_dataframe_or_dataframes: SplinkDataFrame | Sequence[SplinkDataFrame],
         settings: SettingsCreator | dict[str, Any] | Path | str,
-        set_up_basic_logging: bool = True,
+        log_level: int | str | None = logging.INFO,
         validate_settings: bool = True,
     ):
         """
@@ -114,18 +115,14 @@ class Linker:
             settings_dict (dict | Path | str): A Splink settings dictionary,
                 or a path (either as a pathlib.Path object, or a string) to a json file
                 defining a settings dictionary or pre-trained model.
-            set_up_basic_logging (bool, optional): If true, sets ups up basic logging
-                so that Splink sends messages at INFO level to stdout. Defaults to True.
+            log_level (int | str | None, optional): Logging level for Splink messages.
+                Defaults to logging.INFO. If None, Splink logging is not configured.
             validate_settings (bool, optional): When True, check your settings
                 dictionary for any potential errors that may cause splink to fail.
         """  # noqa: E501
         self._db_schema = "splink"
-        if set_up_basic_logging:
-            logging.basicConfig(
-                format="%(message)s",
-            )
-            splink_logger = logging.getLogger("splink")
-            splink_logger.setLevel(logging.INFO)
+        if log_level is not None:
+            enable_logging(log_level)
 
         self._db_api = get_db_api_from_inputs(splink_dataframe_or_dataframes)
 

--- a/splink/internals/splink_logging.py
+++ b/splink/internals/splink_logging.py
@@ -47,6 +47,9 @@ def disable() -> None:
             splink_logger.removeHandler(handler)
             handler.close()
 
+    if not splink_logger.handlers:
+        splink_logger.propagate = True
+
 
 logging.addLevelName(VERBOSE, "VERBOSE")
 logging.addLevelName(PIPELINE, "PIPELINE")

--- a/splink/internals/splink_logging.py
+++ b/splink/internals/splink_logging.py
@@ -4,27 +4,27 @@ import logging
 import sys
 from typing import TextIO
 
-DEFAULT_LOG_FORMAT = "%(message)s"
-VERBOSE_LOG_LEVEL = 15
-PIPELINE_LOG_LEVEL = 7
-SQL_LOG_LEVEL = 5
+DEFAULT_FORMAT = "%(message)s"
+VERBOSE = 15
+PIPELINE = 7
+SQL = 5
 
 _SPLINK_DEFAULT_HANDLER_ATTR = "_splink_default_handler"
 
 
-def _validate_log_level(level: int | str) -> None:
+def _validate_level(level: int | str) -> None:
     if isinstance(level, bool):
-        raise TypeError("log_level must be an int, str, or None; use None to disable")
+        raise TypeError("level must be an int, str, or None; use None to disable")
 
 
-def enable_logging(
+def enable(
     level: int | str = logging.INFO,
     *,
     stream: TextIO | None = None,
-    format: str = DEFAULT_LOG_FORMAT,
+    format: str = DEFAULT_FORMAT,
 ) -> None:
     """Configure logging for Splink messages without changing root logging."""
-    _validate_log_level(level)
+    _validate_level(level)
 
     splink_logger = logging.getLogger("splink")
     splink_logger.setLevel(level)
@@ -39,7 +39,7 @@ def enable_logging(
     splink_logger.propagate = False
 
 
-def disable_logging() -> None:
+def disable() -> None:
     """Remove Splink's default handler, leaving user-provided handlers alone."""
     splink_logger = logging.getLogger("splink")
     for handler in list(splink_logger.handlers):
@@ -48,6 +48,6 @@ def disable_logging() -> None:
             handler.close()
 
 
-logging.addLevelName(VERBOSE_LOG_LEVEL, "VERBOSE")
-logging.addLevelName(PIPELINE_LOG_LEVEL, "PIPELINE")
-logging.addLevelName(SQL_LOG_LEVEL, "SQL")
+logging.addLevelName(VERBOSE, "VERBOSE")
+logging.addLevelName(PIPELINE, "PIPELINE")
+logging.addLevelName(SQL, "SQL")

--- a/splink/internals/splink_logging.py
+++ b/splink/internals/splink_logging.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TextIO
+
+DEFAULT_LOG_FORMAT = "%(message)s"
+VERBOSE_LOG_LEVEL = 15
+PIPELINE_LOG_LEVEL = 7
+SQL_LOG_LEVEL = 5
+
+_SPLINK_DEFAULT_HANDLER_ATTR = "_splink_default_handler"
+
+
+def _validate_log_level(level: int | str) -> None:
+    if isinstance(level, bool):
+        raise TypeError("log_level must be an int, str, or None; use None to disable")
+
+
+def enable_logging(
+    level: int | str = logging.INFO,
+    *,
+    stream: TextIO | None = None,
+    format: str = DEFAULT_LOG_FORMAT,
+) -> None:
+    """Configure logging for Splink messages without changing root logging."""
+    _validate_log_level(level)
+
+    splink_logger = logging.getLogger("splink")
+    splink_logger.setLevel(level)
+
+    if splink_logger.hasHandlers():
+        return
+
+    handler = logging.StreamHandler(stream or sys.stderr)
+    handler.setFormatter(logging.Formatter(format))
+    setattr(handler, _SPLINK_DEFAULT_HANDLER_ATTR, True)
+    splink_logger.addHandler(handler)
+    splink_logger.propagate = False
+
+
+def disable_logging() -> None:
+    """Remove Splink's default handler, leaving user-provided handlers alone."""
+    splink_logger = logging.getLogger("splink")
+    for handler in list(splink_logger.handlers):
+        if getattr(handler, _SPLINK_DEFAULT_HANDLER_ATTR, False):
+            splink_logger.removeHandler(handler)
+            handler.close()
+
+
+logging.addLevelName(VERBOSE_LOG_LEVEL, "VERBOSE")
+logging.addLevelName(PIPELINE_LOG_LEVEL, "PIPELINE")
+logging.addLevelName(SQL_LOG_LEVEL, "SQL")

--- a/splink/logging.py
+++ b/splink/logging.py
@@ -1,0 +1,9 @@
+from splink.internals.splink_logging import (
+    PIPELINE,
+    SQL,
+    VERBOSE,
+    disable,
+    enable,
+)
+
+__all__ = ["disable", "enable", "PIPELINE", "SQL", "VERBOSE"]

--- a/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
+++ b/tests/test_join_type_for_estimate_u_and_predict_are_efficient.py
@@ -131,7 +131,7 @@ def test_dedupe_only():
     linker = Linker(
         df_one_sdf,
         settings,
-        set_up_basic_logging=False,
+        log_level=None,
     )
     logging.getLogger("splink").setLevel(1)
 
@@ -176,7 +176,7 @@ def test_link_and_dedupe(fake_1000):
     linker = Linker(
         [df_one_sdf, df_two_sdf],
         settings,
-        set_up_basic_logging=False,
+        log_level=None,
     )
 
     handler.log_list.clear()
@@ -223,7 +223,7 @@ def test_link_only_two(fake_1000):
     linker = Linker(
         [df_one_sdf, df_two_sdf],
         settings,
-        set_up_basic_logging=False,
+        log_level=None,
     )
 
     log_list.clear()
@@ -299,7 +299,7 @@ def test_link_only_three(fake_1000):
     linker = Linker(
         [df_one_sdf, df_two_sdf, df_three_sdf],
         settings,
-        set_up_basic_logging=False,
+        log_level=None,
     )
 
     log_list.clear()


### PR DESCRIPTION
In previous versions of Splink logging was not very Pythonic.  The `set_up_bassic_logging` argument on the `Linker`'s `__init__` meddled with the overall logging settings.

It also meant it was hard to enable logging for non-linker operations such as blocking analysis.

This PR makes logging more pythonic by replacing `set_up_basic_logging` with a `log_level` argument on `Linker`, and by moving Splink's logging setup into a Splink-scoped logger configuration.  By default, `Linker` still enables useful Splink messages at `logging.INFO`, so users continue to see progress messages and warnings during training and prediction.  Passing `log_level=None` opts out of Splink configuring logging.

