### PR TITLE
(WIP/Experimental) Allow match weight to be fixed when training

### DIFF
--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -51,6 +51,15 @@ def _validate_m_u_probability(
         )
 
 
+def _validate_fixed_match_weight(value: float | None) -> None:
+    if value is None:
+        return
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError("fixed_match_weight must be a number")
+    if not math.isfinite(value):
+        raise ValueError("fixed_match_weight must be a finite number")
+
+
 def _is_exact_match(sql_syntax_tree):
     signature = sqlglot_tree_signature(sql_syntax_tree)
 
@@ -192,6 +201,7 @@ class ComparisonLevel:
         disable_tf_exact_match_detection: bool = False,
         fix_m_probability: bool = False,
         fix_u_probability: bool = False,
+        fixed_match_weight: float | None = None,
     ):
         self.sql_dialect = sql_dialect
 
@@ -211,8 +221,10 @@ class ComparisonLevel:
         _validate_m_u_probability(
             u_probability, "u_probability", LEVEL_NOT_OBSERVED_TEXT
         )
+        _validate_fixed_match_weight(fixed_match_weight)
         self._m_probability: float | None | str = m_probability
         self._u_probability: float | None | str = u_probability
+        self._fixed_match_weight: float | None = fixed_match_weight
         self.default_m_probability: float | None = None
         self.default_u_probability: float | None = None
 
@@ -268,9 +280,50 @@ class ComparisonLevel:
             return input_column.unquote().name
 
     @property
+    def fixed_match_weight(self) -> float | None:
+        """The match weight fixed for this level, or None if not fixed.
+
+        When set, this level contributes exactly this match weight
+        (log2(m / u)) and its m and u probabilities are derived from it and
+        held constant throughout training.
+        """
+        return self._fixed_match_weight
+
+    @property
+    def _has_fixed_match_weight(self) -> bool:
+        return self._fixed_match_weight is not None
+
+    @property
+    def _fix_m_probability_effective(self) -> bool:
+        return self._fix_m_probability or self._has_fixed_match_weight
+
+    @property
+    def _fix_u_probability_effective(self) -> bool:
+        return self._fix_u_probability or self._has_fixed_match_weight
+
+    @property
+    def _m_probability_from_fixed_match_weight(self) -> float:
+        # A fixed match weight only pins log2(m / u); it does not pin m and u
+        # individually.  We choose the representation that pins one side to 1.0
+        # and encodes the whole weight in the other side.
+        fixed_match_weight = cast(float, self._fixed_match_weight)
+        if fixed_match_weight >= 0:
+            return 1.0
+        return max(match_weight_to_bayes_factor(fixed_match_weight), M_U_CLAMP_MIN)
+
+    @property
+    def _u_probability_from_fixed_match_weight(self) -> float:
+        fixed_match_weight = cast(float, self._fixed_match_weight)
+        if fixed_match_weight < 0:
+            return 1.0
+        return max(match_weight_to_bayes_factor(-fixed_match_weight), M_U_CLAMP_MIN)
+
+    @property
     def m_probability(self) -> float | None:
         if self.is_null_level:
             raise ValueError("Null levels have no m-probability")
+        if self._has_fixed_match_weight:
+            return self._m_probability_from_fixed_match_weight
         if self._m_probability == LEVEL_NOT_OBSERVED_TEXT:
             return 1e-6
         m_probability = cast(Union[float, None], self._m_probability)
@@ -289,6 +342,8 @@ class ComparisonLevel:
     def u_probability(self) -> float | None:
         if self.is_null_level:
             raise ValueError("Null levels have no u-probability")
+        if self._has_fixed_match_weight:
+            return self._u_probability_from_fixed_match_weight
         if self._u_probability == LEVEL_NOT_OBSERVED_TEXT:
             return 1e-6
         u_probability = cast(Union[float, None], self._u_probability)
@@ -389,6 +444,8 @@ class ComparisonLevel:
     def _m_is_trained(self):
         if self.is_null_level:
             return True
+        if self._has_fixed_match_weight:
+            return True
         if self._m_probability == LEVEL_NOT_OBSERVED_TEXT:
             return False
         if self._m_probability is None:
@@ -398,6 +455,8 @@ class ComparisonLevel:
     @property
     def _u_is_trained(self):
         if self.is_null_level:
