### PR TITLE
More attempts to make tests faster

### DIFF
--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -165,6 +165,7 @@ def test_parameter_estimate_charts(dialect, test_helpers):
             cl.LevenshteinAtThresholds("first_name", [1]),
             cl.LevenshteinAtThresholds("surname", [1]),
         ],
+        "max_iterations": 1,
     }
     helper = test_helpers[dialect]
 
@@ -178,11 +179,13 @@ def test_parameter_estimate_charts(dialect, test_helpers):
         "l.surname = r.surname",
         fix_u_probabilities=False,
         fix_probability_two_random_records_match=True,
+        max_pairs=10_000,
     )
     linker.training.estimate_parameters_using_expectation_maximisation(
         "l.first_name = r.first_name",
         fix_u_probabilities=False,
         fix_probability_two_random_records_match=True,
+        max_pairs=10_000,
     )
 
     exact_gender_m_estimates = [
@@ -204,7 +207,7 @@ def test_parameter_estimate_charts(dialect, test_helpers):
         ],
     }
     linker = helper.linker_with_registration([data], settings)
-    linker.training.estimate_u_using_random_sampling(1e6)
+    linker.training.estimate_u_using_random_sampling(10_000)
 
     linker.visualisations.parameter_estimate_comparisons_chart()
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -171,6 +171,8 @@ def test_parameter_estimate_charts(dialect, test_helpers):
 
     linker = helper.linker_with_registration([data], settings)
 
