### PR TITLE
Fix 3038

### DIFF
--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -505,7 +505,7 @@ class ComparisonLevel:
             return False
 
         sql_syntax_tree = sqlglot.parse_one(
-            self.sql_condition.lower(), read=self.sqlglot_dialect
+            self.sql_condition, read=self.sqlglot_dialect
         )
         sql_cnf = simplify(normalize(sql_syntax_tree))
 
@@ -518,7 +518,7 @@ class ComparisonLevel:
     @property
     def _exact_match_colnames(self):
         sql_syntax_tree = sqlglot.parse_one(
-            self.sql_condition.lower(), read=self.sqlglot_dialect
+            self.sql_condition, read=self.sqlglot_dialect
         )
         sql_cnf = simplify(normalize(sql_syntax_tree))
 

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -204,32 +204,36 @@ def test_deactivate_columns_with_case_variation():
 
     linker = Linker(df, settings, db_api=db_api)
 
-    ts1 = linker.training.estimate_parameters_using_expectation_maximisation(block_on("DOB"))
+    ts1 = linker.training.estimate_parameters_using_expectation_maximisation(
+        block_on("DOB"),
+    )
 
     deactivated = [
         cc.output_column_name for cc in ts1._comparisons_that_cannot_be_estimated
     ]
 
     # no m probabilities should be trained for the DOB comparison
-    assert "DOB" in deactivated, (
-        "DOB is used in blocking rule so its parameters should not be trained"
-    )
+    assert (
+        "DOB" in deactivated
+    ), "DOB is used in blocking rule so its parameters should not be trained"
 
     # training session should adjust probability using DOB despite upper case
     ts_prob = ts1._lambda_history_records[0]["probability_two_random_records_match"]
     orig_prob = settings.probability_two_random_records_match
     assert ts_prob > orig_prob, (
-        "probability_two_random_records_match should be adjusted for comparison used in "
-        "blocking rule"
+        "probability_two_random_records_match should be adjusted for comparison "
+        "used in blocking rule"
     )
 
-    ts2 = linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))
+    ts2 = linker.training.estimate_parameters_using_expectation_maximisation(
+        block_on("dob"),
+    )
 
     deactivated = [
         cc.output_column_name for cc in ts2._comparisons_that_cannot_be_estimated
     ]
 
-    assert not "DOB" in deactivated, (
+    assert "DOB" not in deactivated, (
         "DOB (upper case) is not used in the blocking rule so its parameters should "
         "be trained."
     )
@@ -241,5 +245,3 @@ def test_deactivate_columns_with_case_variation():
         "probability_two_random_records_match should not be adjusted since blocking "
         "rule uses dob (lower case) while comparison is DOB (upper case)."
     )
-
-

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -180,3 +180,66 @@ def test_fix_probabilities():
     assert (
         else_level["u_probability"] != 0.9
     ), "Else level u_probability should have changed"
