### PR TITLE
Comparison viewer: DuckDB speedup

### DIFF
--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -84,11 +84,79 @@ def row_examples(
     return sqls
 
 
+def _duckdb_comparison_viewer_table_sqls(
+    linker: Linker,
+    example_rows_per_category: int = 2,
+    minimum_comparison_vector_count: int = 0,
+) -> list[dict[str, str]]:
+    uid_cols = linker._settings_obj.column_info_settings.unique_id_input_columns
+    uid_cols_l = [uid_col.name_l for uid_col in uid_cols]
+    uid_cols_r = [uid_col.name_r for uid_col in uid_cols]
+    uid_col_lr_names = uid_cols_l + uid_cols_r
+    uid_expr = " || '-' ||".join(f"pred.{name}" for name in uid_col_lr_names)
+
+    gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
+    gam_concat = " || ',' || ".join(gamma_columns)
+    groupby_cols = " , ".join(gamma_columns)
+
+    # See https://github.com/moj-analytical-services/splink/issues/1651
+    # This ensures we have an average match weight that isn't affected by tf
+    mw_columns_no_tf = [c._mw_column_name for c in linker._settings_obj.comparisons]
+
+    p = linker._settings_obj._probability_two_random_records_match
+    mw_final_no_tf = _combine_prior_and_mws(
+        p,
+        mw_terms=mw_columns_no_tf,
+        sql_dialect=linker._db_api.sql_dialect,
+    )[0]
+
+    sql = f"""
+    select pred.*,
+           {uid_expr} as rec_comparison_id,
+           keys.gam_concat as gam_concat,
+           {mw_final_no_tf} as sort_avg_match_weight,
+           random() as rand_order,
+           row_number() over (
+               partition by keys.gam_concat order by pred.rowid
+           ) as row_example_index,
+           cvd.sum_gam,
+           cvd.count_rows_in_comparison_vector_group as count,
+           cvd.proportion_of_comparisons
+    from (
+        select
+            {gam_concat} as gam_concat,
+            unnest(arg_min(rowid, rowid, {example_rows_per_category}))
+                as example_rowid
+        from __splink__df_predict
+        group by {groupby_cols}
+        having count(*) >= {minimum_comparison_vector_count}
+    ) as keys
+    inner join __splink__df_predict as pred
+        on pred.rowid = keys.example_rowid
+    left join __splink__df_comparison_vector_distribution as cvd
+        on keys.gam_concat = cvd.gam_concat
+    """
+
+    return [
+        {
+            "sql": sql,
+            "output_table_name": "__splink__df_comparison_viewer_table",
+        }
+    ]
+
+
 def comparison_viewer_table_sqls(
     linker: Linker,
     example_rows_per_category: int = 2,
     minimum_comparison_vector_count: int = 0,
 ) -> list[dict[str, str]]:
+    if linker._db_api.sql_dialect.sql_dialect_str == "duckdb":
+        return _duckdb_comparison_viewer_table_sqls(
+            linker,
+            example_rows_per_category,
+            minimum_comparison_vector_count,
+        )
+
     sqls = row_examples(linker, example_rows_per_category)
 
     sql = f"""


### PR DESCRIPTION
`comparison_viewer_dashboard()` has always been quite slow to run.

The problem is that it turns out its surprisingly hard to quickly select a few example rows from each comparison vector; there doesn't appear to be a backend-agnostic way of 'phrasing' the SQL that makes it run fast across engines.

In this PR I use DuckDB-specific SQL to substantially speed up the generation of the dashboard.  The gains are greatest when:
- `predict()` has returned a large number of comparison pairs
- `minimum_comparison_vector_count` > 1

On a test workflow, with 50 million comparisons, we saw the code run between 1.6x and 6x faster (best case 6 seconds -> 1 second).  Gains are even larger where there are few comparison vector combinations.

I did try to find similar optimisations in Spark, but I couldn't find anything where the code was simple enough to be worth it