+    linker.training.estimate_m_from_label_column("true_match_id")
+
     linker.training.estimate_probability_two_random_records_match(
         ["l.true_match_id = r.true_match_id"], recall=1.0
     )

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -71,7 +71,7 @@ def test_chunked_predict_matches_non_chunked(test_helpers, dialect, chunking_dat
     assert df_no_chunk["unique_id_r"] == df_chunked["unique_id_r"]
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_chunked_predict_with_different_chunk_sizes(
     test_helpers, dialect, chunking_data
 ):
@@ -111,7 +111,7 @@ def test_chunked_predict_with_different_chunk_sizes(
         assert df_baseline["unique_id_r"] == df_chunked["unique_id_r"]
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_precached_blocked_pairs_same_result(test_helpers, dialect, chunking_data):
     """Test that pre-caching blocked pairs produces same result as no pre-caching."""
     helper = test_helpers[dialect]
@@ -138,7 +138,7 @@ def test_precached_blocked_pairs_same_result(test_helpers, dialect, chunking_dat
     assert df_no_cache["unique_id_r"] == df_with_cache["unique_id_r"]
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_precached_chunked_blocked_pairs_same_result(
     test_helpers, dialect, chunking_data
 ):
@@ -401,7 +401,7 @@ def test_blocked_pairs_deleted_when_not_from_cache(fake_1000):
     assert cache_key not in linker._intermediate_table_cache
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_chunked_predict_link_only(test_helpers, dialect, chunking_data):
     """Test chunked predictions work correctly with link_only (two datasets)."""
     helper = test_helpers[dialect]
@@ -445,7 +445,7 @@ def test_chunked_predict_link_only(test_helpers, dialect, chunking_data):
         assert df_baseline["unique_id_r"] == df_chunked["unique_id_r"]
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, chunking_data):
     """Test chunked predictions work correctly with link_only (three datasets).
 
@@ -493,7 +493,7 @@ def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, chunkin
         assert df_baseline["unique_id_r"] == df_chunked["unique_id_r"]
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_chunked_predict_link_and_dedupe(test_helpers, dialect, chunking_data):
     """Test chunked predictions work correctly with link_and_dedupe (two datasets)."""
     helper = test_helpers[dialect]
@@ -537,7 +537,7 @@ def test_chunked_predict_link_and_dedupe(test_helpers, dialect, chunking_data):
         assert df_baseline["unique_id_r"] == df_chunked["unique_id_r"]
 
 
-@mark_with_dialects_excluding()
+@mark_with_dialects_excluding("spark")
 def test_chunked_predict_link_and_dedupe_three_datasets(
     test_helpers, dialect, chunking_data
 ):

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -19,6 +19,11 @@ from .basic_settings import get_settings_dict
 from .decorator import mark_with_dialects_excluding
 
 
+@pytest.fixture(scope="module")
+def chunking_data(fake_1000):
+    return fake_1000.slice(length=100)
+
+
 def _get_comparison_count(result):
     """Get the number of comparisons in a prediction result."""
     return len(result.as_record_list())
@@ -32,12 +37,12 @@ def _sort_predictions(sdf):
 
 
 @mark_with_dialects_excluding()
-def test_chunked_predict_matches_non_chunked(test_helpers, dialect, fake_1000):
+def test_chunked_predict_matches_non_chunked(test_helpers, dialect, chunking_data):
     """Test that chunked predictions produce identical results to non-chunked."""
     helper = test_helpers[dialect]
 
     settings = get_settings_dict()
-    linker = helper.linker_with_registration(fake_1000, settings)
+    linker = helper.linker_with_registration(chunking_data, settings)
 
     # Get non-chunked predictions
     predictions_no_chunk = linker.inference.predict(threshold_match_weight=-10)
@@ -67,12 +72,14 @@ def test_chunked_predict_matches_non_chunked(test_helpers, dialect, fake_1000):
 
 
 @mark_with_dialects_excluding()
-def test_chunked_predict_with_different_chunk_sizes(test_helpers, dialect, fake_1000):
+def test_chunked_predict_with_different_chunk_sizes(
+    test_helpers, dialect, chunking_data
+):
     """Test various chunk size combinations produce consistent results."""
     helper = test_helpers[dialect]
 
     settings = get_settings_dict()
-    linker = helper.linker_with_registration(fake_1000, settings)
+    linker = helper.linker_with_registration(chunking_data, settings)
 
     # Get baseline predictions
     predictions_baseline = linker.inference.predict(threshold_match_weight=-10)
@@ -105,19 +112,19 @@ def test_chunked_predict_with_different_chunk_sizes(test_helpers, dialect, fake_
 
 
 @mark_with_dialects_excluding()
-def test_precached_blocked_pairs_same_result(test_helpers, dialect, fake_1000):
+def test_precached_blocked_pairs_same_result(test_helpers, dialect, chunking_data):
     """Test that pre-caching blocked pairs produces same result as no pre-caching."""
     helper = test_helpers[dialect]
 
     settings = get_settings_dict()
 
     # First: run without pre-caching
-    linker1 = helper.linker_with_registration(fake_1000, settings)
+    linker1 = helper.linker_with_registration(chunking_data, settings)
     predictions_no_cache = linker1.inference.predict(threshold_match_weight=-10)
     df_no_cache = _sort_predictions(predictions_no_cache)
 
     # Second: run with pre-caching
-    linker2 = helper.linker_with_registration(fake_1000, settings)
+    linker2 = helper.linker_with_registration(chunking_data, settings)
     linker2.inference.compute_blocked_pairs_for_predict_chunk(
         left_chunk=(1, 1),
         right_chunk=(1, 1),
@@ -132,14 +139,16 @@ def test_precached_blocked_pairs_same_result(test_helpers, dialect, fake_1000):
 
 
 @mark_with_dialects_excluding()
-def test_precached_chunked_blocked_pairs_same_result(test_helpers, dialect, fake_1000):
+def test_precached_chunked_blocked_pairs_same_result(
+    test_helpers, dialect, chunking_data
+):
     """Test that pre-caching chunked blocked pairs produces same result."""
     helper = test_helpers[dialect]
 
     settings = get_settings_dict()
 
     # First: run chunked without pre-caching
-    linker1 = helper.linker_with_registration(fake_1000, settings)
+    linker1 = helper.linker_with_registration(chunking_data, settings)
     predictions_no_cache = linker1.inference.predict(
         threshold_match_weight=-10,
         num_chunks_left=2,
@@ -148,7 +157,7 @@ def test_precached_chunked_blocked_pairs_same_result(test_helpers, dialect, fake
     df_no_cache = _sort_predictions(predictions_no_cache)
 
     # Second: run chunked with pre-caching of all chunks
-    linker2 = helper.linker_with_registration(fake_1000, settings)
+    linker2 = helper.linker_with_registration(chunking_data, settings)
 
     # Pre-compute all 4 chunk combinations (2x2)
     for left_chunk_num in [1, 2]:
@@ -393,7 +402,7 @@ def test_blocked_pairs_deleted_when_not_from_cache(fake_1000):
 
 
 @mark_with_dialects_excluding()
-def test_chunked_predict_link_only(test_helpers, dialect, fake_1000):
+def test_chunked_predict_link_only(test_helpers, dialect, chunking_data):
     """Test chunked predictions work correctly with link_only (two datasets)."""
     helper = test_helpers[dialect]
 
@@ -401,8 +410,8 @@ def test_chunked_predict_link_only(test_helpers, dialect, fake_1000):
     settings["link_type"] = "link_only"
 
     # Split into two datasets using modulo arithmetic
-    df_1 = fake_1000.take(list(range(0, 1000, 2)))
-    df_2 = fake_1000.take(list(range(1, 1000, 2)))
+    df_1 = chunking_data.take(list(range(0, len(chunking_data), 2)))
+    df_2 = chunking_data.take(list(range(1, len(chunking_data), 2)))
 
     linker = helper.linker_with_registration([df_1, df_2], settings)
 
@@ -437,7 +446,9 @@ def test_chunked_predict_link_only(test_helpers, dialect, fake_1000):
 
 
 @mark_with_dialects_excluding()
-def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, fake_1000):
+def test_chunked_predict_link_only_three_datasets(
+    test_helpers, dialect, chunking_data
+):
     """Test chunked predictions work correctly with link_only (three datasets).
 
     Two datasets is a special case, so we test with three datasets as well.
@@ -448,9 +459,9 @@ def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, fake_10
     settings["link_type"] = "link_only"
 
     # Split into three datasets using modulo arithmetic
-    df_1 = fake_1000.take(list(range(0, 1000, 3)))
-    df_2 = fake_1000.take(list(range(1, 1000, 3)))
-    df_3 = fake_1000.take(list(range(2, 1000, 3)))
+    df_1 = chunking_data.take(list(range(0, len(chunking_data), 3)))
+    df_2 = chunking_data.take(list(range(1, len(chunking_data), 3)))
+    df_3 = chunking_data.take(list(range(2, len(chunking_data), 3)))
 
     linker = helper.linker_with_registration([df_1, df_2, df_3], settings)
 
@@ -485,7 +496,7 @@ def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, fake_10
 
 
 @mark_with_dialects_excluding()
-def test_chunked_predict_link_and_dedupe(test_helpers, dialect, fake_1000):
+def test_chunked_predict_link_and_dedupe(test_helpers, dialect, chunking_data):
     """Test chunked predictions work correctly with link_and_dedupe (two datasets)."""
     helper = test_helpers[dialect]
 
@@ -493,8 +504,8 @@ def test_chunked_predict_link_and_dedupe(test_helpers, dialect, fake_1000):
     settings["link_type"] = "link_and_dedupe"
 
     # Split into two datasets using modulo arithmetic
-    df_1 = fake_1000.take(list(range(0, 1000, 2)))
-    df_2 = fake_1000.take(list(range(1, 1000, 2)))
+    df_1 = chunking_data.take(list(range(0, len(chunking_data), 2)))
+    df_2 = chunking_data.take(list(range(1, len(chunking_data), 2)))
 
     linker = helper.linker_with_registration([df_1, df_2], settings)
 
@@ -530,7 +541,7 @@ def test_chunked_predict_link_and_dedupe(test_helpers, dialect, fake_1000):
 
 @mark_with_dialects_excluding()
 def test_chunked_predict_link_and_dedupe_three_datasets(
-    test_helpers, dialect, fake_1000
+    test_helpers, dialect, chunking_data
 ):
     """Test chunked predictions work correctly with link_and_dedupe (three datasets).
 
@@ -542,9 +553,9 @@ def test_chunked_predict_link_and_dedupe_three_datasets(
     settings["link_type"] = "link_and_dedupe"
 
     # Split into three datasets using modulo arithmetic
-    df_1 = fake_1000.take(list(range(0, 1000, 3)))
-    df_2 = fake_1000.take(list(range(1, 1000, 3)))
-    df_3 = fake_1000.take(list(range(2, 1000, 3)))
+    df_1 = chunking_data.take(list(range(0, len(chunking_data), 3)))
+    df_2 = chunking_data.take(list(range(1, len(chunking_data), 3)))
+    df_3 = chunking_data.take(list(range(2, len(chunking_data), 3)))
 
     linker = helper.linker_with_registration([df_1, df_2, df_3], settings)
 

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -446,9 +446,7 @@ def test_chunked_predict_link_only(test_helpers, dialect, chunking_data):
 
 
 @mark_with_dialects_excluding()
-def test_chunked_predict_link_only_three_datasets(
-    test_helpers, dialect, chunking_data
-):
+def test_chunked_predict_link_only_three_datasets(test_helpers, dialect, chunking_data):
     """Test chunked predictions work correctly with link_only (three datasets).
 
     Two datasets is a special case, so we test with three datasets as well.


### PR DESCRIPTION
- Testing chunking on Spark is very slow.  Instead of running all chunking tests on Spark, just run one of them.  Essentially all we need to verify is that the hash is deterministic so if it passes one it will pass all the others
- Reduce data sizes
- Don't do complete EM training just for a chart 