### PR TITLE
Unpin ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ docs = [
     "neoteroi-mkdocs>=1.1.2",
     "pymdown-extensions>=10.15",
 ]
-linting = ["ruff>=0.4.2,<0.5"]
+linting = ["ruff>=0.15.18"]
 pandas = ["pandas>=1.3.5", "numpy>=1.19.3"]
 postgres = [
     "psycopg2-binary>=2.9.0",

--- a/splink/internals/blocking.py
+++ b/splink/internals/blocking.py
@@ -217,10 +217,11 @@ class BlockingRule:
             on
             ({self.blocking_rule_sql})
             {where_condition}
-            {self.exclude_pairs_generated_by_all_preceding_rules_sql(
-                source_dataset_input_column,
-                unique_id_input_column)
-            }
+            {
+            self.exclude_pairs_generated_by_all_preceding_rules_sql(
+                source_dataset_input_column, unique_id_input_column
+            )
+        }
             """
         return sql
 

--- a/splink/internals/cache_dict_with_logging.py
+++ b/splink/internals/cache_dict_with_logging.py
@@ -33,7 +33,7 @@ class CacheDictWithLogging(TypedUserDict):
         super().__setitem__(key, value)
 
         logger.log(
-            1, f"Setting cache for {key}" f" with physical name {value.physical_name}"
+            1, f"Setting cache for {key} with physical name {value.physical_name}"
         )
 
     def invalidate_cache(self):
@@ -43,7 +43,7 @@ class CacheDictWithLogging(TypedUserDict):
         df = self[key]
         phy_name = df.physical_name
         logger.debug(
-            f"Using cache for template name {key}" f" with physical name {phy_name}"
+            f"Using cache for template name {key} with physical name {phy_name}"
         )
         self.queries_retrieved_from_cache.append(df)
 

--- a/splink/internals/cluster_studio.py
+++ b/splink/internals/cluster_studio.py
@@ -333,8 +333,8 @@ def _get_cluster_ids(
         if len(cluster_id_infos) > sample_size:
             cluster_id_infos = random.sample(cluster_id_infos, k=sample_size)
         cluster_names = [
-            f"""Cluster ID: {c['cluster_id']}, density (4dp): {c['density_4dp']},
-            size: {c['cluster_size']}"""
+            f"""Cluster ID: {c["cluster_id"]}, density (4dp): {c["density_4dp"]},
+            size: {c["cluster_size"]}"""
             for c in cluster_id_infos
         ]
         cluster_ids = [c["cluster_id"] for c in cluster_id_infos]

--- a/splink/internals/clustering.py
+++ b/splink/internals/clustering.py
@@ -280,9 +280,9 @@ def _generate_detailed_cluster_comparison_sql(
     ]
 
     sql = f"""
-    SELECT {', '.join(select_columns)}
+    SELECT {", ".join(select_columns)}
     {from_clause}
-    {' '.join(join_clauses)}
+    {" ".join(join_clauses)}
     """
 
     return sql

--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -472,8 +472,7 @@ class ComparisonLevel:
         else:
             mult = 1 / self._bayes_factor
             return (
-                f"{text} {self._num_fmt_dp_or_sf(mult)} times "
-                "less likely to be a match"
+                f"{text} {self._num_fmt_dp_or_sf(mult)} times less likely to be a match"
             )
 
     @property

--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -81,7 +81,7 @@ def validate_categorical_parameter(
     else:
         comma_quote_separated_options = "', '".join(allowed_values)
         raise ValueError(
-            f"'{parameter_name}' must be one of: " f"'{comma_quote_separated_options}'"
+            f"'{parameter_name}' must be one of: '{comma_quote_separated_options}'"
         )
 
 
@@ -350,7 +350,7 @@ class LiteralMatchLevel(ComparisonLevelCreator):
         elif self.side_of_comparison == "right":
             return f"{col.name_r} = {dialected}"
         elif self.side_of_comparison == "both":
-            return f"{col.name_l} = {dialected}" f" AND {col.name_r} = {dialected}"
+            return f"{col.name_l} = {dialected} AND {col.name_r} = {dialected}"
         raise ValueError(f"Invalid `side_of_comparison`: {self.side_of_comparison}.")
 
     def create_label_for_charts(self) -> str:

--- a/splink/internals/completeness.py
+++ b/splink/internals/completeness.py
@@ -83,7 +83,7 @@ def completeness_data(
     # Replace table names with something user-friendly
     if table_names_for_chart is None:
         table_names_for_chart = [
-            f"input_data_{i+1}" for i in range(len(splink_df_dict))
+            f"input_data_{i + 1}" for i in range(len(splink_df_dict))
         ]
     physical_names = [df.physical_name for df in splink_df_dict.values()]
     whens = " ".join(

--- a/splink/internals/dialects.py
+++ b/splink/internals/dialects.py
@@ -80,8 +80,7 @@ class SplinkDialect(ABC):
     @property
     def levenshtein_function_name(self):
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have a "
-            "'Levenshtein' function"
+            f"Backend '{self.sql_dialect_str}' does not have a 'Levenshtein' function"
         )
 
     @property
@@ -94,8 +93,7 @@ class SplinkDialect(ABC):
     @property
     def jaro_winkler_function_name(self):
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have a "
-            "'Jaro-Winkler' function"
+            f"Backend '{self.sql_dialect_str}' does not have a 'Jaro-Winkler' function"
         )
 
     @property
@@ -146,13 +144,13 @@ class SplinkDialect(ABC):
     @property
     def greatest_function_name(self):
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have a " "'Greatest' function"
+            f"Backend '{self.sql_dialect_str}' does not have a 'Greatest' function"
         )
 
     @property
     def least_function_name(self):
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have a " "'Least' function"
+            f"Backend '{self.sql_dialect_str}' does not have a 'Least' function"
         )
 
     @property
@@ -242,8 +240,7 @@ class SplinkDialect(ABC):
         self, name: str, pattern: str, capture_group: int = 0
     ) -> str:
         raise NotImplementedError(
-            f"Backend '{self.sql_dialect_str}' does not have a "
-            "'regex_extract' function"
+            f"Backend '{self.sql_dialect_str}' does not have a 'regex_extract' function"
         )
 
     def access_extreme_array_element(
@@ -387,8 +384,8 @@ class DuckDBDialect(SplinkDialect):
                 + columns_to_explode
             )
             other_columns_to_retain.append(column_to_explode)
-            return f"""select {','.join(cols_to_select)}
-                from ({self.explode_arrays_sql(tbl_name,columns_to_explode,other_columns_to_retain)})"""  # noqa: E501
+            return f"""select {",".join(cols_to_select)}
+                from ({self.explode_arrays_sql(tbl_name, columns_to_explode, other_columns_to_retain)})"""  # noqa: E501
 
     @property
     def cosine_similarity_function_name(self):
@@ -509,8 +506,8 @@ class SparkDialect(SplinkDialect):
                 + other_columns_to_retain
                 + columns_to_explode
             )
-        return f"""select {','.join(cols_to_select)}
-                from ({self.explode_arrays_sql(tbl_name,columns_to_explode,other_columns_to_retain+[column_to_explode])})"""  # noqa: E501
+        return f"""select {",".join(cols_to_select)}
+                from ({self.explode_arrays_sql(tbl_name, columns_to_explode, other_columns_to_retain + [column_to_explode])})"""  # noqa: E501
 
     @property
     def hash_function_name(self) -> str:

--- a/splink/internals/em_sampling.py
+++ b/splink/internals/em_sampling.py
@@ -155,7 +155,7 @@ def resolve_em_sample_threshold(
         raise ValueError(f"max_pairs must be positive, or None; got {max_pairs!r}")
     if not 0 < probe_proportion <= 1:
         raise ValueError(
-            "record_sample_proportion must be in (0, 1]; got " f"{probe_proportion!r}"
+            f"record_sample_proportion must be in (0, 1]; got {probe_proportion!r}"
         )
 
     info: dict[str, Any] = {

--- a/splink/internals/estimate_u.py
+++ b/splink/internals/estimate_u.py
@@ -451,7 +451,7 @@ def estimate_u_values(
     for i, comparison in enumerate(settings_obj.comparisons):
         logger.info(
             f"\nEstimating u for: {comparison.output_column_name} "
-            f"(Comparison {i+1} of {len(settings_obj.comparisons)})"
+            f"(Comparison {i + 1} of {len(settings_obj.comparisons)})"
         )
         original_comparison = original_settings_obj.comparisons[i]
 

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -438,7 +438,7 @@ class Linker:
                     (
                         "This estimate of probability two random records match now: "
                         f" {as_prob:,.3f} "
-                        f"with reciprocal {(1/as_prob):,.3f}"
+                        f"with reciprocal {(1 / as_prob):,.3f}"
                     ),
                 )
             logger.log(15, "\n---------")
@@ -453,7 +453,7 @@ class Linker:
             "\nMedian of prop of matches estimates: "
             f"{self._settings_obj._probability_two_random_records_match:,.3f} "
             "reciprocal "
-            f"{1/self._settings_obj._probability_two_random_records_match:,.3f}",
+            f"{1 / self._settings_obj._probability_two_random_records_match:,.3f}",
         )
 
     def _populate_m_u_from_trained_values(self):

--- a/splink/internals/linker_components/evaluation.py
+++ b/splink/internals/linker_components/evaluation.py
@@ -161,7 +161,7 @@ class LinkerEvalution:
 
         if not all(metric in allowed for metric in add_metrics):
             raise ValueError(
-                "Invalid metric. " f"Allowed metrics are: {', '.join(allowed)}."
+                f"Invalid metric. Allowed metrics are: {', '.join(allowed)}."
             )
 
         df_truth_space = truth_space_table_from_labels_column(

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -1503,7 +1503,7 @@ class LinkerInference:
                 input_tablename_r=right_unnested,
             )
             table_name = (
-                "__splink__predict_between_marginal_exploded_ids_mk_" f"{br.match_key}"
+                f"__splink__predict_between_marginal_exploded_ids_mk_{br.match_key}"
             )
             pipeline.enqueue_sql(marginal_sql, table_name)
             br.exploded_id_pair_table = db_api.sql_pipeline_to_splink_dataframe(

--- a/splink/internals/linker_components/training.py
+++ b/splink/internals/linker_components/training.py
@@ -118,7 +118,7 @@ class LinkerTraining:
                 f"Deterministic matching rules led to more "
                 f"observed matches than is consistent with supplied recall. "
                 f"With these rules, recall must be at least "
-                f"{num_observed_matches/num_total_comparisons:,.2f}."
+                f"{num_observed_matches / num_total_comparisons:,.2f}."
             )
 
         num_expected_matches = num_observed_matches / recall
@@ -133,7 +133,7 @@ class LinkerTraining:
                 f"If this is truly the case then you do not need "
                 f"to run the linkage model.\n"
                 f"However this is usually in error; "
-                f"expected rules to have recall of {100*recall:,.0f}%. "
+                f"expected rules to have recall of {100 * recall:,.0f}%. "
                 f"Consider revising rules as they may have an error."
             )
         if prob == 1:
@@ -150,7 +150,7 @@ class LinkerTraining:
 
         self._linker._settings_obj._probability_two_random_records_match = prob
 
-        reciprocal_prob = "Infinity" if prob == 0 else f"{1/prob:,.2f}"
+        reciprocal_prob = "Infinity" if prob == 0 else f"{1 / prob:,.2f}"
         logger.info(
             f"Probability two random records match is estimated to be  {prob:.3g}.\n"
             f"This means that amongst all possible pairwise record comparisons, one in "

--- a/splink/internals/logging_messages.py
+++ b/splink/internals/logging_messages.py
@@ -1,10 +1,6 @@
 def execute_sql_logging_message_info(templated_name, physical_name):
-    return (
-        f"Executing sql to create "
-        f"{templated_name} "
-        f"as physical name {physical_name}"
-    )
+    return f"Executing sql to create {templated_name} as physical name {physical_name}"
 
 
 def log_sql(sql):
-    return "\n------Start SQL---------\n" f"{sql}\n" "-------End SQL-----------\n"
+    return f"\n------Start SQL---------\n{sql}\n-------End SQL-----------\n"

--- a/splink/internals/misc.py
+++ b/splink/internals/misc.py
@@ -193,7 +193,7 @@ def calculate_cartesian(df_rows, link_type):
     if link_type == "link_only":
         if len(n) <= 1:
             raise ValueError(
-                "if 'link_type 'is 'link_only' should have " "at least two input frames"
+                "if 'link_type 'is 'link_only' should have at least two input frames"
             )
         # sum of pairwise product can be found as
         # half of [(sum)-squared - (sum of squares)]
@@ -204,8 +204,7 @@ def calculate_cartesian(df_rows, link_type):
     if link_type == "dedupe_only":
         if len(n) > 1:
             raise ValueError(
-                "if 'link_type' is 'dedupe_only' should have only "
-                "a single input frame"
+                "if 'link_type' is 'dedupe_only' should have only a single input frame"
             )
         return n[0]["count"] * (n[0]["count"] - 1) / 2
 
@@ -214,8 +213,7 @@ def calculate_cartesian(df_rows, link_type):
         return total_rows * (total_rows - 1) / 2
 
     raise ValueError(
-        "'link_type' should be either 'link_only', 'dedupe_only', "
-        "or 'link_and_dedupe'"
+        "'link_type' should be either 'link_only', 'dedupe_only', or 'link_and_dedupe'"
     )
 
 

--- a/splink/internals/parse_sql.py
+++ b/splink/internals/parse_sql.py
@@ -17,18 +17,18 @@ def get_columns_used_from_sql(sql, sqlglot_dialect=None, retain_table_prefix=Fal
         # check if any parents are lambdas
         parent = subtree.parent
         while parent is not None:
-            if type(parent) == Lambda:
+            if isinstance(parent, Lambda):
                 break
             parent = parent.parent
 
-        if type(parent) == Lambda:
+        if isinstance(parent, Lambda):
             continue
 
-        if subtree.find(Bracket) and type(subtree) == Column:
+        if subtree.find(Bracket) and isinstance(subtree, Column):
             # Column with bracket in it
             table = subtree.table
             column = subtree.this.this.this
-        elif type(subtree.parent) != Column and type(subtree) == Column:
+        elif not isinstance(subtree.parent, Column) and isinstance(subtree, Column):
             # Plain column
             table = subtree.table
 

--- a/splink/internals/pipeline.py
+++ b/splink/internals/pipeline.py
@@ -132,7 +132,7 @@ class CTEPipeline:
             )
 
             for i, part in enumerate(parts):
-                logger.log(7, f"    Pipeline part {i+1}: {part.cte_description}")
+                logger.log(7, f"    Pipeline part {i + 1}: {part.cte_description}")
 
     def ctes_pipeline(self) -> List[CTE]:
         """Common table expressions"""

--- a/splink/internals/profile_data.py
+++ b/splink/internals/profile_data.py
@@ -57,8 +57,8 @@ def _get_inner_chart_spec_freq(percentile_data, top_n_data, bottom_n_data, col_n
     perc = total_non_null_rows / total_rows_inc_nulls
 
     sub = (
-        f"In this col, {total_rows_inc_nulls*(1-perc):,.0f} values "
-        f"({1-perc:,.1%}) are null and there are "
+        f"In this col, {total_rows_inc_nulls * (1 - perc):,.0f} values "
+        f"({1 - perc:,.1%}) are null and there are "
         f"{distinct_value_count} distinct values"
     )
     sub = sub.format(**percentile_data[0])

--- a/splink/internals/settings.py
+++ b/splink/internals/settings.py
@@ -149,7 +149,7 @@ class CoreModelSettings:
         prior_description = (
             "The probability that two random records drawn at random match is "
             f"{rr_match:.3f} or one in "
-            f" {1/rr_match:,.1f} records."
+            f" {1 / rr_match:,.1f} records."
             "This is equivalent to a starting match weight of "
             f"{prob_to_match_weight(rr_match):.3f}."
         )

--- a/splink/internals/similarity_analysis.py
+++ b/splink/internals/similarity_analysis.py
@@ -37,11 +37,11 @@ def comparator_score(str1, str2, decimal_places=2):
         select
         '{str1}' as string1,
         '{str2}' as string2,
-        {_comparator_cols_sql.format(
-            comparison1 = 'string1',
-            comparison2 = 'string2',
-            decimal_places=decimal_places
-        )}
+        {
+        _comparator_cols_sql.format(
+            comparison1="string1", comparison2="string2", decimal_places=decimal_places
+        )
+    }
     """
     return con.execute(sql).fetch_df()
 
@@ -69,11 +69,11 @@ def comparator_score_df(list, col1, col2, decimal_places=2):
     sql = f"""
         select
         {col1}, {col2},
-        {_comparator_cols_sql.format(
-            comparison1 = col1,
-            comparison2 = col2,
-            decimal_places=decimal_places
-        )},
+        {
+        _comparator_cols_sql.format(
+            comparison1=col1, comparison2=col2, decimal_places=decimal_places
+        )
+    },
         from list
     """
 

--- a/splink/internals/splink_dataframe.py
+++ b/splink/internals/splink_dataframe.py
@@ -83,7 +83,7 @@ class SplinkDataFrame(ABC):
 
     def _drop_table_from_database(self, force_non_splink_table=False):
         raise NotImplementedError(
-            "_drop_table_from_database from database not " "implemented for this linker"
+            "_drop_table_from_database from database not implemented for this linker"
         )
 
     def drop_table_from_database_and_remove_from_cache(

--- a/splink/internals/term_frequencies.py
+++ b/splink/internals/term_frequencies.py
@@ -232,12 +232,12 @@ def tf_chart_data(
                 unnest(map_entries(histogram(log2_bf_final, {bin_edges}))) AS hist_data,
                 hist_data['key'] AS bin_upper,
                 hist_data['value'] AS count,
-                bin_upper - {bin_width/2} AS log2_bf_final,
+                bin_upper - {bin_width / 2} AS log2_bf_final,
                 (bin_upper - {bin_width})::VARCHAR || '-' || (bin_upper)::VARCHAR
                     AS log2_bf_desc,
                 -- have to repeat ourselves as duckdb can't disambiguate log2_bf_final
                 -- in this relation as opposed to the base table
-                bin_upper - {bin_width/2} - log2_bf AS log2_bf_tf
+                bin_upper - {bin_width / 2} - log2_bf AS log2_bf_tf
             FROM
                 {df_table_name}
             GROUP BY

--- a/tests/literal_utils.py
+++ b/tests/literal_utils.py
@@ -22,9 +22,9 @@ def run_is_in_level_tests(test_cases: List[Dict[str, Any]], db_api: Any) -> None
                 expected.append(input_data["expected"])
 
         results = is_in_level(case["level"], inputs, db_api)
-        assert (
-            results == expected
-        ), f"Expected {expected}, but got {results} for case: {case}"
+        assert results == expected, (
+            f"Expected {expected}, but got {results} for case: {case}"
+        )
 
 
 def run_comparison_vector_value_tests(

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -57,9 +57,9 @@ def test_chunked_predict_matches_non_chunked(test_helpers, dialect, fake_1000):
     # Results should be identical
     no_chunked_count = len(df_no_chunk["unique_id_l"])
     chunked_count = len(df_no_chunk["unique_id_l"])
-    assert (
-        no_chunked_count == chunked_count
-    ), f"Row count mismatch: {no_chunked_count} vs {chunked_count}"
+    assert no_chunked_count == chunked_count, (
+        f"Row count mismatch: {no_chunked_count} vs {chunked_count}"
+    )
 
     # Compare the actual data
     assert df_no_chunk["unique_id_l"] == df_chunked["unique_id_l"]
@@ -95,9 +95,9 @@ def test_chunked_predict_with_different_chunk_sizes(test_helpers, dialect, fake_
             num_chunks_right=num_right,
         )
 
-        assert (
-            _get_comparison_count(predictions) == baseline_count
-        ), f"Chunk config ({num_left}, {num_right}) produced different count"
+        assert _get_comparison_count(predictions) == baseline_count, (
+            f"Chunk config ({num_left}, {num_right}) produced different count"
+        )
 
         df_chunked = _sort_predictions(predictions)
         assert df_baseline["unique_id_l"] == df_chunked["unique_id_l"]
@@ -427,9 +427,9 @@ def test_chunked_predict_link_only(test_helpers, dialect, fake_1000):
             num_chunks_right=num_right,
         )
 
-        assert (
-            _get_comparison_count(predictions) == baseline_count
-        ), f"Chunk config ({num_left}, {num_right}) produced different count"
+        assert _get_comparison_count(predictions) == baseline_count, (
+            f"Chunk config ({num_left}, {num_right}) produced different count"
+        )
 
         df_chunked = _sort_predictions(predictions)
         assert df_baseline["unique_id_l"] == df_chunked["unique_id_l"]
@@ -475,9 +475,9 @@ def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, fake_10
             num_chunks_right=num_right,
         )
 
-        assert (
-            _get_comparison_count(predictions) == baseline_count
-        ), f"Chunk config ({num_left}, {num_right}) produced different count"
+        assert _get_comparison_count(predictions) == baseline_count, (
+            f"Chunk config ({num_left}, {num_right}) produced different count"
+        )
 
         df_chunked = _sort_predictions(predictions)
         assert df_baseline["unique_id_l"] == df_chunked["unique_id_l"]
@@ -519,9 +519,9 @@ def test_chunked_predict_link_and_dedupe(test_helpers, dialect, fake_1000):
             num_chunks_right=num_right,
         )
 
-        assert (
-            _get_comparison_count(predictions) == baseline_count
-        ), f"Chunk config ({num_left}, {num_right}) produced different count"
+        assert _get_comparison_count(predictions) == baseline_count, (
+            f"Chunk config ({num_left}, {num_right}) produced different count"
+        )
 
         df_chunked = _sort_predictions(predictions)
         assert df_baseline["unique_id_l"] == df_chunked["unique_id_l"]
@@ -569,9 +569,9 @@ def test_chunked_predict_link_and_dedupe_three_datasets(
             num_chunks_right=num_right,
         )
 
-        assert (
-            _get_comparison_count(predictions) == baseline_count
-        ), f"Chunk config ({num_left}, {num_right}) produced different count"
+        assert _get_comparison_count(predictions) == baseline_count, (
+            f"Chunk config ({num_left}, {num_right}) produced different count"
+        )
 
         df_chunked = _sort_predictions(predictions)
         assert df_baseline["unique_id_l"] == df_chunked["unique_id_l"]

--- a/tests/test_comparison_level_composition.py
+++ b/tests/test_comparison_level_composition.py
@@ -59,7 +59,7 @@ def binary_composition_internals(clause, c_fun, dialect, q):
     )
     # Default label
     assert level.label_for_charts == (
-        "(Exact match on first_name) " f"{clause} " "(first_name is NULL)"
+        f"(Exact match on first_name) {clause} (first_name is NULL)"
     )
     # should default to False
     assert level.is_null_level is False