+
+
+def test_deactivate_columns_with_case_variation():
+    # rename a column to be all caps
+    fake_1000 = pd.read_csv("./tests/datasets/fake_1000_from_splink_demos.csv")
+    df = fake_1000.rename(columns={"dob": "DOB"})
+
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("DOB"),
+        ],
+        blocking_rules_to_generate_predictions=[
+            block_on("first_name"),
+        ],
+        additional_columns_to_retain=["cluster"],
+    )
+
+    db_api = DuckDBAPI()
+
+    linker = Linker(df, settings, db_api=db_api)
+
+    ts1 = linker.training.estimate_parameters_using_expectation_maximisation(block_on("DOB"))
+
+    deactivated = [
+        cc.output_column_name for cc in ts1._comparisons_that_cannot_be_estimated
+    ]
+
+    # no m probabilities should be trained for the DOB comparison
+    assert "DOB" in deactivated, (
+        "DOB is used in blocking rule so its parameters should not be trained"
+    )
+
+    # training session should adjust probability using DOB despite upper case
+    ts_prob = ts1._lambda_history_records[0]["probability_two_random_records_match"]
+    orig_prob = settings.probability_two_random_records_match
+    assert ts_prob > orig_prob, (
+        "probability_two_random_records_match should be adjusted for comparison used in "
+        "blocking rule"
+    )
+
+    ts2 = linker.training.estimate_parameters_using_expectation_maximisation(block_on("dob"))
+
+    deactivated = [
+        cc.output_column_name for cc in ts2._comparisons_that_cannot_be_estimated
+    ]
+
+    assert not "DOB" in deactivated, (
+        "DOB (upper case) is not used in the blocking rule so its parameters should "
+        "be trained."
+    )
+
+    # training session should not adjust probability because of case
+    ts_prob = ts2._lambda_history_records[0]["probability_two_random_records_match"]
+    orig_prob = settings.probability_two_random_records_match
+    assert ts_prob == orig_prob, (
+        "probability_two_random_records_match should not be adjusted since blocking "
+        "rule uses dob (lower case) while comparison is DOB (upper case)."
+    )
+
+

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -93,7 +93,7 @@ email_comparison_to_check = {
         {"sql_condition": "email_l IS NULL OR email_r IS NULL"},
         {"sql_condition": "levenshtein(emails_l, test.email_r) < 3"},
         {"sql_condition": "date_diff('day', email_date, email_lz)"},
-        {"sql_condition": "\"EMAIL_l\" = \"EMAIL_r\""},
+        {"sql_condition": '"EMAIL_l" = "EMAIL_r"'},
         {"sql_condition": "ELSE"},
     ],
 }
@@ -107,7 +107,7 @@ expected_email_comparison_errors = (
             MissingColumnsLogGenerator({"email_date", "email_lz"}),
             InvalidColumnSuffixesLogGenerator({"email_date", "email_lz"}),
         ],
-        "\"EMAIL_l\" = \"EMAIL_r\"" : [
+        '"EMAIL_l" = "EMAIL_r"': [
             MissingColumnsLogGenerator({"EMAIL"}),
         ],
     },

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -93,6 +93,7 @@ email_comparison_to_check = {
         {"sql_condition": "email_l IS NULL OR email_r IS NULL"},
         {"sql_condition": "levenshtein(emails_l, test.email_r) < 3"},
         {"sql_condition": "date_diff('day', email_date, email_lz)"},
+        {"sql_condition": "\"EMAIL_l\" = \"EMAIL_r\""},
         {"sql_condition": "ELSE"},
     ],
 }
@@ -105,6 +106,9 @@ expected_email_comparison_errors = (
         "date_diff('day', email_date, email_lz)": [
             MissingColumnsLogGenerator({"email_date", "email_lz"}),
             InvalidColumnSuffixesLogGenerator({"email_date", "email_lz"}),
+        ],
+        "\"EMAIL_l\" = \"EMAIL_r\"" : [
+            MissingColumnsLogGenerator({"EMAIL"}),
         ],
     },
 )


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?
Fixes #3038 and #2706.


### Give a brief description for the solution you have provided

This is a very small change to decide not to lower case some SQL strings in comparison_level.py, but the added tests clarify what I think is supposed to happen in these situations. 

Here's how I interpreted the expected behaviour:
- If you use a column (e.g. "EMAIL") in a comparison / blocking rule, and the input dataframes have a column in the same name but lower case (e.g. "email") then Splink should give you the missing columns warning. Splink already did this but it was never tested for.
- If you write your code with consistent cases for all the columns then they should be correctly deselected when running EM training and the probability two random records match should be adjusted using that comparison. This was the bug in the two mentioned issues.
- (this is the one I'm least sure about) if you use inconsistent cases Splink should treat them with the possibility that they are different columns, e.g. if a comparison uses "DOB" and you run EM training blocking on "dob" then it should **not** deselect the "DOB" comparison and it should **not** adjust the probability two random records match using that comparison. In some backends when you quote a column name it can be case-sensitive (e.g. Postgres https://www.postgresql.org/docs/18/sql-syntax-lexical.html, see the part about quoted identifiers).

I've made this PR for splink4_maintenance because it's a small bug fix and might be well-suited for a final Splink 4 release.

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the [linter](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/lint_and_format.html)
- [ ] Run the [spellchecker](https://moj-analytical-services.github.io/splink/dev_guides/changing_splink/contributing_to_docs.html?h=spellch#spellchecking-docs) (if appropriate)


