### PR TITLE
Optimise performance of collecting Spark results to address Splink 4 -> 5 performance regression

### DIFF
--- a/splink/internals/spark/dataframe.py
+++ b/splink/internals/spark/dataframe.py
@@ -50,10 +50,16 @@ class SparkDataFrame(SplinkDataFrame):
             sql += f" limit {limit}"
 
         spark_df = self.db_api._execute_sql_against_backend(sql)
-        return {
-            col: [row[col] for row in spark_df.select(col).toLocalIterator()]
-            for col in spark_df.columns
-        }
+        # Collect the whole result in a single Spark job. The previous
+        # implementation iterated one toLocalIterator() per column, and
+        # toLocalIterator fetches partitions to the driver serially (one job per
+        # partition), so the cost was ~(n_columns * n_partitions) serial driver
+        # round-trips. For the per-iteration __splink__m_u_counts pull in EM
+        # training this dominated runtime on Spark. A single collect() retrieves
+        # all columns and partitions in one parallel job.
+        columns = spark_df.columns
+        rows = spark_df.collect()
+        return {col: [row[col] for row in rows] for col in columns}
 
     def as_pyarrow_table(self, limit: int = None) -> PyArrowTable:
         # spark 3 doesn't have native arrow support, so use our fallback method instead

--- a/splink/internals/spark/dataframe.py
+++ b/splink/internals/spark/dataframe.py
@@ -50,13 +50,7 @@ class SparkDataFrame(SplinkDataFrame):
             sql += f" limit {limit}"
 
         spark_df = self.db_api._execute_sql_against_backend(sql)
-        # Collect the whole result in a single Spark job. The previous
-        # implementation iterated one toLocalIterator() per column, and
-        # toLocalIterator fetches partitions to the driver serially (one job per
-        # partition), so the cost was ~(n_columns * n_partitions) serial driver
-        # round-trips. For the per-iteration __splink__m_u_counts pull in EM
-        # training this dominated runtime on Spark. A single collect() retrieves
-        # all columns and partitions in one parallel job.
+
         columns = spark_df.columns
         rows = spark_df.collect()
         return {col: [row[col] for row in rows] for col in columns}


### PR DESCRIPTION

`SparkDataFrame.as_dict()` pulled a result to the driver **one column at a time**
using `select(col).toLocalIterator()`. `toLocalIterator()` runs **one Spark job
per partition, serially**, so the cost was roughly `n_columns × n_partitions`
sequential driver round-trips for a single small result.

This path is hit on **every EM iteration** (via the PySpark‑3
`as_pyarrow_table()` → `as_dict()` fallback) to fetch the new
`m_u_counts` parameters, and it is the dominant cause of Splink 5 EM training
being **1.3–2.6× slower than Splink 4 on Spark** (DuckDB EM is unaffected).

The fix is to collect the whole result in a **single job**, identical in spirit
to the sibling methods `as_record_dict()` and `as_pandas_dataframe()`, which
already use `collect()` / `toPandas()`.

No change to the return type or to memory behaviour: `as_dict()` already
materialises the **entire** result into Python lists (`{col: [all values]}`), so
the per‑partition "bounded memory" property of `toLocalIterator()` bought nothing
here — the peak driver memory is the full result either way. We simply fetch it
in one job instead of `n_columns × n_partitions` serial jobs.

## Why it was slow

`DataFrame.toLocalIterator()` is designed to bound driver memory by streaming
**one partition at a time**, which means it launches a **separate Spark job per
partition and waits for each in turn**. `collect()` instead runs a single job
whose partition tasks execute in parallel.

The old `as_dict()` compounded this by looping **per output column**, so a result
with `C` columns spread over `P` partitions cost up to `C × P` sequential jobs.

This matters because of where it is called. In EM training, every iteration ends
by pulling the freshly‑computed `__splink__m_u_counts` parameters back to the
driver:

- **v4**: `df_params.as_pandas_dataframe()` → a single `.toPandas()` (one job).
- **v5**: `df_params.as_pyarrow_table()` → on PySpark 3 there is no native Arrow
  path, so it falls back to the base class, which calls `as_dict()` → the
  per‑column `toLocalIterator()` loop.

`m_u_counts` is a small result (a few dozen rows, a handful of columns) but it is
a lazy view over the **whole comparison‑vector table**, and it is pulled **once
per iteration**. `predict()`, which uses the identical match‑weight maths, never
does a per‑iteration driver pull, which is why inference stayed at parity and
only EM regressed.

## Evidence 1 — the EM benchmark (2M rows, Spark `local[*]`)

