### PR TITLE
Cosine similarity in spark

### DIFF
--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -931,8 +931,13 @@ class CosineSimilarityLevel(ComparisonLevelCreator):
     def create_sql(self, sql_dialect: SplinkDialect) -> str:
         self.col_expression.sql_dialect = sql_dialect
         col = self.col_expression
-        cs_fn = sql_dialect.cosine_similarity_function_name
-        return f"{cs_fn}({col.name_l}, {col.name_r}) >= {self.similarity_threshold}"
+        cosine_similarity_sql = getattr(sql_dialect, "cosine_similarity_sql", None)
+        if cosine_similarity_sql is not None:
+            cs_sql = cosine_similarity_sql(col.name_l, col.name_r)
+        else:
+            cs_fn = sql_dialect.cosine_similarity_function_name
+            cs_sql = f"{cs_fn}({col.name_l}, {col.name_r})"
+        return f"{cs_sql} >= {self.similarity_threshold}"
 
     def create_label_for_charts(self) -> str:
         col = self.col_expression

--- a/splink/internals/dialects.py
+++ b/splink/internals/dialects.py
@@ -399,6 +399,26 @@ class SparkDialect(SplinkDialect):
     def sql_dialect_str(self):
         return "spark"
 
+    def cosine_similarity_sql(self, col_l: str, col_r: str) -> str:
+        # Spark has no native array cosine similarity function, so it is
+        # computed using Spark SQL's higher-order array functions
+        # (zip_with/transform/aggregate), which are natively supported.
+        dot_product = (
+            f"aggregate(zip_with({col_l}, {col_r}, (x, y) -> x * y), "
+            "CAST(0.0 AS DOUBLE), (acc, x) -> acc + x)"
+        )
+        norm_l = (
+            f"sqrt(aggregate(transform({col_l}, x -> x * x), "
+            "CAST(0.0 AS DOUBLE), (acc, x) -> acc + x))"
+        )
+        norm_r = (
+            f"sqrt(aggregate(transform({col_r}, x -> x * x), "
+            "CAST(0.0 AS DOUBLE), (acc, x) -> acc + x))"
+        )
+
+        denominator = f"nullif(({norm_l}) * ({norm_r}), 0.0)"
+        return f"({dot_product}) / ({denominator})"
+
     @property
     def levenshtein_function_name(self):
         return "levenshtein"

--- a/tests/test_comparison_level_lib.py
+++ b/tests/test_comparison_level_lib.py
@@ -365,14 +365,12 @@ def test_absolute_difference(test_helpers, dialect):
     run_comparison_vector_value_tests(test_cases, db_api)
 
 
-@mark_with_dialects_including("duckdb", pass_dialect=True)
+@mark_with_dialects_including("duckdb", "spark", pass_dialect=True)
 def test_cosine_similarity_level(test_helpers, dialect):
     import pyarrow as pa
 
     helper = test_helpers[dialect]
     db_api = helper.db_api()
-
-    EMBEDDING_DIMENSION = 4
 
     cosine_similarity_comparison_using_levels = cl.CustomComparison(
         comparison_description="text_vector",
@@ -419,17 +417,20 @@ def test_cosine_similarity_level(test_helpers, dialect):
     ]
 
     # Convert input_dicts to a pyarrow Table
-    inputs_pa = pa.Table.from_pydict(
-        {
-            "text_vector_l": [d["text_vector_l"] for d in input_dicts],
-            "text_vector_r": [d["text_vector_r"] for d in input_dicts],
-            "expected_value": [d["expected_value"] for d in input_dicts],
-            "expected_label": [d["expected_label"] for d in input_dicts],
-        },
+    inputs_pa = pa.Table.from_pylist(
+        [
+            {
+                "text_vector_l": d["text_vector_l"],
+                "text_vector_r": d["text_vector_r"],
+                "expected_value": d["expected_value"],
+                "expected_label": d["expected_label"],
+            }
+            for d in input_dicts
+        ],
         schema=pa.schema(
             [
-                ("text_vector_l", pa.list_(pa.float32(), EMBEDDING_DIMENSION)),
-                ("text_vector_r", pa.list_(pa.float32(), EMBEDDING_DIMENSION)),
+                ("text_vector_l", pa.list_(pa.float64(), 4)),
+                ("text_vector_r", pa.list_(pa.float64(), 4)),
                 ("expected_value", pa.int16()),
                 ("expected_label", pa.string()),
             ]


### PR DESCRIPTION
Splink currently includes `CosineSimilarityAtThresholds` / `CosineSimilarityLevel` for DuckDB only. 

This adds Spark support 

Note `CosineDistance` in [splink_scalaudfs](https://github.com/moj-analytical-services/splink_scalaudfs/blob/904bc83807ffea4084fa81696c62a90f4031e5e5/src/main/scala/uk/gov/moj/dash/linkage/Similarity.scala#L188) is **not** an embeddings function, it works on strings.



Closes https://github.com/moj-analytical-services/splink/issues/1011