--- a/tests/test_em_max_pairs.py
+++ b/tests/test_em_max_pairs.py
@@ -95,9 +95,9 @@ def test_em_max_pairs_reduces_pair_count(test_helpers, dialect, fake_1000, link_
 
     # Sampling should bring the pair count down, roughly to the target.
     assert sampled < unsampled, f"{link_type}: sampling did not reduce pairs"
-    assert (
-        0.4 * target_max_pairs <= sampled <= 1.8 * target_max_pairs
-    ), f"{link_type}: sampled {sampled}, target {target_max_pairs}"
+    assert 0.4 * target_max_pairs <= sampled <= 1.8 * target_max_pairs, (
+        f"{link_type}: sampled {sampled}, target {target_max_pairs}"
+    )
 
 
 @mark_with_dialects_excluding()

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -195,22 +195,22 @@ def test_fix_probabilities(fake_1000):
     exact_match_level = first_name_comparison["comparison_levels"][1]
     levenshtein_level = first_name_comparison["comparison_levels"][2]
 
-    assert (
-        exact_match_level["m_probability"] == 0.9999
-    ), "Exact match m_probability is not as expected"
-    assert (
-        exact_match_level["u_probability"] == 0.001
-    ), "Exact match u_probability is not as expected"
-    assert (
-        levenshtein_level["m_probability"] == 0.88
-    ), "Levenshtein m_probability is not as expected"
+    assert exact_match_level["m_probability"] == 0.9999, (
+        "Exact match m_probability is not as expected"
+    )
+    assert exact_match_level["u_probability"] == 0.001, (
+        "Exact match u_probability is not as expected"
+    )
+    assert levenshtein_level["m_probability"] == 0.88, (
+        "Levenshtein m_probability is not as expected"
+    )
 
     # Check that non-fixed probabilities on the else level have changed
     else_level = first_name_comparison["comparison_levels"][3]
 
-    assert (
-        else_level["m_probability"] != 0.001
-    ), "Else level m_probability should have changed"
-    assert (
-        else_level["u_probability"] != 0.9
-    ), "Else level u_probability should have changed"
+    assert else_level["m_probability"] != 0.001, (
+        "Else level m_probability should have changed"
+    )
+    assert else_level["u_probability"] != 0.9, (
+        "Else level u_probability should have changed"
+    )

--- a/tests/test_full_example_deterministic_link.py
+++ b/tests/test_full_example_deterministic_link.py
@@ -14,8 +14,7 @@ def test_deterministic_link_full_example(fake_1000, dialect, tmp_path, test_help
     br_for_predict = [
         "l.first_name = r.first_name and l.surname = r.surname and l.dob = r.dob",
         "l.surname = r.surname and l.dob = r.dob and l.email = r.email",
-        "l.first_name = r.first_name and l.surname = r.surname "
-        "and l.email = r.email",
+        "l.first_name = r.first_name and l.surname = r.surname and l.email = r.email",
     ]
     settings = {
         "link_type": "dedupe_only",

--- a/tests/test_new_comparison_levels.py
+++ b/tests/test_new_comparison_levels.py
@@ -132,12 +132,7 @@ comparison_name = cl.CustomComparison(
             "label_for_charts": "both names matching",
         },
         cll.CustomLevel(
-            (
-                "levenshtein("
-                "first_name_l || surname_l, "
-                "first_name_r || surname_r"
-                ") <= 3"
-            ),
+            ("levenshtein(first_name_l || surname_l, first_name_r || surname_r) <= 3"),
             "both names fuzzy matching",
         ),
         cll.ExactMatchLevel("first_name"),

--- a/tests/test_new_db_api.py
+++ b/tests/test_new_db_api.py
@@ -23,12 +23,7 @@ comparison_name = cl.CustomComparison(
             "label_for_charts": "both names matching",
         },
         cll.CustomLevel(
-            (
-                "levenshtein("
-                "first_name_l || surname_l, "
-                "first_name_r || surname_r"
-                ") <= 3"
-            ),
+            ("levenshtein(first_name_l || surname_l, first_name_r || surname_r) <= 3"),
             "both names fuzzy matching",
         ),
         cll.ExactMatchLevel("first_name"),

--- a/uv.lock
+++ b/uv.lock
@@ -3521,26 +3521,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.4.10"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/04/b660bc832ebfa40e1788edf6934388340751cbc6f733d1f807edca9d96e6/ruff-0.4.10.tar.gz", hash = "sha256:3aa4f2bc388a30d346c56524f7cacca85945ba124945fe489952aadb6b5cd804", size = 2577674, upload-time = "2024-06-20T17:42:56.184Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/0d/134fdd72f566d37b0c59b6e55f60993c705f93a0fe3c1faa6f8a269057c7/ruff-0.4.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c2c4d0859305ac5a16310eec40e4e9a9dec5dcdfbe92697acd99624e8638dac", size = 8510271, upload-time = "2024-06-20T17:41:49.591Z" },
-    { url = "https://files.pythonhosted.org/packages/46/5e/4ac799ffec39ef5012052c1f144a0f7a63a0322ebd328b802d64beb3d091/ruff-0.4.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a79489607d1495685cdd911a323a35871abfb7a95d4f98fc6f85e799227ac46e", size = 8107776, upload-time = "2024-06-20T17:41:55.14Z" },
-    { url = "https://files.pythonhosted.org/packages/78/6f/37af054d3ced5a6196201f6c248eeaec6b3b844136cf3da510d591dbfd89/ruff-0.4.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1dd1681dfa90a41b8376a61af05cc4dc5ff32c8f14f5fe20dba9ff5deb80cd6", size = 9868358, upload-time = "2024-06-20T17:41:58.162Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/38/070baf0393ba0da9d85409bdd63874776926acfc372e8e9f0ed21957aeee/ruff-0.4.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c75c53bb79d71310dc79fb69eb4902fba804a81f374bc86a9b117a8d077a1784", size = 9172824, upload-time = "2024-06-20T17:42:02.386Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/9d/bad51d81c918e1ce1648b24480a63f5605662efe69b55fad05825b5711ff/ruff-0.4.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18238c80ee3d9100d3535d8eb15a59c4a0753b45cc55f8bf38f38d6a597b9739", size = 9997887, upload-time = "2024-06-20T17:42:06.309Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a4/1310b3d003cb67f3c86cb8cc5c5e475dab152b1eef88558abd11e55daaad/ruff-0.4.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d8f71885bce242da344989cae08e263de29752f094233f932d4f5cfb4ef36a81", size = 10743762, upload-time = "2024-06-20T17:42:11.13Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c1/5373bc5a4c3782c0a368ce5ca4ec3a689574daf71f68f55720a6a64321d4/ruff-0.4.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:330421543bd3222cdfec481e8ff3460e8702ed1e58b494cf9d9e4bf90db52b9d", size = 10329524, upload-time = "2024-06-20T17:42:15.294Z" },
-    { url = "https://files.pythonhosted.org/packages/48/dc/2c057e7717a3eaaa89ea848a26ef085930a2509f9b66ceae55319668c03d/ruff-0.4.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e9b6fb3a37b772628415b00c4fc892f97954275394ed611056a4b8a2631365e", size = 11208593, upload-time = "2024-06-20T17:42:20.077Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c3/3f89b1e967a869642bd9198f27e2b89b8300862555d3e1e39b4ccaf92e8b/ruff-0.4.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f54c481b39a762d48f64d97351048e842861c6662d63ec599f67d515cb417f6", size = 10041835, upload-time = "2024-06-20T17:42:24.487Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/e6/734aed23112de8df5a2f3bc02e9e45cd3910fe83b0d2bb2456e200c52d98/ruff-0.4.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:67fe086b433b965c22de0b4259ddfe6fa541c95bf418499bedb9ad5fb8d1c631", size = 9842683, upload-time = "2024-06-20T17:42:28.324Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/13/bc788b2e21d3e4db74d1375da22f50f944bc1fef064c4749f307b0c8794f/ruff-0.4.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:acfaaab59543382085f9eb51f8e87bac26bf96b164839955f244d07125a982ef", size = 9283929, upload-time = "2024-06-20T17:42:32.221Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/09/f3c6560f9d81a4c5d800996090c9cc54d794ea14ab8f8af46b7483005963/ruff-0.4.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3cea07079962b2941244191569cf3a05541477286f5cafea638cd3aa94b56815", size = 9617526, upload-time = "2024-06-20T17:42:36.588Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/9e/11ae4e8587efe40aa083835665d0818626f8f4a10aa4ebc097cdbfae7624/ruff-0.4.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:338a64ef0748f8c3a80d7f05785930f7965d71ca260904a9321d13be24b79695", size = 10114053, upload-time = "2024-06-20T17:42:41.144Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/94/3bb62a0086e9c61d0506e546e7cf68456fd93bf569a8adfa5e324812970d/ruff-0.4.10-py3-none-win32.whl", hash = "sha256:ffe3cd2f89cb54561c62e5fa20e8f182c0a444934bf430515a4b422f1ab7b7ca", size = 7707741, upload-time = "2024-06-20T17:42:45.061Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/4e/6fd32ebd0a09f25ed9911b77c5273b7a6b3b50a78d6ed0508d66a24398b8/ruff-0.4.10-py3-none-win_amd64.whl", hash = "sha256:67f67cef43c55ffc8cc59e8e0b97e9e60b4837c8f21e8ab5ffd5d66e196e25f7", size = 8519153, upload-time = "2024-06-20T17:42:48.907Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/78/5109b7db3b44a64157b025e45eec6591e4beb53732104637d8e0ee0c5570/ruff-0.4.10-py3-none-win_arm64.whl", hash = "sha256:dd1fcee327c20addac7916ca4e2653fbbf2e8388d8a6477ce5b4e986b68ae6c0", size = 7906942, upload-time = "2024-06-20T17:42:52.972Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]
@@ -3878,7 +3879,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
     { name = "rapidfuzz", specifier = ">=3.10.0" },
-    { name = "ruff", specifier = ">=0.4.2,<0.5" },
+    { name = "ruff", specifier = ">=0.15.18" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
 docs = [
@@ -3896,7 +3897,7 @@ docs = [
     { name = "neoteroi-mkdocs", marker = "python_full_version >= '3.13'", specifier = ">=1.1.2" },
     { name = "pymdown-extensions", marker = "python_full_version >= '3.13'", specifier = ">=10.15" },
 ]
-linting = [{ name = "ruff", specifier = ">=0.4.2,<0.5" }]
+linting = [{ name = "ruff", specifier = ">=0.15.18" }]
 pandas = [
     { name = "numpy", specifier = ">=1.19.3" },
     { name = "pandas", specifier = ">=1.3.5" },


### PR DESCRIPTION
We have been on `ruff` version `0.4.10` (released 20/06/24 - nover 2 years ago!) for some time, as we capped it to `<0.5`.

This brings us to a near-latest version. Given the minimal change required to the codebase to conform (and most of the changes here are due to formatting), it seems sensible to allow dependabot to manage the bumps to `ruff`, and we can manually adjust the code when a version bump causes a failure, which should generally be small. As such, this uncapps the version.