Measured with an instrumented run that records the time spent inside the
per‑iteration driver pull (`collection`), all variants back‑to‑back on the same
host (so they are directly comparable). Every variant converged in the **same 9
iterations** — i.e. identical results, only speed differs.

| v5 variant | EM time | collection time |
|---|---|---|
| v4 master (reference) | 33.4 s | 14.7 s |
| **v5 master (before)** | **39.4 s** | **23.9 s** |
| v5 + persist `m_u_counts`, keep per‑column loop | 50.3 s | 32.6 s |
| **v5 + single `collect()` (this PR)** | **33.0 / 28.8 s** | **13.1 / 11.8 s** |

Two takeaways:

- The single `collect()` restores **v4 parity** — the collection time drops from
  23.9 s to ~12 s, *below* v4's 14.7 s.
- Merely *materialising* the table (persist) while keeping the per‑column loop
  made things **worse**, confirming the cost is the **collection mechanism**
  (serial, per‑partition, per‑column fetch), not upstream recomputation.

Across the full sweep the regression this removes is **1.3–2.6×** on the EM steps
(`em_0`/`em_1`) from 100k to 2M rows.

## Evidence 2 — minimal standalone reprex (no Splink)

`bench/reprex_tolocaliterator_vs_collect.py` — pure PySpark, runs on **cached**
data so there is no recomputation and no shuffle‑reuse asymmetry; the gap is
purely the collection mechanism.

```python
import time
from pyspark.sql import SparkSession, functions as F

spark = (
    SparkSession.builder.master("local[*]")
    .config("spark.ui.enabled", "false")
    .getOrCreate()
)
spark.sparkContext.setLogLevel("ERROR")

def timeit(fn, reps=7, warmup=1):
    for _ in range(warmup):
        fn()
    ts = []
    for _ in range(reps):
        t0 = time.perf_counter(); fn(); ts.append(time.perf_counter() - t0)
    return sorted(ts)[len(ts) // 2]

# Scenario A: single-column fetch from a cached df, varying partition count.
#   collect()         = 1 job, partitions run in parallel
#   toLocalIterator() = 1 job PER PARTITION, serial
for p in (8, 32, 128, 512):
    df = spark.range(0, 200_000).repartition(p).cache(); df.count()
    c  = timeit(lambda: df.collect())
    it = timeit(lambda: list(df.toLocalIterator()))
    print(f"{p:>4} parts  collect={c:.3f}s  toLocalIterator={it:.3f}s  ({it/c:.1f}x)")
    df.unpersist()

# Scenario B: pull a 5-column cached result the way the old as_dict did,
# one column at a time (5 x 32 serial jobs) vs a single collect().
result = (
    spark.range(0, 200_000)
    .select(
        (F.col("id") % 8).alias("g"),
        (F.col("id") % 7).cast("double").alias("m_a"),
        (F.col("id") % 13).cast("double").alias("m_b"),
        (F.col("id") % 17).cast("double").alias("m_c"),
        (F.col("id") % 19).cast("double").alias("m_d"),
    )
    .repartition(32).cache()
)
result.count()

def via_collect():
    rows = result.collect()
    return {c: [r[c] for r in rows] for c in result.columns}

def via_per_column_iter():
    return {c: [row[c] for row in result.select(c).toLocalIterator()]
            for c in result.columns}

print("collect once          :", round(timeit(via_collect), 3), "s")
print("per-column toLocalIter :", round(timeit(via_per_column_iter), 3), "s")
```

Measured results (median of 7 reps; PySpark 3.5.3, `local[*]`, M4 Max):

**Scenario A — single‑column fetch from cached 200,000 rows, varying partitions:**

| partitions | `collect()` | `toLocalIterator()` | ratio |
|---:|---:|---:|---:|
| 8 | 0.145 s | 0.197 s | 1.4× |
| 32 | 0.148 s | 0.516 s | 3.5× |
| 128 | 0.163 s | 0.695 s | 4.3× |
| 512 | 0.207 s | 1.019 s | 4.9× |

**Scenario B — pull a 5‑column cached result, 32 partitions:**

| method | time |
|---|---:|
| `collect()` once (1 job) | 0.325 s |
| per‑column `toLocalIterator()` (5 × 32 serial jobs) | 1.997 s |
| **ratio** | **6.1×** |

`collect()` stays roughly flat as partitions grow (0.15 → 0.21 s) while
`toLocalIterator()` scales with partition count (0.20 → 1.02 s), and the
per‑column loop multiplies that again (6.1× here). In real EM training, with the
result recomputed fresh each iteration over the full comparison‑vector table, the
penalty is larger still.