+            return True
+        if self._has_fixed_match_weight:
             return True
         if self._u_probability == LEVEL_NOT_OBSERVED_TEXT:
             return False
@@ -413,6 +472,9 @@ class ComparisonLevel:
     def _match_weight(self):
         if self.is_null_level:
             return 0.0
+
+        if self._has_fixed_match_weight:
+            return cast(float, self._fixed_match_weight)
 
         m = self.m_probability
         u = self.u_probability
@@ -431,6 +493,8 @@ class ComparisonLevel:
     def _bayes_factor(self):
         if self.is_null_level:
             return 1.0
+        if self._has_fixed_match_weight:
+            return match_weight_to_bayes_factor(cast(float, self._fixed_match_weight))
         if self.m_probability is None or self.u_probability is None:
             return None
         elif self.u_probability == 0:
@@ -442,6 +506,8 @@ class ComparisonLevel:
     def _log2_bayes_factor(self):
         if self.is_null_level:
             return 0.0
+        if self._has_fixed_match_weight:
+            return cast(float, self._fixed_match_weight)
         else:
             return math.log2(self._bayes_factor)
 
@@ -736,11 +802,14 @@ class ComparisonLevel:
         if self.label_for_charts:
             output["label_for_charts"] = self.label_for_charts
 
-        if self._m_probability is not None and self._m_is_trained:
-            output["m_probability"] = self.m_probability
+        if self._has_fixed_match_weight:
+            output["fixed_match_weight"] = self._fixed_match_weight
+        else:
+            if self._m_probability is not None and self._m_is_trained:
+                output["m_probability"] = self.m_probability
 
-        if self._u_probability is not None and self._u_is_trained:
-            output["u_probability"] = self.u_probability
+            if self._u_probability is not None and self._u_is_trained:
+                output["u_probability"] = self.u_probability
 
         output["fix_m_probability"] = self._fix_m_probability
         output["fix_u_probability"] = self._fix_u_probability
@@ -818,6 +887,17 @@ class ComparisonLevel:
         return output_records
 
     def _validate(self):
+        if self._has_fixed_match_weight:
+            if self.is_null_level:
+                raise ValueError(
+                    "Cannot set fixed_match_weight on a comparison level where "
+                    "is_null_level is True"
+                )
+            if self._m_probability is not None or self._u_probability is not None:
+                raise ValueError(
+                    "Cannot provide fixed_match_weight together with "
+                    "m_probability or u_probability"
+                )
         self._validate_sql()
 
     def _abbreviated_sql(self, cutoff=75):

--- a/splink/internals/comparison_level_creator.py
+++ b/splink/internals/comparison_level_creator.py
@@ -74,6 +74,7 @@ class ComparisonLevelCreator(ABC):
         *,
         m_probability: UnsuppliedNoneOr[float] = unsupplied_option,
         u_probability: UnsuppliedNoneOr[float] = unsupplied_option,
+        fixed_match_weight: UnsuppliedNoneOr[float] = unsupplied_option,
         tf_adjustment_column: UnsuppliedNoneOr[str] = unsupplied_option,
         tf_adjustment_weight: UnsuppliedNoneOr[float] = unsupplied_option,
         tf_minimum_u_value: UnsuppliedNoneOr[float] = unsupplied_option,
@@ -106,6 +107,13 @@ class ComparisonLevelCreator(ABC):
                 comparison level.
                 Default is equivalent to None, in which case a default initial value
                 will be provided for this level.
+            fixed_match_weight (float, optional): Fix the match weight
+                (log2(m / u)) for this comparison level directly. When provided,
+                the level contributes exactly this match weight, its m and u
+                probabilities are derived from it, and it is not updated during
+                training. Cannot be combined with m_probability or u_probability.
+                Default is equivalent to None, meaning the match weight is not
+                fixed.
             tf_adjustment_column (str, optional): Make term frequency adjustments for
                 this comparison level using this input column.
                 Default is equivalent to None, meaning that term-frequency adjustments

--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -203,6 +203,7 @@ class CustomLevel(ComparisonLevelCreator):
                 "is_null_level",
                 "m_probability",
                 "u_probability",
+                "fixed_match_weight",
                 "tf_adjustment_column",
                 "tf_adjustment_weight",
                 "tf_minimum_u_value",

