### PR TITLE
Python speedups

### DIFF
--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -110,9 +110,7 @@ def _input_columns_used_by_sql_condition_cached(
     cols = cols[::-1]
     cols = [re.sub(r"_L$|_R$", "", c, flags=re.IGNORECASE) for c in cols]
     cols = dedupe_preserving_order(cols)
-    return tuple(
-        InputColumn(c, sqlglot_dialect_str=sqlglot_dialect) for c in cols
-    )
+    return tuple(InputColumn(c, sqlglot_dialect_str=sqlglot_dialect) for c in cols)
 
 
 def _default_u_values(num_levels: int) -> list[float]:

--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -5,6 +5,7 @@ import math
 import re
 from copy import copy
 from dataclasses import asdict, dataclass
+from functools import lru_cache
 from statistics import median
 from textwrap import dedent
 from typing import Any, Optional, Union, cast
@@ -98,6 +99,20 @@ def _default_m_values(num_levels: int) -> list[float]:
     remainder = 1 - proportion_exact_match
     split_remainder = remainder / (num_levels - 1)
     return [split_remainder] * (num_levels - 1) + [proportion_exact_match]
+
+
+@lru_cache(maxsize=None)
+def _input_columns_used_by_sql_condition_cached(
+    sql_condition: str, sqlglot_dialect: str
+) -> tuple[InputColumn, ...]:
+    cols = get_columns_used_from_sql(sql_condition, sqlglot_dialect=sqlglot_dialect)
+    # Parsed order seems to be roughly in reverse order of apearance
+    cols = cols[::-1]
+    cols = [re.sub(r"_L$|_R$", "", c, flags=re.IGNORECASE) for c in cols]
+    cols = dedupe_preserving_order(cols)
+    return tuple(
+        InputColumn(c, sqlglot_dialect_str=sqlglot_dialect) for c in cols
+    )
 
 
 def _default_u_values(num_levels: int) -> list[float]:
@@ -534,24 +549,15 @@ class ComparisonLevel:
         if self._is_else_level:
             return []
 
-        cols = get_columns_used_from_sql(
-            self.sql_condition, sqlglot_dialect=self.sqlglot_dialect
+        # We could have tf adjustments for surname on a dmeta_surname column.
+        # If so, we want to set the tf adjustments against the surname col,
+        # not the dmeta_surname one.  Return a fresh list so callers cannot mutate
+        # the cached tuple.
+        return list(
+            _input_columns_used_by_sql_condition_cached(
+                self.sql_condition, self.sqlglot_dialect
+            )
         )
-        # Parsed order seems to be roughly in reverse order of apearance
-        cols = cols[::-1]
-
-        cols = [re.sub(r"_L$|_R$", "", c, flags=re.IGNORECASE) for c in cols]
-        cols = dedupe_preserving_order(cols)
-
-        input_cols = []
-        for c in cols:
-            # We could have tf adjustments for surname on a dmeta_surname column
-            # If so, we want to set the tf adjustments against the surname col,
-            # not the dmeta_surname one
-
-            input_cols.append(InputColumn(c, sqlglot_dialect_str=self.sqlglot_dialect))
-
-        return input_cols
 
     @property
     def _columns_to_select_for_blocking(self):

--- a/splink/internals/input_column.py
+++ b/splink/internals/input_column.py
@@ -13,6 +13,24 @@ if TYPE_CHECKING:
     from splink.internals.settings import ColumnInfoSettings
 
 
+_VALID_COLUMN_SIGNATURES: Optional[set[str]] = None
+
+
+def _valid_column_signatures() -> set[str]:
+    """Return the constant set of signatures accepted as plain column references."""
+    global _VALID_COLUMN_SIGNATURES
+    if _VALID_COLUMN_SIGNATURES is None:
+        _VALID_COLUMN_SIGNATURES = {
+            sqlglot_tree_signature(sqlglot.parse_one("col_name")),
+            # negative indices are valid in certain contexts (postgres custom indexing,
+            # duckdb), and are treated separately in newer sqlglot versions (28.7.0+)
+            sqlglot_tree_signature(sqlglot.parse_one("col_name[-1]")),
+            sqlglot_tree_signature(sqlglot.parse_one("col_name[1]")),
+            sqlglot_tree_signature(sqlglot.parse_one("col_name['lat']")),
+        }
+    return _VALID_COLUMN_SIGNATURES
+
+
 @dataclass(frozen=True)
 class SqlglotColumnTreeBuilder:
     """
@@ -101,14 +119,7 @@ class SqlglotColumnTreeBuilder:
             else:
                 return f"{q_s}{input_str}{q_e}"
 
-        valid_signatures = {
-            sqlglot_tree_signature(sqlglot.parse_one("col_name")),
-            # negative indices are valid in certain contexts (postgres custom indexing,
-            # duckdb), and are treated separately in newer sqlglot versions (28.7.0+)
-            sqlglot_tree_signature(sqlglot.parse_one("col_name[-1]")),
-            sqlglot_tree_signature(sqlglot.parse_one("col_name[1]")),
-            sqlglot_tree_signature(sqlglot.parse_one("col_name['lat']")),
-        }
+        valid_signatures = _valid_column_signatures()
 
         # If the raw string parses to a valid signature, use it
         try:


### PR DESCRIPTION
This PR implements two small, behaviour-preserving sqlglot caches that were the lowest-hanging fruit from profiling the DuckDB end-to-end workload.

The benefit can be seen from some of the tests e.g. 

Before:
```
3.42s call     tests/test_full_example_duckdb.py::test_full_example_duckdb
```

After:
```
2.65s call     tests/test_full_example_duckdb.py::test_full_example_duckdb
```


Profiling showed only ~24% of runtime was DuckDB native execution (0.210s/run); ~76% was Python overhead (0.665s/run), and sqlglot alone accounted for ~52% of Python self-time. These two paths were chosen because they were repeated parsing on constant or effectively immutable inputs:

- Hoist the constant `valid_signatures` set in `input_column.py`. This was the single biggest hotspot, rebuilding four constant `sqlglot.parse_one()` signatures on every `InputColumn` construction, about 8,700 times per run. Isolated saving: about 25%.
- Cache `_input_columns_used_by_sql_condition` in `comparison_level.py`, keyed by `(sql_condition, sqlglot_dialect)`. This property was re-parsing the same SQL and rebuilding `InputColumn` objects on every access, including every EM iteration. Isolated saving: about 27%.

Together these two targeted changes remove the most obvious repeated sqlglot work, with a combined reduction of about 34% in the sqlglot-heavy portion of the workload, without changing behaviour.