### PR TITLE
Docs build on `splink4_maintenance` branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,10 +3,10 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - splink4_maintenance
   pull_request:
     branches:
-      - master
+      - splink4_maintenance
     paths:
       # files that affect the docs build:
       - docs/**
@@ -57,7 +57,7 @@ jobs:
           path: site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/splink4_maintenance'
     needs: build
     name: Deploy Documentation to GitHub Pages
     runs-on: ubuntu-latest


### PR DESCRIPTION
This moves the docs build to `splink4_maintenance`, ahead of switch over our default branch to Splink 5.

This PR means that when we switch over we won't start publishing the Splink 5 docs (or maybe failing to build them? not sure of the current state of affairs). I will make a separate PR into `splink4_maintenance` containing this change (as well as some other things to make docs consistent with that branch) that will allow the docs to build from that branch.