### PR TITLE
Table registration functions accept SplinkDataFrames only

### DIFF
--- a/docs/charts/accuracy_analysis_from_labels_table.nb.py
+++ b/docs/charts/accuracy_analysis_from_labels_table.nb.py
@@ -106,7 +106,8 @@ linker.training.estimate_parameters_using_expectation_maximisation(
 
 
 df_labels = splink_dataset_labels.fake_1000_labels
-labels_table = linker.table_management.register_labels_table(df_labels)
+df_labels_sdf = db_api.register(df_labels)
+labels_table = linker.table_management.register_labels_table(df_labels_sdf)
 
 chart = linker.evaluation.accuracy_analysis_from_labels_table(
     labels_table, output_type="accuracy", add_metrics=["f1"]

--- a/docs/charts/threshold_selection_tool_from_labels_table.nb.py
+++ b/docs/charts/threshold_selection_tool_from_labels_table.nb.py
@@ -48,9 +48,9 @@
 #
 # **Precision** can be maximised by **increasing** the match threshold (reducing false positives).
 #
-# **Recall** can be maximised by **decreasing** the match threshold (reducing false negatives). 
+# **Recall** can be maximised by **decreasing** the match threshold (reducing false negatives).
 #
-# Additional metrics can be used to find the optimal compromise between these two, looking for the threshold at which peak accuracy is achieved. 
+# Additional metrics can be used to find the optimal compromise between these two, looking for the threshold at which peak accuracy is achieved.
 
 # %% [markdown]
 # ### Actions to take as a result of the chart
@@ -109,7 +109,8 @@ linker.training.estimate_parameters_using_expectation_maximisation(
 )
 
 df_labels = splink_dataset_labels.fake_1000_labels
-labels_table = linker.table_management.register_labels_table(df_labels)
+df_labels_sdf = db_api.register(df_labels)
+labels_table = linker.table_management.register_labels_table(df_labels_sdf)
 
 chart = linker.evaluation.accuracy_analysis_from_labels_table(
     labels_table, output_type="threshold_selection", add_metrics=["f1"]

--- a/docs/demos/examples/duckdb/pairwise_labels.nb.py
+++ b/docs/demos/examples/duckdb/pairwise_labels.nb.py
@@ -107,7 +107,8 @@ linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
 
 # %%
 # Register the pairwise labels table with the database, and then use it to estimate the m values
-labels_df = linker.table_management.register_labels_table(pairwise_labels, overwrite=True)
+pairwise_labels_sdf = db_api.register(pairwise_labels)
+labels_df = linker.table_management.register_labels_table(pairwise_labels_sdf)
 linker.training.estimate_m_from_pairwise_labels(labels_df)
 
 

--- a/docs/demos/tutorials/07_Evaluation.nb.py
+++ b/docs/demos/tutorials/07_Evaluation.nb.py
@@ -93,7 +93,8 @@ from splink.datasets import splink_dataset_labels
 from splink.internals.misc import show
 
 df_labels = splink_dataset_labels.fake_1000_labels
-labels_table = linker.table_management.register_labels_table(df_labels)
+df_labels_sdf = db_api.register(df_labels)
+labels_table = linker.table_management.register_labels_table(df_labels_sdf)
 show(df_labels, rows=5)
 
 # %% [markdown]

--- a/splink/internals/linker_components/table_management.py
+++ b/splink/internals/linker_components/table_management.py
@@ -11,6 +11,7 @@ from splink.internals.misc import (
 )
 from splink.internals.pipeline import CTEPipeline
 from splink.internals.splink_dataframe import SplinkDataFrame
+from splink.internals.splinkdataframe_utils import _raise_not_a_splink_dataframe
 from splink.internals.term_frequencies import (
     colname_to_tf_tablename,
     term_frequencies_for_single_column_sql,
@@ -55,7 +56,7 @@ class LinkerTableManagement:
             df_first_name_tf.write.parquet("folder/first_name_tf")
             >>>
             # On subsequent data linking job, read this table rather than recompute
-            df_first_name_tf = pd.read_parquet("folder/first_name_tf")
+            df_first_name_tf = db_api.register(pd.read_parquet("folder/first_name_tf"))
             linker.table_management.register_term_frequency_lookup(
                 df_first_name_tf, "first_name"
             )
@@ -92,8 +93,7 @@ class LinkerTableManagement:
 
     def register_blocked_pairs_for_predict(
         self,
-        input_data: AcceptableInputTableType,
-        overwrite: bool = False,
+        input_data: SplinkDataFrame,
     ) -> SplinkDataFrame:
         """Register a pre-computed blocked pairs table to be scored by `predict()`
         rather than Splink computing blocking from the model's blocking rules.
@@ -108,11 +108,8 @@ class LinkerTableManagement:
         its output.
 
         Args:
-            input_data (AcceptableInputTableType): The blocked pairs table to register.
-                This can be either a dictionary, pandas dataframe, pyarrow table, or
-                a spark dataframe.
-            overwrite (bool, optional): Overwrite the table in the underlying database
-                if it exists. Defaults to False.
+            input_data (SplinkDataFrame): The blocked pairs table to register. Register
+                raw data first with `db_api.register()` to obtain a `SplinkDataFrame`.
 
         Returns:
             SplinkDataFrame: An abstraction representing the registered blocked pairs
@@ -120,20 +117,22 @@ class LinkerTableManagement:
 
         Examples:
             ```py
-            blocked_pairs_df = duckdb.read_parquet("path/to/blocked_pairs.parquet")
-            linker.table_management.register_blocked_pairs_for_predict(blocked_pairs_df)
+            blocked_pairs = db_api.register(
+                duckdb.read_parquet("path/to/blocked_pairs.parquet")
+            )
+            linker.table_management.register_blocked_pairs_for_predict(blocked_pairs)
             predictions = linker.inference.predict()
             ```
         """
-        cache_key = _blocked_pairs_cache_key()
-        table_name_physical = f"{cache_key}_{self._linker._cache_uid}"
+        if not isinstance(input_data, SplinkDataFrame):
+            _raise_not_a_splink_dataframe(input_data)
 
-        splink_dataframe = self.register_table(
-            input_data,
-            table_name_physical,
-            overwrite=overwrite,
+        cache_key = _blocked_pairs_cache_key()
+
+        splink_dataframe = self._linker._db_api.table_to_splink_dataframe(
+            "__splink__blocked_id_pairs",
+            input_data.physical_name,
         )
-        splink_dataframe.templated_name = "__splink__blocked_id_pairs"
         splink_dataframe.metadata["registered_for_predict"] = True
         self._linker._intermediate_table_cache[cache_key] = splink_dataframe
 
@@ -165,7 +164,7 @@ class LinkerTableManagement:
         # As a result, any previously cached tables will not be found
         self._linker._intermediate_table_cache.invalidate_cache()
 
-    def register_table_predict(self, input_data, overwrite=False):
+    def register_table_predict(self, input_data: SplinkDataFrame) -> SplinkDataFrame:
         """Register a pre-computed version of the prediction table for use in Splink.
 
         This method allows you to register a pre-computed prediction table in the Splink
@@ -173,35 +172,37 @@ class LinkerTableManagement:
 
         Examples:
             ```py
-            predict_df = pd.read_parquet("path/to/predict_df.parquet")
-            predict_as_splinkdataframe = linker.table_management.register_table_predict(predict_df)
+            predict_df = db_api.register(pd.read_parquet("path/to/predict_df.parquet"))
+            predict_as_splinkdataframe = linker.table_management.register_table_predict(
+                predict_df
+            )
             clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
                 predict_as_splinkdataframe, threshold_match_probability=0.75
             )
             ```
 
         Args:
-            input_data (AcceptableInputTableType): The data you wish to register. This
-                can be either a dictionary, pandas dataframe, pyarrow table, or a spark
-                dataframe.
-            overwrite (bool, optional): Overwrite the table in the underlying database
-                if it exists. Defaults to False.
+            input_data (SplinkDataFrame): The prediction table to register. Register
+                raw data first with `db_api.register()` to obtain a `SplinkDataFrame`.
 
         Returns:
-            (SplinkDataFrame): An abstraction representing the table created by the SQL
-                pipeline.
+            (SplinkDataFrame): An abstraction representing the registered table.
         """  # noqa: E501
-        table_name_physical = "__splink__df_predict_" + self._linker._cache_uid
-        splink_dataframe = self.register_table(
-            input_data, table_name_physical, overwrite=overwrite
+        if not isinstance(input_data, SplinkDataFrame):
+            _raise_not_a_splink_dataframe(input_data)
+
+        splink_dataframe = self._linker._db_api.table_to_splink_dataframe(
+            "__splink__df_predict",
+            input_data.physical_name,
         )
         self._linker._intermediate_table_cache["__splink__df_predict"] = (
             splink_dataframe
         )
-        splink_dataframe.templated_name = "__splink__df_predict"
         return splink_dataframe
 
-    def register_term_frequency_lookup(self, input_data, col_name, overwrite=False):
+    def register_term_frequency_lookup(
+        self, input_data: SplinkDataFrame, col_name: str
+    ) -> SplinkDataFrame:
         """Register a pre-computed term frequency lookup table for a given column.
 
         This method allows you to register a term frequency table in the Splink
@@ -209,13 +210,10 @@ class LinkerTableManagement:
         rather than computing the term frequency table anew from your input data.
 
         Args:
-            input_data (AcceptableInputTableType): The data representing the term
-                frequency table. This can be either a dictionary, pandas dataframe,
-                pyarrow table, or a spark dataframe.
+            input_data (SplinkDataFrame): The term frequency table to register. Register
+                raw data first with `db_api.register()` to obtain a `SplinkDataFrame`.
             col_name (str): The name of the column for which the term frequency
                 lookup table is being registered.
-            overwrite (bool, optional): Overwrite the table in the underlying
-                database if it exists. Defaults to False.
 
         Returns:
             (SplinkDataFrame): An abstraction representing the registered term
@@ -227,13 +225,16 @@ class LinkerTableManagement:
                 {"first_name": "theodore", "tf_first_name": 0.012},
                 {"first_name": "alfie", "tf_first_name": 0.013},
             ]
-            tf_df = pd.DataFrame(tf_table)
+            tf_df = db_api.register(pd.DataFrame(tf_table))
             linker.table_management.register_term_frequency_lookup(
                 tf_df,
                 "first_name"
             )
             ```
         """
+
+        if not isinstance(input_data, SplinkDataFrame):
+            _raise_not_a_splink_dataframe(input_data)
 
         input_col = InputColumn(
             col_name,
@@ -242,21 +243,21 @@ class LinkerTableManagement:
         )
 
         table_name_templated = colname_to_tf_tablename(input_col)
-        table_name_physical = f"{table_name_templated}_{self._linker._cache_uid}"
-        splink_dataframe = self.register_table(
-            input_data, table_name_physical, overwrite=overwrite
+        splink_dataframe = self._linker._db_api.table_to_splink_dataframe(
+            table_name_templated,
+            input_data.physical_name,
         )
         self._linker._intermediate_table_cache[table_name_templated] = splink_dataframe
-        splink_dataframe.templated_name = table_name_templated
         return splink_dataframe
 
-    def register_labels_table(self, input_data, overwrite=False):
-        table_name_physical = "__splink__df_labels_" + ascii_uid(8)
-        splink_dataframe = self.register_table(
-            input_data, table_name_physical, overwrite=overwrite
+    def register_labels_table(self, input_data: SplinkDataFrame) -> SplinkDataFrame:
+        if not isinstance(input_data, SplinkDataFrame):
+            _raise_not_a_splink_dataframe(input_data)
+
+        return self._linker._db_api.table_to_splink_dataframe(
+            "__splink__df_labels",
+            input_data.physical_name,
         )
-        splink_dataframe.templated_name = "__splink__df_labels"
-        return splink_dataframe
 
     def delete_tables_created_by_splink_from_db(self):
         self._linker._db_api.delete_tables_created_by_splink_from_db()

--- a/splink/internals/splinkdataframe_utils.py
+++ b/splink/internals/splinkdataframe_utils.py
@@ -32,7 +32,7 @@ def _raise_not_a_splink_dataframe(obj: Any) -> None:
         "From Splink 5 onwards, input data must be registered with the database API "
         "before it is passed  to Splink. Registering a table returns a "
         "SplinkDataFrame:\n\n"
-        '    df = db_api.register(my_data, dataset_display_name="my_dataset")\n'
+        "    df = db_api.register(my_data)\n"
         "    linker = Linker(df, settings)\n\n"
         "db_api.register() accepts a pandas DataFrame, a pyarrow Table, a "
         "dict[str, list], a list[dict], a backend-native object (such as a duckdb "

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -845,8 +845,9 @@ def test_truth_space_table_from_table_vs_pandas_cartesian(fake_1000):
     db_api_answer = DuckDBAPI(con)
     df_sdf_answer = db_api_answer.register(fake_1000)
     linker_for_splink_answer = Linker(df_sdf_answer, settings)
+    labels_table_sdf = db_api_answer.register(labels_table)
     labels_input = linker_for_splink_answer.table_management.register_labels_table(
-        labels_table
+        labels_table_sdf
     )
     splink_rows = (
         linker_for_splink_answer.evaluation.accuracy_analysis_from_labels_table(
@@ -933,8 +934,9 @@ def test_truth_space_table_from_table_vs_pandas_with_blocking(fake_1000):
     df_1_sdf_answer = db_api_answer.register(df_1)
     df_2_sdf_answer = db_api_answer.register(df_2)
     linker_for_splink_answer = Linker([df_1_sdf_answer, df_2_sdf_answer], settings)
+    labels_table_sdf = db_api_answer.register(labels_table)
     labels_input = linker_for_splink_answer.table_management.register_labels_table(
-        labels_table
+        labels_table_sdf
     )
     splink_rows = (
         linker_for_splink_answer.evaluation.accuracy_analysis_from_labels_table(

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -180,6 +180,6 @@ def test_cache_register_compute_tf_table(debug_mode, fake_1000):
     with patch.object(
         db_api, "_sql_to_splink_dataframe", new=make_mock_execute(db_api)
     ) as mockexecute_sql_pipeline:
-        linker.table_management.register_term_frequency_lookup(fake_1000, "first_name")
+        linker.table_management.register_term_frequency_lookup(df_sdf, "first_name")
         linker.table_management.compute_tf_table("first_name")
         mockexecute_sql_pipeline.assert_not_called()

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -225,7 +225,7 @@ def test_registered_chunked_blocked_pairs_match_from_scratch(fake_1000):
     df_sdf_source = db_api_source.register(fake_1000)
     linker_source = Linker(df_sdf_source, settings)
 
-    blocked_pairs = (
+    blocked_pairs_arrow = (
         linker_source.inference.compute_blocked_pairs_for_predict().as_pyarrow_table()
     )
 
@@ -234,6 +234,7 @@ def test_registered_chunked_blocked_pairs_match_from_scratch(fake_1000):
     df_sdf_target = db_api_target.register(fake_1000)
     linker_target = Linker(df_sdf_target, settings)
 
+    blocked_pairs = db_api_target.register(blocked_pairs_arrow)
     linker_target.table_management.register_blocked_pairs_for_predict(blocked_pairs)
 
     loaded_predictions = linker_target.inference.predict(
@@ -338,13 +339,14 @@ def test_register_blocked_pairs_then_predict_chunk_errors(fake_1000):
     db_api_source = DuckDBAPI()
     df_sdf_source = db_api_source.register(fake_1000)
     linker_source = Linker(df_sdf_source, settings)
-    blocked_pairs = (
+    blocked_pairs_arrow = (
         linker_source.inference.compute_blocked_pairs_for_predict().as_pyarrow_table()
     )
 
     db_api_target = DuckDBAPI()
     df_sdf_target = db_api_target.register(fake_1000)
     linker_target = Linker(df_sdf_target, settings)
+    blocked_pairs = db_api_target.register(blocked_pairs_arrow)
     linker_target.table_management.register_blocked_pairs_for_predict(blocked_pairs)
 
     # predict() with no chunk arguments must succeed and score the registered table.

--- a/tests/test_cluster_using_single_best_links.py
+++ b/tests/test_cluster_using_single_best_links.py
@@ -33,9 +33,8 @@ def test_single_best_links_correctness_example_1(test_helpers, dialect):
 
     linker = helper.linker_with_registration(data, settings)
 
-    df_predict = linker.table_management.register_table_predict(
-        predictions, overwrite=True
-    )
+    predictions_sdf = linker._db_api.register(predictions)
+    df_predict = linker.table_management.register_table_predict(predictions_sdf)
 
     df_clusters = linker.clustering.cluster_using_single_best_links(
         df_predict,
@@ -91,9 +90,8 @@ def test_single_best_links_example_2(test_helpers, dialect):
 
     linker = helper.linker_with_registration(df, settings)
 
-    df_predict = linker.table_management.register_table_predict(
-        predictions, overwrite=True
-    )
+    predictions_sdf = linker._db_api.register(predictions)
+    df_predict = linker.table_management.register_table_predict(predictions_sdf)
 
     df_clusters = linker.clustering.cluster_using_single_best_links(
         df_predict,
@@ -147,9 +145,8 @@ def test_single_best_links_example_3(test_helpers, dialect):
 
     linker = helper.linker_with_registration(df, settings)
 
-    df_predict = linker.table_management.register_table_predict(
-        predictions, overwrite=True
-    )
+    predictions_sdf = linker._db_api.register(predictions)
+    df_predict = linker.table_management.register_table_predict(predictions_sdf)
 
     df_clusters = linker.clustering.cluster_using_single_best_links(
         df_predict,
@@ -201,9 +198,8 @@ def test_single_best_links_ties(test_helpers, dialect):
 
     linker = helper.linker_with_registration(df, settings)
 
-    df_predict = linker.table_management.register_table_predict(
-        predictions, overwrite=True
-    )
+    predictions_sdf = linker._db_api.register(predictions)
+    df_predict = linker.table_management.register_table_predict(predictions_sdf)
 
     df_clusters = linker.clustering.cluster_using_single_best_links(
         df_predict,
@@ -250,9 +246,8 @@ def test_single_best_links_ties_method(test_helpers, dialect):
 
     linker = helper.linker_with_registration(df, settings)
 
-    df_predict = linker.table_management.register_table_predict(
-        predictions, overwrite=True
-    )
+    predictions_sdf = linker._db_api.register(predictions)
+    df_predict = linker.table_management.register_table_predict(predictions_sdf)
 
     df_clusters = linker.clustering.cluster_using_single_best_links(
         df_predict,
@@ -328,9 +323,8 @@ def test_single_best_links_one_to_many(test_helpers, dialect):
 
     linker = helper.linker_with_registration(df, settings)
 
-    df_predict = linker.table_management.register_table_predict(
-        predictions, overwrite=True
-    )
+    predictions_sdf = linker._db_api.register(predictions)
+    df_predict = linker.table_management.register_table_predict(predictions_sdf)
 
     df_clusters = linker.clustering.cluster_using_single_best_links(
         df_predict,

--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -34,7 +34,8 @@ def test_pre_registered_tf_tables(dialect, test_helpers, debug_mode):
         {"city": "Liverpool", "tf_city": 0.8},
     ]
 
-    linker.table_management.register_term_frequency_lookup(city_tf, "city")
+    city_tf_sdf = linker._db_api.register(city_tf)
+    linker.table_management.register_term_frequency_lookup(city_tf_sdf, "city")
     sdf_pred = linker.inference.predict()
 
     assert set(sdf_pred.as_dict()["tf_city_l"]) == {0.2, 0.8}

--- a/tests/test_disable_tf_exact_match_detection.py
+++ b/tests/test_disable_tf_exact_match_detection.py
@@ -165,7 +165,8 @@ def test_with_predict_calculation(fake_1000):
         {"surname": "Taylor", "tf_surname": 0.4},
         {"surname": "Kirk", "tf_surname": 0.2},
     ]
-    linker.table_management.register_term_frequency_lookup(tf_lookup, "surname")
+    tf_lookup_sdf = linker._db_api.register(tf_lookup)
+    linker.table_management.register_term_frequency_lookup(tf_lookup_sdf, "surname")
 
     df_predict = linker.inference.predict()
 
@@ -209,7 +210,8 @@ def test_with_predict_calculation(fake_1000):
         {"surname": "Taylor", "tf_surname": 0.4},
         {"surname": "Kirk", "tf_surname": 0.2},
     ]
-    linker.table_management.register_term_frequency_lookup(tf_lookup, "surname")
+    tf_lookup_sdf = linker._db_api.register(tf_lookup)
+    linker.table_management.register_term_frequency_lookup(tf_lookup_sdf, "surname")
 
     df_predict = linker.inference.predict()
 
@@ -266,7 +268,8 @@ def test_with_predict_calculation(fake_1000):
             {"surname": "Taylor", "tf_surname": 0.001},
             {"surname": "Kirk", "tf_surname": 0.2},
         ]
-        linker.table_management.register_term_frequency_lookup(tf_lookup, "surname")
+        tf_lookup_sdf = linker._db_api.register(tf_lookup)
+        linker.table_management.register_term_frequency_lookup(tf_lookup_sdf, "surname")
 
         df_predict = linker.inference.predict()
 

--- a/tests/test_score_pairs.py
+++ b/tests/test_score_pairs.py
@@ -41,7 +41,8 @@ def test_score_pair_tf_table_and_derived(test_helpers, dialect, fake_1000):
         {"city": "London", "tf_city": 0.2},
         {"city": "Liverpool", "tf_city": 0.8},
     ]
-    linker.table_management.register_term_frequency_lookup(city_tf, "city")
+    city_tf_sdf = linker._db_api.register(city_tf)
+    linker.table_management.register_term_frequency_lookup(city_tf_sdf, "city")
 
     r1 = {
         "first_name": "Julia ",
@@ -79,13 +80,17 @@ def test_score_pair_input_values_take_precedence(test_helpers, dialect, fake_100
         {"city": "London", "tf_city": 0.2},
         {"city": "Liverpool", "tf_city": 0.8},
     ]
-    linker.table_management.register_term_frequency_lookup(city_tf, "city")
+    city_tf_sdf = linker._db_api.register(city_tf)
+    linker.table_management.register_term_frequency_lookup(city_tf_sdf, "city")
 
     first_name_tf = [
         {"first_name": "Julia", "tf_first_name": 0.3},
         {"first_name": "Robert", "tf_first_name": 0.8},
     ]
-    linker.table_management.register_term_frequency_lookup(first_name_tf, "first_name")
+    first_name_tf_sdf = linker._db_api.register(first_name_tf)
+    linker.table_management.register_term_frequency_lookup(
+        first_name_tf_sdf, "first_name"
+    )
 
     r1 = {
         "first_name": "Julia",

--- a/tests/test_term_frequencies.py
+++ b/tests/test_term_frequencies.py
@@ -258,7 +258,8 @@ def test_tf_missing_values_in_lookup():
         },
     ]
 
-    linker.table_management.register_term_frequency_lookup(tf_data, "city")
+    tf_data_sdf = db_api.register(tf_data)
+    linker.table_management.register_term_frequency_lookup(tf_data_sdf, "city")
 
     df_predict = linker.inference.predict()
 


### PR DESCRIPTION
This brings all the `register_` functions from `table_management` into line with the rest of the API, such that they only accept SplinkDataFrames as their input and raise an error if anything else is provided:
```
register_blocked_pairs_for_predict
register_table_predict
register_term_frequency_lookup
register_labels_table
register_table
```