--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -554,12 +554,13 @@ def estimate_u_values(
 
         # Apply estimated u values to the original settings object
         for cl in original_comparison._comparison_levels_excluding_null:
-            append_u_probability_to_comparison_level_trained_probabilities(
-                cl,
-                m_u_records_lookup,
-                original_comparison.output_column_name,
-                "estimate u by random sampling",
-            )
+            if not cl._fix_u_probability_effective:
+                append_u_probability_to_comparison_level_trained_probabilities(
+                    cl,
+                    m_u_records_lookup,
+                    original_comparison.output_column_name,
+                    "estimate u by random sampling",
+                )
 
     df_sample.drop_table_from_database_and_remove_from_cache()
 

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -149,7 +149,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
 
-    if not cl._fix_m_probability and "m" not in training_fixed_probabilities:
+    if not cl._fix_m_probability_effective and "m" not in training_fixed_probabilities:
         try:
             m_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -168,7 +168,7 @@ def populate_m_u_from_lookup(
                 cl._m_warning_sent = True
         cl.m_probability = m_probability
 
-    if not cl._fix_u_probability and "u" not in training_fixed_probabilities:
+    if not cl._fix_u_probability_effective and "u" not in training_fixed_probabilities:
         try:
             u_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -458,9 +458,9 @@ class Linker:
 
         for cc in ccs:
             for cl in cc._comparison_levels_excluding_null:
-                if cl._has_estimated_u_values and not cl._fix_u_probability:
+                if cl._has_estimated_u_values and not cl._fix_u_probability_effective:
                     cl.u_probability = cl._trained_u_median
-                if cl._has_estimated_m_values and not cl._fix_m_probability:
+                if cl._has_estimated_m_values and not cl._fix_m_probability_effective:
                     cl.m_probability = cl._trained_m_median
 
     def _raise_error_if_necessary_waterfall_columns_not_computed(self):

--- a/splink/internals/m_from_labels.py
+++ b/splink/internals/m_from_labels.py
@@ -60,7 +60,7 @@ def estimate_m_from_pairwise_labels(linker: "Linker", table_name: str) -> None:
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in linker._settings_obj.comparisons:
         for cl in cc._comparison_levels_excluding_null:
-            if not cl._fix_m_probability:
+            if not cl._fix_m_probability_effective:
                 append_m_probability_to_comparison_level_trained_probabilities(
                     cl,
                     m_u_records_lookup,

--- a/splink/internals/m_training.py
+++ b/splink/internals/m_training.py
@@ -94,9 +94,10 @@ def estimate_m_values_from_label_column(linker: "Linker", label_colname: str) ->
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in original_settings_object.comparisons:
         for cl in cc._comparison_levels_excluding_null:
-            append_m_probability_to_comparison_level_trained_probabilities(
-                cl,
-                m_u_records_lookup,
-                cc.output_column_name,
-                "estimate m from label column",
-            )
+            if not cl._fix_m_probability_effective:
+                append_m_probability_to_comparison_level_trained_probabilities(
+                    cl,
+                    m_u_records_lookup,
+                    cc.output_column_name,
+                    "estimate m from label column",
+                )

--- a/tests/test_comparison_level.py
+++ b/tests/test_comparison_level.py
@@ -83,3 +83,87 @@ def test_exact_match_colnames_for_non_exact_matchy_levels(sql_condition, dialect
     # not actually an exact match level
     with raises(ValueError):
         lev._exact_match_colnames  # noqa: B018
+
+
+def _fixed_weight_level(fixed_match_weight, **kwargs):
+    return ComparisonLevel(
+        sql_condition="ELSE",
+        label_for_charts="nice_informative_label",
+        sql_dialect=SplinkDialect.from_string("duckdb"),
+        fixed_match_weight=fixed_match_weight,
+        **kwargs,
+    )
+
+
+def test_fixed_match_weight_positive_serialisation():
+    lev = _fixed_weight_level(4)
+
+    # A positive match weight pins m to 1.0 and encodes the weight in u
+    assert lev.fixed_match_weight == 4
+    assert lev.m_probability == 1.0
+    assert lev.u_probability == 2**-4
+    assert lev._match_weight == 4
+    assert lev._log2_bayes_factor == 4
+    assert lev._bayes_factor == 2**4
+
+    lev_dict = lev.as_dict()
+    # Only the fixed match weight is serialised - no derived m/u probabilities
+    assert lev_dict["fixed_match_weight"] == 4
+    assert "m_probability" not in lev_dict
+    assert "u_probability" not in lev_dict
+
+
+def test_fixed_match_weight_negative_serialisation():
+    lev = _fixed_weight_level(-4)
+
+    # A negative match weight pins u to 1.0 and encodes the weight in m
+    assert lev.fixed_match_weight == -4
+    assert lev.m_probability == 2**-4
+    assert lev.u_probability == 1.0
+    assert lev._match_weight == -4
+    assert lev._log2_bayes_factor == -4
+
+    lev_dict = lev.as_dict()
+    assert lev_dict["fixed_match_weight"] == -4
+    assert "m_probability" not in lev_dict
+    assert "u_probability" not in lev_dict
+
+
+def test_fixed_match_weight_zero():
+    lev = _fixed_weight_level(0)
+    assert lev.m_probability == 1.0
+    assert lev.u_probability == 1.0
+    assert lev._match_weight == 0
+    assert lev.as_dict()["fixed_match_weight"] == 0
+
+
+def test_fixed_match_weight_round_trips_through_as_dict():
+    lev = _fixed_weight_level(2.5)
+    rebuilt = ComparisonLevel(
+        sql_dialect=SplinkDialect.from_string("duckdb"),
+        **lev.as_dict(),
+    )
+    assert rebuilt.fixed_match_weight == 2.5
+    assert rebuilt._match_weight == lev._match_weight
+    assert rebuilt.m_probability == lev.m_probability
+    assert rebuilt.u_probability == lev.u_probability
+
+
+def test_fixed_match_weight_rejects_m_probability():
+    with raises(ValueError):
+        _fixed_weight_level(-2, m_probability=0.2)
+
+
+def test_fixed_match_weight_rejects_u_probability():
+    with raises(ValueError):
+        _fixed_weight_level(-2, u_probability=0.8)
+
+
+def test_fixed_match_weight_rejects_on_null_level():
+    with raises(ValueError):
+        _fixed_weight_level(3, is_null_level=True)
+
+
+def test_fixed_match_weight_rejects_non_finite():
+    with raises(ValueError):
+        _fixed_weight_level(float("inf"))

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -214,3 +214,60 @@ def test_fix_probabilities(fake_1000):
     assert (
         else_level["u_probability"] != 0.9
     ), "Else level u_probability should have changed"
+
+
+def test_fixed_match_weight_is_preserved_through_em_training(fake_1000):
+    first_name_comparison = cl.CustomComparison(
+        output_column_name="first_name",
+        comparison_levels=[
+            cll.NullLevel("first_name"),
+            cll.ExactMatchLevel("first_name").configure(fixed_match_weight=3),
+            cll.ElseLevel().configure(fixed_match_weight=-4),
+        ],
+    )
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            first_name_comparison,
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("dob"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("first_name"),
+            block_on("dob"),
+        ],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    db_api = DuckDBAPI()
+    df_sdf = db_api.register(fake_1000)
+    linker = Linker(df_sdf, settings)
+
+    linker.training.estimate_u_using_random_sampling(max_pairs=1e4)
+    linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))
+
+    # The in-memory model derives m/u from the fixed weight and never updates them
+    first_name_levels = linker._settings_obj.comparisons[0].comparison_levels
+    exact_obj = first_name_levels[1]
+    assert exact_obj.fixed_match_weight == 3
+    assert exact_obj.m_probability == 1.0
+    assert exact_obj.u_probability == 2**-3
+
+    else_obj = first_name_levels[2]
+    assert else_obj.fixed_match_weight == -4
+    assert else_obj.m_probability == 2**-4
+    assert else_obj.u_probability == 1.0
+
+    # The saved model serialises only the fixed match weight (no derived m/u)
+    model = linker.misc.save_model_to_json()
+    first_name_dicts = model["comparisons"][0]["comparison_levels"]
+
+    exact_match_level = first_name_dicts[1]
+    assert exact_match_level["fixed_match_weight"] == 3
+    assert "m_probability" not in exact_match_level
+    assert "u_probability" not in exact_match_level
+
+    else_level = first_name_dicts[2]
+    assert else_level["fixed_match_weight"] == -4
+    assert "m_probability" not in else_level
+    assert "u_probability" not in else_level

--- a/tests/test_m_train.py
+++ b/tests/test_m_train.py
@@ -64,3 +64,87 @@ def test_m_train():
     assert cl_lev.m_probability == 2 / 4
     cl_no = cc_name._get_comparison_level_by_comparison_vector_value(0)
     assert cl_no.m_probability == 1 / 4
+
+
+def _fixed_match_weight_name_settings():
+    return {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            {
+                "output_column_name": "name",
+                "comparison_levels": [
+                    {
+                        "sql_condition": '"name_l" = "name_r"',
+                        "label_for_charts": "Exact match",
+                        "fixed_match_weight": 2,
+                    },
+                    {
+                        "sql_condition": "ELSE",
+                        "label_for_charts": "All other comparisons",
+                    },
+                ],
+            }
+        ],
+        "blocking_rules_to_generate_predictions": ["l.name = r.name"],
+    }
+
+
+def test_m_train_label_column_respects_fixed_match_weight():
+    data = [
+        {"unique_id": 1, "name": "Robin", "cluster": 1},
+        {"unique_id": 2, "name": "Robyn", "cluster": 1},
+        {"unique_id": 3, "name": "Robin", "cluster": 1},
+        {"unique_id": 4, "name": "James", "cluster": 2},
+        {"unique_id": 5, "name": "David", "cluster": 2},
+    ]
+
+    db_api = DuckDBAPI()
+    df_sdf = db_api.register(data)
+    linker = Linker(df_sdf, _fixed_match_weight_name_settings())
+
+    linker.training.estimate_m_from_label_column("cluster")
+
+    exact_level = linker._settings_obj.comparisons[
+        0
+    ]._get_comparison_level_by_comparison_vector_value(1)
+    # The fixed match weight must be unchanged by training
+    assert exact_level.fixed_match_weight == 2
+    assert exact_level.m_probability == 1.0
+    assert exact_level.u_probability == 2**-2
+
+
+def test_m_train_pairwise_labels_respects_fixed_match_weight():
+    data = [
+        {"unique_id": 1, "name": "Robin", "cluster": 1},
+        {"unique_id": 2, "name": "Robyn", "cluster": 1},
+        {"unique_id": 3, "name": "Robin", "cluster": 1},
+        {"unique_id": 4, "name": "James", "cluster": 2},
+        {"unique_id": 5, "name": "David", "cluster": 2},
+    ]
+    labels = [
+        {
+            "cluster": row_l["cluster"],
+            "source_dataset_l": "fake_data_1",
+            "source_dataset_r": "fake_data_1",
+            "unique_id_l": row_l["unique_id"],
+            "unique_id_r": row_r["unique_id"],
+        }
+        for row_l in data
+        for row_r in data
+        if row_l["cluster"] == row_r["cluster"]
+        and row_l["unique_id"] < row_r["unique_id"]
+    ]
+
+    db_api = DuckDBAPI()
+    df_sdf = db_api.register(data)
+    linker = Linker(df_sdf, _fixed_match_weight_name_settings())
+    db_api.register(labels, table_name="labels")
+
+    linker.training.estimate_m_from_pairwise_labels("labels")
+
+    exact_level = linker._settings_obj.comparisons[
+        0
+    ]._get_comparison_level_by_comparison_vector_value(1)
+    assert exact_level.fixed_match_weight == 2
+    assert exact_level.m_probability == 1.0
+    assert exact_level.u_probability == 2**-2

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -119,6 +119,26 @@ def test_cll_creators_instantiate_levels_with_config(dialect):
     )
     assert lev_dict["label_for_charts"] == "city loose fuzzy match"
 
