### PR TITLE
Allow match weight in settings 4

### DIFF
--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -206,7 +206,7 @@ class ComparisonLevel:
         self._tf_minimum_u_value = tf_minimum_u_value
         self._disable_tf_exact_match_detection = disable_tf_exact_match_detection
 
-        self._match_weight_value = match_weight
+        self._configured_match_weight = match_weight
 
         # internally these can be LEVEL_NOT_OBSERVED_TEXT, so allow for this
         _validate_m_u_probability(
@@ -273,7 +273,7 @@ class ComparisonLevel:
 
     @property
     def m_probability(self) -> float | None:
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             return None
         if self.is_null_level:
             raise ValueError("Null levels have no m-probability")
@@ -286,7 +286,7 @@ class ComparisonLevel:
 
     @m_probability.setter
     def m_probability(self, value: float | str | None) -> None:
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             raise AttributeError(
                 "Cannot set m_probability on a level configured with match_weight"
             )
@@ -297,7 +297,7 @@ class ComparisonLevel:
 
     @property
     def u_probability(self) -> float | None:
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             return None
         if self.is_null_level:
             raise ValueError("Null levels have no u-probability")
@@ -310,7 +310,7 @@ class ComparisonLevel:
 
     @u_probability.setter
     def u_probability(self, value: float | str | None) -> None:
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             raise AttributeError(
                 "Cannot set u_probability on a level configured with match_weight"
             )
@@ -356,14 +356,14 @@ class ComparisonLevel:
             return ""
 
     def _add_trained_u_probability(self, val, desc="no description given"):
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             return
         self._trained_u_probabilities.append(
             {"probability": val, "description": desc, "m_or_u": "u"}
         )
 
     def _add_trained_m_probability(self, val, desc="no description given"):
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             return
         self._trained_m_probabilities.append(
             {"probability": val, "description": desc, "m_or_u": "m"}
@@ -407,7 +407,7 @@ class ComparisonLevel:
 
     @property
     def _m_is_trained(self):
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             return True
         if self.is_null_level:
             return True
@@ -419,7 +419,7 @@ class ComparisonLevel:
 
     @property
     def _u_is_trained(self):
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             return True
         if self.is_null_level:
             return True
@@ -434,26 +434,27 @@ class ComparisonLevel:
         return self._m_is_trained and self._u_is_trained
 
     @property
-    def _is_match_weight_mode(self) -> bool:
-        return self._match_weight_value is not None
+    def is_match_weight_mode(self) -> bool:
+        """Whether this level was configured directly with a match weight."""
+        return self._configured_match_weight is not None
 
     @property
     def _m_probability_is_fixed(self) -> bool:
-        return self._fix_m_probability or self._is_match_weight_mode
+        return self._fix_m_probability or self.is_match_weight_mode
 
     @property
     def _u_probability_is_fixed(self) -> bool:
-        return self._fix_u_probability or self._is_match_weight_mode
+        return self._fix_u_probability or self.is_match_weight_mode
 
     @property
     def match_weight(self) -> float | None:
-        """The level's score in log2 Bayes-factor space."""
+        """The effective score used during prediction, in log2 Bayes-factor space."""
         return self._match_weight
 
     @property
     def _match_weight(self):
-        if self._is_match_weight_mode:
-            return self._match_weight_value
+        if self.is_match_weight_mode:
+            return self._configured_match_weight
         if self.is_null_level:
             return 0.0
 
@@ -472,9 +473,9 @@ class ComparisonLevel:
 
     @property
     def _bayes_factor(self):
-        if self._is_match_weight_mode:
+        if self.is_match_weight_mode:
             try:
-                return 2.0 ** cast(float, self._match_weight_value)
+                return 2.0 ** cast(float, self._configured_match_weight)
             except OverflowError:
                 return math.inf
         if self.is_null_level:
@@ -488,8 +489,8 @@ class ComparisonLevel:
 
     @property
     def _log2_bayes_factor(self):
-        if self._is_match_weight_mode:
-            return self._match_weight_value
+        if self.is_match_weight_mode:
+            return self._configured_match_weight
         if self.is_null_level:
             return 0.0
         else:
@@ -785,8 +786,8 @@ class ComparisonLevel:
         if self.label_for_charts:
             output["label_for_charts"] = self.label_for_charts
 
-        if self._is_match_weight_mode:
-            output["match_weight"] = self._match_weight_value
+        if self.is_match_weight_mode:
+            output["match_weight"] = self._configured_match_weight
         else:
             if self._m_probability is not None and self._m_is_trained:
                 output["m_probability"] = self.m_probability
@@ -872,10 +873,10 @@ class ComparisonLevel:
     def _validate(self):
         self._validate_sql()
 
-        if self._match_weight_value is None:
+        if self._configured_match_weight is None:
             return
 
-        match_weight = self._match_weight_value
+        match_weight = self._configured_match_weight
         is_finite_real = False
         if isinstance(match_weight, Real) and not isinstance(match_weight, bool):
             try:

--- a/splink/internals/comparison_level.py
+++ b/splink/internals/comparison_level.py
@@ -5,6 +5,7 @@ import math
 import re
 from copy import copy
 from dataclasses import asdict, dataclass
+from numbers import Real
 from statistics import median
 from textwrap import dedent
 from typing import Any, Optional, Union, cast
@@ -189,6 +190,7 @@ class ComparisonLevel:
         tf_minimum_u_value: float = 0.0,
         m_probability: float | None = None,
         u_probability: float | None = None,
+        match_weight: float | None = None,
         disable_tf_exact_match_detection: bool = False,
         fix_m_probability: bool = False,
         fix_u_probability: bool = False,
@@ -203,6 +205,8 @@ class ComparisonLevel:
         self._tf_adjustment_weight = tf_adjustment_weight
         self._tf_minimum_u_value = tf_minimum_u_value
         self._disable_tf_exact_match_detection = disable_tf_exact_match_detection
+
+        self._match_weight_value = match_weight
 
         # internally these can be LEVEL_NOT_OBSERVED_TEXT, so allow for this
         _validate_m_u_probability(
@@ -269,6 +273,8 @@ class ComparisonLevel:
 
     @property
     def m_probability(self) -> float | None:
+        if self._is_match_weight_mode:
+            return None
         if self.is_null_level:
             raise ValueError("Null levels have no m-probability")
         if self._m_probability == LEVEL_NOT_OBSERVED_TEXT:
@@ -280,6 +286,10 @@ class ComparisonLevel:
 
     @m_probability.setter
     def m_probability(self, value: float | str | None) -> None:
+        if self._is_match_weight_mode:
+            raise AttributeError(
+                "Cannot set m_probability on a level configured with match_weight"
+            )
         if self.is_null_level:
             raise AttributeError("Cannot set m_probability when is_null_level is true")
         _validate_m_u_probability(value, "m_probability", LEVEL_NOT_OBSERVED_TEXT)
@@ -287,6 +297,8 @@ class ComparisonLevel:
 
     @property
     def u_probability(self) -> float | None:
+        if self._is_match_weight_mode:
+            return None
         if self.is_null_level:
             raise ValueError("Null levels have no u-probability")
         if self._u_probability == LEVEL_NOT_OBSERVED_TEXT:
@@ -298,6 +310,10 @@ class ComparisonLevel:
 
     @u_probability.setter
     def u_probability(self, value: float | str | None) -> None:
+        if self._is_match_weight_mode:
+            raise AttributeError(
+                "Cannot set u_probability on a level configured with match_weight"
+            )
         if self.is_null_level:
             raise AttributeError("Cannot set u_probability when is_null_level is true")
         _validate_m_u_probability(value, "u_probability", LEVEL_NOT_OBSERVED_TEXT)
@@ -340,11 +356,15 @@ class ComparisonLevel:
             return ""
 
     def _add_trained_u_probability(self, val, desc="no description given"):
+        if self._is_match_weight_mode:
+            return
         self._trained_u_probabilities.append(
             {"probability": val, "description": desc, "m_or_u": "u"}
         )
 
     def _add_trained_m_probability(self, val, desc="no description given"):
+        if self._is_match_weight_mode:
+            return
         self._trained_m_probabilities.append(
             {"probability": val, "description": desc, "m_or_u": "m"}
         )
@@ -387,6 +407,8 @@ class ComparisonLevel:
 
     @property
     def _m_is_trained(self):
+        if self._is_match_weight_mode:
+            return True
         if self.is_null_level:
             return True
         if self._m_probability == LEVEL_NOT_OBSERVED_TEXT:
@@ -397,6 +419,8 @@ class ComparisonLevel:
 
     @property
     def _u_is_trained(self):
+        if self._is_match_weight_mode:
+            return True
         if self.is_null_level:
             return True
         if self._u_probability == LEVEL_NOT_OBSERVED_TEXT:
@@ -410,7 +434,26 @@ class ComparisonLevel:
         return self._m_is_trained and self._u_is_trained
 
     @property
+    def _is_match_weight_mode(self) -> bool:
+        return self._match_weight_value is not None
+
+    @property
+    def _m_probability_is_fixed(self) -> bool:
+        return self._fix_m_probability or self._is_match_weight_mode
+
+    @property
+    def _u_probability_is_fixed(self) -> bool:
+        return self._fix_u_probability or self._is_match_weight_mode
+
+    @property
+    def match_weight(self) -> float | None:
+        """The level's score in log2 Bayes-factor space."""
+        return self._match_weight
+
+    @property
     def _match_weight(self):
+        if self._is_match_weight_mode:
+            return self._match_weight_value
         if self.is_null_level:
             return 0.0
 
@@ -429,6 +472,11 @@ class ComparisonLevel:
 
     @property
     def _bayes_factor(self):
+        if self._is_match_weight_mode:
+            try:
+                return 2.0 ** cast(float, self._match_weight_value)
+            except OverflowError:
+                return math.inf
         if self.is_null_level:
             return 1.0
         if self.m_probability is None or self.u_probability is None:
@@ -440,6 +488,8 @@ class ComparisonLevel:
 
     @property
     def _log2_bayes_factor(self):
+        if self._is_match_weight_mode:
+            return self._match_weight_value
         if self.is_null_level:
             return 0.0
         else:
@@ -735,14 +785,17 @@ class ComparisonLevel:
         if self.label_for_charts:
             output["label_for_charts"] = self.label_for_charts
 
-        if self._m_probability is not None and self._m_is_trained:
-            output["m_probability"] = self.m_probability
+        if self._is_match_weight_mode:
+            output["match_weight"] = self._match_weight_value
+        else:
+            if self._m_probability is not None and self._m_is_trained:
+                output["m_probability"] = self.m_probability
 
-        if self._u_probability is not None and self._u_is_trained:
-            output["u_probability"] = self.u_probability
+            if self._u_probability is not None and self._u_is_trained:
+                output["u_probability"] = self.u_probability
 
-        output["fix_m_probability"] = self._fix_m_probability
-        output["fix_u_probability"] = self._fix_u_probability
+            output["fix_m_probability"] = self._fix_m_probability
+            output["fix_u_probability"] = self._fix_u_probability
 
         if self._has_tf_adjustments:
             output["tf_adjustment_column"] = self._tf_adjustment_input_column.input_name
@@ -818,6 +871,38 @@ class ComparisonLevel:
 
     def _validate(self):
         self._validate_sql()
+
+        if self._match_weight_value is None:
+            return
+
+        match_weight = self._match_weight_value
+        is_finite_real = False
+        if isinstance(match_weight, Real) and not isinstance(match_weight, bool):
+            try:
+                is_finite_real = math.isfinite(match_weight)
+            except (OverflowError, TypeError):
+                pass
+        if not is_finite_real:
+            raise ValueError("match_weight must be a finite number")
+
+        if self._m_probability is not None or self._u_probability is not None:
+            raise ValueError(
+                "match_weight cannot be combined with m_probability or u_probability"
+            )
+
+        if self._fix_m_probability or self._fix_u_probability:
+            raise ValueError(
+                "match_weight cannot be combined with fix_m_probability or "
+                "fix_u_probability"
+            )
+
+        if self._has_tf_adjustments:
+            message = (
+                "match_weight cannot be combined with term-frequency adjustments; "
+                "TF adjustments require explicit m_probability and u_probability"
+            )
+            logger.warning(message)
+            raise ValueError(message)
 
     def _abbreviated_sql(self, cutoff=75):
         sql = self.sql_condition

--- a/splink/internals/comparison_level_creator.py
+++ b/splink/internals/comparison_level_creator.py
@@ -74,6 +74,7 @@ class ComparisonLevelCreator(ABC):
         *,
         m_probability: UnsuppliedNoneOr[float] = unsupplied_option,
         u_probability: UnsuppliedNoneOr[float] = unsupplied_option,
+        match_weight: UnsuppliedNoneOr[float] = unsupplied_option,
         tf_adjustment_column: UnsuppliedNoneOr[str] = unsupplied_option,
         tf_adjustment_weight: UnsuppliedNoneOr[float] = unsupplied_option,
         tf_minimum_u_value: UnsuppliedNoneOr[float] = unsupplied_option,
@@ -106,6 +107,9 @@ class ComparisonLevelCreator(ABC):
                 comparison level.
                 Default is equivalent to None, in which case a default initial value
                 will be provided for this level.
+            match_weight (float, optional): A fixed match weight for this comparison
+                level. This is mutually exclusive with m_probability, u_probability,
+                their fix flags, and term-frequency adjustments.
             tf_adjustment_column (str, optional): Make term frequency adjustments for
                 this comparison level using this input column.
                 Default is equivalent to None, meaning that term-frequency adjustments

--- a/splink/internals/comparison_level_library.py
+++ b/splink/internals/comparison_level_library.py
@@ -203,6 +203,7 @@ class CustomLevel(ComparisonLevelCreator):
                 "is_null_level",
                 "m_probability",
                 "u_probability",
+                "match_weight",
                 "tf_adjustment_column",
                 "tf_adjustment_weight",
                 "tf_minimum_u_value",

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -359,7 +359,7 @@ def _max_change_in_parameters_comparison_levels(
             prev_cl = z_cl[0]
             this_cl = z_cl[1]
 
-            if this_cl._is_match_weight_mode:
+            if this_cl.is_match_weight_mode:
                 continue
 
             prev_m_prob = cast(float, prev_cl.m_probability)

--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -149,7 +149,7 @@ def populate_m_u_from_lookup(
 ) -> None:
     cl = comparison_level
 
-    if not cl._fix_m_probability and "m" not in training_fixed_probabilities:
+    if not cl._m_probability_is_fixed and "m" not in training_fixed_probabilities:
         try:
             m_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -168,7 +168,7 @@ def populate_m_u_from_lookup(
                 cl._m_warning_sent = True
         cl.m_probability = m_probability
 
-    if not cl._fix_u_probability and "u" not in training_fixed_probabilities:
+    if not cl._u_probability_is_fixed and "u" not in training_fixed_probabilities:
         try:
             u_probability = m_u_records_lookup[output_column_name][
                 cl.comparison_vector_value
@@ -358,6 +358,9 @@ def _max_change_in_parameters_comparison_levels(
                 continue
             prev_cl = z_cl[0]
             this_cl = z_cl[1]
+
+            if this_cl._is_match_weight_mode:
+                continue
 
             prev_m_prob = cast(float, prev_cl.m_probability)
             this_m_prob = cast(float, this_cl.m_probability)

--- a/splink/internals/linker.py
+++ b/splink/internals/linker.py
@@ -461,9 +461,9 @@ class Linker:
 
         for cc in ccs:
             for cl in cc._comparison_levels_excluding_null:
-                if cl._has_estimated_u_values and not cl._fix_u_probability:
+                if cl._has_estimated_u_values and not cl._u_probability_is_fixed:
                     cl.u_probability = cl._trained_u_median
-                if cl._has_estimated_m_values and not cl._fix_m_probability:
+                if cl._has_estimated_m_values and not cl._m_probability_is_fixed:
                     cl.m_probability = cl._trained_m_median
 
     def _raise_error_if_necessary_waterfall_columns_not_computed(self):

--- a/splink/internals/m_from_labels.py
+++ b/splink/internals/m_from_labels.py
@@ -60,7 +60,7 @@ def estimate_m_from_pairwise_labels(linker: "Linker", table_name: str) -> None:
     m_u_records_lookup = m_u_records_to_lookup_dict(m_u_records)
     for cc in linker._settings_obj.comparisons:
         for cl in cc._comparison_levels_excluding_null:
-            if not cl._fix_m_probability:
+            if not cl._m_probability_is_fixed:
                 append_m_probability_to_comparison_level_trained_probabilities(
                     cl,
                     m_u_records_lookup,

--- a/tests/test_match_weight_levels.py
+++ b/tests/test_match_weight_levels.py
@@ -70,7 +70,7 @@ def _linker():
 def test_match_weight_mode_and_serialization(match_weight):
     level = _level(match_weight=match_weight)
 
-    assert level._is_match_weight_mode
+    assert level.is_match_weight_mode
     assert level.match_weight == match_weight
     assert level.m_probability is None
     assert level.u_probability is None
@@ -124,8 +124,9 @@ def test_invalid_match_weight_settings(kwargs, message):
 
 
 def test_match_weight_with_tf_warns_and_errors(caplog):
-    with caplog.at_level(logging.WARNING), pytest.raises(
-        ValueError, match="term-frequency adjustments"
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(ValueError, match="term-frequency adjustments"),
     ):
         _level(match_weight=3, tf_adjustment_column="name")
 
@@ -134,9 +135,7 @@ def test_match_weight_with_tf_warns_and_errors(caplog):
 
 def test_creator_configure_supports_match_weight():
     level_dict = (
-        ExactMatchLevel("name")
-        .configure(match_weight=3)
-        .create_level_dict("duckdb")
+        ExactMatchLevel("name").configure(match_weight=3).create_level_dict("duckdb")
     )
 
     assert level_dict["match_weight"] == 3
@@ -217,9 +216,21 @@ def test_training_never_overwrites_match_weight(training_method):
 def test_existing_m_u_mode_is_unchanged():
     level = _level(m_probability=0.6, u_probability=0.2)
 
-    assert not level._is_match_weight_mode
+    assert not level.is_match_weight_mode
     assert level.m_probability == 0.6
     assert level.u_probability == 0.2
     assert level.match_weight == pytest.approx(1.584962500721156)
     assert level.as_dict()["m_probability"] == 0.6
     assert level.as_dict()["u_probability"] == 0.2
+
+
+def test_effective_match_weight_is_independent_of_mode():
+    configured_level = _level(match_weight=2.0)
+    probability_level = _level(m_probability=0.8, u_probability=0.2)
+
+    assert configured_level.match_weight == 2.0
+    assert probability_level.match_weight == 2.0
+    assert configured_level.is_match_weight_mode
+    assert not probability_level.is_match_weight_mode
+    assert configured_level.as_dict()["match_weight"] == 2.0
+    assert "match_weight" not in probability_level.as_dict()

--- a/tests/test_match_weight_levels.py
+++ b/tests/test_match_weight_levels.py
@@ -1,0 +1,225 @@
+import logging
+
+import pytest
+
+from splink.internals.comparison_level import ComparisonLevel
+from splink.internals.comparison_level_library import ExactMatchLevel
+from splink.internals.dialects import SplinkDialect
+from splink.internals.duckdb.database_api import DuckDBAPI
+from splink.internals.linker import Linker
+
+
+def _level(**kwargs):
+    return ComparisonLevel(
+        sql_condition=kwargs.pop("sql_condition", "ELSE"),
+        label_for_charts=kwargs.pop("label_for_charts", "Test level"),
+        sql_dialect=SplinkDialect.from_string("duckdb"),
+        **kwargs,
+    )
+
+
+def _settings():
+    return {
+        "link_type": "dedupe_only",
+        "probability_two_random_records_match": 0.5,
+        "comparisons": [
+            {
+                "output_column_name": "name",
+                "comparison_levels": [
+                    {
+                        "sql_condition": "name_l IS NULL OR name_r IS NULL",
+                        "label_for_charts": "Null",
+                        "is_null_level": True,
+                        "match_weight": 1.25,
+                    },
+                    {
+                        "sql_condition": "name_l = name_r",
+                        "label_for_charts": "Exact",
+                        "match_weight": 3.0,
+                    },
+                    {
+                        "sql_condition": "ELSE",
+                        "label_for_charts": "Else",
+                        "m_probability": 0.2,
+                        "u_probability": 0.8,
+                    },
+                ],
+            }
+        ],
+        "blocking_rules_to_generate_predictions": ["1=1"],
+        "retain_intermediate_calculation_columns": True,
+    }
+
+
+def _data():
+    return [
+        {"unique_id": 1, "name": None, "cluster": 1},
+        {"unique_id": 2, "name": None, "cluster": 1},
+        {"unique_id": 3, "name": "Robin", "cluster": 2},
+        {"unique_id": 4, "name": "Robin", "cluster": 2},
+        {"unique_id": 5, "name": "James", "cluster": 3},
+    ]
+
+
+def _linker():
+    db_api = DuckDBAPI()
+    return Linker(db_api.register(_data()), _settings()), db_api
+
+
+@pytest.mark.parametrize("match_weight", [0, 3.5, -4.25])
+def test_match_weight_mode_and_serialization(match_weight):
+    level = _level(match_weight=match_weight)
+
+    assert level._is_match_weight_mode
+    assert level.match_weight == match_weight
+    assert level.m_probability is None
+    assert level.u_probability is None
+    assert level._m_is_trained
+    assert level._u_is_trained
+    assert level.as_dict() == {
+        "sql_condition": "ELSE",
+        "label_for_charts": "Test level",
+        "match_weight": match_weight,
+    }
+
+
+def test_match_weight_can_be_used_on_null_level():
+    level = _level(match_weight=1.5, is_null_level=True)
+
+    assert level.match_weight == 1.5
+    assert level._match_weight == 1.5
+    assert level._log2_bayes_factor == 1.5
+    assert level.m_probability is None
+    assert level.u_probability is None
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"match_weight": float("nan")}, "finite number"),
+        ({"match_weight": float("inf")}, "finite number"),
+        ({"match_weight": "3"}, "finite number"),
+        ({"match_weight": True}, "finite number"),
+        (
+            {"match_weight": 3, "m_probability": 0.9},
+            "cannot be combined with m_probability or u_probability",
+        ),
+        (
+            {"match_weight": 3, "u_probability": 0.1},
+            "cannot be combined with m_probability or u_probability",
+        ),
+        (
+            {"match_weight": 3, "fix_m_probability": True},
+            "cannot be combined with fix_m_probability or fix_u_probability",
+        ),
+        (
+            {"match_weight": 3, "fix_u_probability": True},
+            "cannot be combined with fix_m_probability or fix_u_probability",
+        ),
+    ],
+)
+def test_invalid_match_weight_settings(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        _level(**kwargs)
+
+
+def test_match_weight_with_tf_warns_and_errors(caplog):
+    with caplog.at_level(logging.WARNING), pytest.raises(
+        ValueError, match="term-frequency adjustments"
+    ):
+        _level(match_weight=3, tf_adjustment_column="name")
+
+    assert "TF adjustments require explicit" in caplog.text
+
+
+def test_creator_configure_supports_match_weight():
+    level_dict = (
+        ExactMatchLevel("name")
+        .configure(match_weight=3)
+        .create_level_dict("duckdb")
+    )
+
+    assert level_dict["match_weight"] == 3
+    assert "m_probability" not in level_dict
+    assert "u_probability" not in level_dict
+
+
+def test_raw_settings_predict_exact_weights_and_round_trip():
+    linker, _ = _linker()
+    records = linker.inference.predict().as_record_list()
+    weights_by_ids = {
+        (record["unique_id_l"], record["unique_id_r"]): record["mw_name"]
+        for record in records
+    }
+
+    assert weights_by_ids[(1, 2)] == 1.25
+    assert weights_by_ids[(3, 4)] == 3.0
+    assert weights_by_ids[(3, 5)] == -2.0
+
+    serialized = linker._settings_obj.as_dict()
+    levels = serialized["comparisons"][0]["comparison_levels"]
+    assert levels[0]["match_weight"] == 1.25
+    assert levels[1]["match_weight"] == 3.0
+    for level in levels[:2]:
+        assert "m_probability" not in level
+        assert "u_probability" not in level
+        assert "fix_m_probability" not in level
+        assert "fix_u_probability" not in level
+
+    db_api = DuckDBAPI()
+    reloaded = Linker(db_api.register(_data()), serialized)
+    reloaded_records = reloaded.inference.predict().as_record_list()
+    reloaded_weights = {
+        (record["unique_id_l"], record["unique_id_r"]): record["mw_name"]
+        for record in reloaded_records
+    }
+    assert reloaded_weights == weights_by_ids
+
+
+@pytest.mark.parametrize(
+    "training_method",
+    ["estimate_u", "em", "m_from_column", "m_from_pairwise_labels"],
+)
+def test_training_never_overwrites_match_weight(training_method):
+    linker, db_api = _linker()
+
+    if training_method == "estimate_u":
+        linker.training.estimate_u_using_random_sampling(max_pairs=100, num_chunks=1)
+    elif training_method == "em":
+        linker.training.estimate_parameters_using_expectation_maximisation("1=1")
+    elif training_method == "m_from_column":
+        linker.training.estimate_m_from_label_column("cluster")
+    else:
+        labels = [
+            {
+                "source_dataset_l": "fake_data_1",
+                "source_dataset_r": "fake_data_1",
+                "unique_id_l": left["unique_id"],
+                "unique_id_r": right["unique_id"],
+            }
+            for left in _data()
+            for right in _data()
+            if left["cluster"] == right["cluster"]
+            and left["unique_id"] < right["unique_id"]
+        ]
+        db_api.register(labels, table_name="labels")
+        linker.training.estimate_m_from_pairwise_labels("labels")
+
+    level = linker._settings_obj.comparisons[0].comparison_levels[1]
+    assert level.match_weight == 3.0
+    assert level.m_probability is None
+    assert level.u_probability is None
+    assert level._trained_m_probabilities == []
+    assert level._trained_u_probabilities == []
+    assert level.as_dict()["match_weight"] == 3.0
+
+
+def test_existing_m_u_mode_is_unchanged():
+    level = _level(m_probability=0.6, u_probability=0.2)
+
+    assert not level._is_match_weight_mode
+    assert level.m_probability == 0.6
+    assert level.u_probability == 0.2
+    assert level.match_weight == pytest.approx(1.584962500721156)
+    assert level.as_dict()["m_probability"] == 0.6
+    assert level.as_dict()["u_probability"] == 0.2


### PR DESCRIPTION
Adds support for configuring a comparison level with a direct `match_weight` (`log2(m / u)`) instead of separate `m_probability` and `u_probability` values.

Match-weight levels contribute the configured score during prediction, are not overwritten by training, and serialize with `match_weight` only. The setting is supported in raw settings dictionaries and comparison-level creator `.configure(...)`, including for null levels.

Term frequency adjustments are not available for comparison levels that have match weight fixed.

## Implementation notes

- Implements distinct match-weight and m/u modes without deriving synthetic probability values.
- Uses `match_weight` for the effective prediction score, `_configured_match_weight` for the direct setting, and `is_match_weight_mode` to distinguish how a level is parameterized.
- Enforces mode invariants within `ComparisonLevel`, so probability setters and training-result collection cannot mutate match-weight levels. EM also excludes these levels from convergence calculations.
- Validates that weights are finite and mutually exclusive with m/u probabilities, probability fix flags, and term-frequency adjustments. Invalid TF combinations emit a warning before raising an error.
- Adds focused coverage for prediction, serialization and reload, creator configuration, validation, null levels, backwards-compatible m/u behavior, and all supported training paths.

## Example

Using a comparison-level creator:

```python
import splink.comparison_level_library as cll

level = cll.ExactMatchLevel("name").configure(match_weight=3.0)
```

The same level in serialized settings JSON:

```json
{
	"sql_condition": "name_l = name_r",
	"label_for_charts": "Exact match on name",
	"match_weight": 3.0
}
```

The serialized level contains `match_weight` instead of synthetic `m_probability` and `u_probability` values.

Alternatively, a level can use m/u mode, where probability fix flags are also available:

```json
{
	"sql_condition": "name_l = name_r",
	"label_for_charts": "Exact match on name",
	"m_probability": 0.9,
	"u_probability": 0.1,
	"fix_m_probability": true,
	"fix_u_probability": false
}
```

The two modes are mutually exclusive. Combining `match_weight` with either m/u probability is rejected:

```json
{
	"sql_condition": "name_l = name_r",
	"match_weight": 3.0,
	"m_probability": 0.9,
	"u_probability": 0.1
}
```

Combining `match_weight` with either probability fix flag is also rejected:

```json
{
	"sql_condition": "name_l = name_r",
	"match_weight": 3.0,
	"fix_m_probability": true,
	"fix_u_probability": true
}
```

In both invalid examples, including any one of the conflicting fields is enough to raise a validation error.