+    lev_dict = (
+        cll.ElseLevel()
+        .configure(fixed_match_weight=2)
+        .get_comparison_level(dialect)
+        .as_dict()
+    )
+    assert lev_dict["fixed_match_weight"] == 2
+    assert "m_probability" not in lev_dict
+    assert "u_probability" not in lev_dict
+
+    lev_dict = (
+        cll.ElseLevel()
+        .configure(fixed_match_weight=-4)
+        .get_comparison_level(dialect)
+        .as_dict()
+    )
+    assert lev_dict["fixed_match_weight"] == -4
+    assert "m_probability" not in lev_dict
+    assert "u_probability" not in lev_dict
+
 
 comparison_name = cl.CustomComparison(
     output_column_name="name",

--- a/tests/test_u_train.py
+++ b/tests/test_u_train.py
@@ -418,3 +418,47 @@ def test_seed_u_outputs_different_order(test_helpers, dialect):
     # should have got the same u-value each time, as we supply a seed
     # input data is same, just shuffled - should get ordered when we sample
     assert len(u_vals) == 1
+
+
+@mark_with_dialects_excluding()
+def test_u_train_respects_fixed_match_weight(test_helpers, dialect):
+    helper = test_helpers[dialect]
+    data = [
+        {"unique_id": 1, "name": "Amanda"},
+        {"unique_id": 2, "name": "Robin"},
+        {"unique_id": 3, "name": "Robyn"},
+        {"unique_id": 4, "name": "David"},
+        {"unique_id": 5, "name": "Eve"},
+        {"unique_id": 6, "name": "Amanda"},
+    ]
+
+    settings = {
+        "link_type": "dedupe_only",
+        "comparisons": [
+            {
+                "output_column_name": "name",
+                "comparison_levels": [
+                    {
+                        "sql_condition": '"name_l" = "name_r"',
+                        "label_for_charts": "Exact match",
+                        "fixed_match_weight": 3,
+                    },
+                    {
+                        "sql_condition": "ELSE",
+                        "label_for_charts": "All other comparisons",
+                    },
+                ],
+            }
+        ],
+        "blocking_rules_to_generate_predictions": ["l.name = r.name"],
+    }
+    linker = helper.linker_with_registration([data], settings)
+    linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
+
+    exact_level = linker._settings_obj.comparisons[
+        0
+    ]._get_comparison_level_by_comparison_vector_value(1)
+    # u must remain derived from the fixed match weight, not estimated
+    assert exact_level.fixed_match_weight == 3
+    assert exact_level.m_probability == 1.0
+    assert exact_level.u_probability == 2**-3


### PR DESCRIPTION
# Allow a comparison level's match weight to be fixed in settings

## Summary

This PR adds a new comparison-level option, `fixed_match_weight`, that lets a
user pin the **match weight** (`log2(m / u)`) of a comparison level directly in
their settings. When set, the level always contributes exactly that match
weight, and the value is held constant through **all** model training
(`u`-training, Expectation Maximisation, `m`-from-labels and `m`-from-pairwise
-labels).

It works both in the raw settings dictionary and through the comparison-level
creator API (`.configure(fixed_match_weight=...)`).

## Motivation

Splink already lets users fix `m` and `u` probabilities independently via
`fix_m_probability` / `fix_u_probability`. However, the quantity that actually
drives a comparison level's contribution to the final score is the **match
weight** `log2(m / u)` — the Bayes factor in log space.

There are common situations where a user knows (or wants to assert) the *net*
evidential strength of a level, but does not care about the individual `m` and
`u` values:

- **Domain knowledge / hand-tuning.** "An exact match on this column should be
  worth +3 bits, full stop" — without having to back-calculate a consistent
  `m`/`u` pair.
- **Stabilising a level that trains poorly.** Sparse or degenerate levels can
  produce unstable `m`/`u` estimates; fixing the weight keeps that level's
  contribution sensible while everything else trains around it.
- **Reproducibility and review.** A single number per level is far easier to
  reason about, diff, and review than a derived `m`/`u` pair.

Previously this required choosing an arbitrary `m`/`u` combination by hand and
fixing both — error-prone, and the intent (the *weight*) was obscured. This PR
makes the intent first-class.

## Usage

### In a settings dictionary

```python
settings = {
    "link_type": "dedupe_only",
    "comparisons": [
        {
            "output_column_name": "name",
            "comparison_levels": [
                {
                    "sql_condition": '"name_l" IS NULL OR "name_r" IS NULL',
                    "label_for_charts": "Null",
                    "is_null_level": True,
                },
                {
                    "sql_condition": '"name_l" = "name_r"',
                    "label_for_charts": "Exact match",
                    "fixed_match_weight": 3,      # always contributes +3 bits
                },
                {
                    "sql_condition": "ELSE",
                    "label_for_charts": "All other",
                    "fixed_match_weight": -4,     # always contributes -4 bits
                },
            ],
        },
    ],
    "blocking_rules_to_generate_predictions": ["1=1"],
}
```

A `fixed_match_weight` of `3` means the level contributes a Bayes factor of
`2**3 = 8`; a value of `-4` contributes `2**-4 = 0.0625`. After `predict()`,
the per-comparison match-weight column (`mw_name` above) is exactly `3.0` /
`-4.0` for records landing in those levels, regardless of any training that has
been run.

### With the comparison-level creator API

`fixed_match_weight` is accepted by `.configure()` on any comparison-level
creator, so it composes with the library creators:

```python
import splink.comparison_level_library as cll

cll.ExactMatchLevel("name").configure(fixed_match_weight=3)
cll.ElseLevel().configure(fixed_match_weight=-4)
```

### Behaviour through training

```python
linker = Linker(df, settings, db_api)
linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
linker.training.estimate_parameters_using_expectation_maximisation("1=1")

# The exact-match level above still contributes exactly +3 bits;
# EM and u-training leave it untouched.
```

## How it works

- **Single source of truth.** A `fixed_match_weight` pins `log2(m / u)`, not
  `m` and `u` individually. Internally we choose the representation that pins
  one side to `1.0` and encodes the whole weight in the other side
  (clamping the tiny side to `M_U_CLAMP_MIN` to avoid zero/underflow):
  - `w >= 0` → `m = 1.0`, `u = 2**-w`
  - `w <  0` → `u = 1.0`, `m = 2**w`
- **Exact weight in scoring.** `_match_weight`, `_bayes_factor` and
  `_log2_bayes_factor` return the *true* fixed weight rather than recomputing
  from the (possibly clamped) derived `m`/`u`, so there's no display or
  precision drift at extreme weights.
- **Held constant in training.** New effective-fix flags
  (`_fix_m_probability_effective` / `_fix_u_probability_effective`) treat a
  fixed-weight level as already trained, so `u`-training, EM, `m`-from-labels
  and `m`-from-pairwise-labels all skip it.
- **Clean serialization.** `as_dict()` writes **only** `fixed_match_weight`
  for these levels (never a derived `m`/`u`), so saved models round-trip
  losslessly and remain easy to read:

  ```json
  {
    "sql_condition": "\"name_l\" = \"name_r\"",
    "label_for_charts": "Exact match",
    "fixed_match_weight": 3,
    "fix_m_probability": false,
    "fix_u_probability": false
  }
  ```

## Validation

`fixed_match_weight` is validated eagerly and strictly:

- Must be a **finite number** (rejects `NaN`/`inf`, strings and booleans).
- **Cannot** be combined with `m_probability` or `u_probability` on the same
  level (avoids ambiguous/contradictory specifications).
- **Cannot** be set on a null level (`is_null_level: True`).

## Files changed

**Core**

- `splink/internals/comparison_level.py` — new `fixed_match_weight` constructor
  arg, public `fixed_match_weight` property, derived `m`/`u`, true-weight
  scoring, effective-fix flags, `as_dict` serialization and validation.
- `splink/internals/comparison_level_creator.py` — `fixed_match_weight` added
  to `.configure()` (with docstring).
- `splink/internals/comparison_level_library.py` — `fixed_match_weight` added
  to the configurable parameters wired up from settings dictionaries.

**Training**

- `splink/internals/estimate_u.py`
- `splink/internals/expectation_maximisation.py`
- `splink/internals/linker.py`
- `splink/internals/m_from_labels.py`
- `splink/internals/m_training.py`

  All updated to use the effective-fix flags so fixed-weight levels are never
  overwritten during training. (This also tightens two pre-existing spots that
  previously lacked a fix guard.)

## Testing

New and extended tests, all passing:

- `tests/test_comparison_level.py` — serialization (positive / negative /
  zero), `as_dict` round-trip, and rejection of invalid combinations
  (`m_probability`, `u_probability`, null level, non-finite values).
- `tests/test_new_comparison_levels.py` — creator `.configure(...)` produces a
  level that serializes only `fixed_match_weight`.
- `tests/test_u_train.py` — `u`-training leaves a fixed-weight level unchanged.
- `tests/test_m_train.py` — both `m`-from-labels and `m`-from-pairwise-labels
  respect the fixed weight.
- `tests/test_expectation_maximisation.py` — the fixed weight is preserved
  through EM training, in-memory and in the serialized model.

Also validated end-to-end: a settings-dictionary model with fixed weights
produces the expected per-record match weights via `predict()`, and the model
round-trips through `save_model_to_json()` / reload with identical predictions.
