### PR TITLE
Warn instead of reporting convergence when EM hits max_iterations

### DIFF
--- a/splink/internals/expectation_maximisation.py
+++ b/splink/internals/expectation_maximisation.py
@@ -250,6 +250,7 @@ def expectation_maximisation(
         pipeline.enqueue_sql(sql, "__splink__agreement_pattern_counts")
         agreement_pattern_counts = db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
+    converged = False
     for i in range(1, max_iterations + 1):
         pipeline = CTEPipeline()
         probability_two_random_records_match = (
@@ -305,9 +306,19 @@ def expectation_maximisation(
         logger.log(15, f"    Iteration time: {end_time - start_time} seconds")
 
         if max_change_dict["max_abs_change_value"] < em_convergence:
+            converged = True
             break
 
-    logger.info(f"\nEM converged after {i} iterations")
+    if converged:
+        logger.info(f"\nEM converged after {i} iterations")
+    else:
+        logger.warning(
+            f"\nEM did not converge: reached the maximum of {max_iterations} "
+            "iterations without the largest change in parameters dropping below "
+            f"the convergence threshold ({em_convergence}). The model parameters "
+            "may not be reliable; consider increasing `max_iterations` or "
+            "`em_convergence` in the training settings."
+        )
     return core_model_settings_history
 
 

--- a/tests/test_expectation_maximisation.py
+++ b/tests/test_expectation_maximisation.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 import splink.comparison_level_library as cll
@@ -6,6 +8,31 @@ from splink import DuckDBAPI, SettingsCreator, block_on
 from splink.internals.exceptions import EMTrainingException
 from splink.internals.linker import Linker
 from tests.decorator import mark_with_dialects_excluding
+
+
+def test_em_warns_when_max_iterations_reached(fake_1000, caplog):
+    # With max_iterations=1 the model cannot converge, so training should warn
+    # that it did not converge rather than report convergence (issue #1382).
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            cl.ExactMatch("first_name"),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("city"),
+        ],
+        max_iterations=1,
+    )
+    db_api = DuckDBAPI()
+    df_sdf = db_api.register(fake_1000)
+    linker = Linker(df_sdf, settings)
+
+    with caplog.at_level(logging.INFO):
+        linker.training.estimate_parameters_using_expectation_maximisation(
+            block_on("first_name")
+        )
+
+    assert "did not converge" in caplog.text
+    assert "EM converged after" not in caplog.text
 
 
 @mark_with_dialects_excluding()


### PR DESCRIPTION
Closes #1382.

### Problem
In `expectation_maximisation.py`, the training loop logs the convergence message unconditionally after the loop ends:

```python
for i in range(1, max_iterations + 1):
    ...
    if max_change_dict["max_abs_change_value"] < em_convergence:
        break

logger.info(f"\nEM converged after {i} iterations")
```

So when training stops because it has exhausted `max_iterations` (rather than because the parameter change dropped below `em_convergence`), it still reports *"EM converged after N iterations"* — which is misleading, since the model hasn't actually converged.

### Fix
Track whether the convergence criterion was met. If it was, log the same message as before; otherwise log a warning that the maximum iteration count was reached, the parameters may be unreliable, and the user may want to increase `max_iterations` or `em_convergence`.

### Verification
On `fake_1000` with `max_iterations=1` (which cannot converge in one step):

| | before | after |
|---|---|---|
| log | `INFO … EM converged after 1 iterations` | `WARNING … EM did not converge: reached the maximum of 1 iterations …` |

A converging run (default `max_iterations`) is unaffected — it still logs `EM converged after 10 iterations`.

Added `test_em_warns_when_max_iterations_reached` (DuckDB) which asserts the warning is emitted and the false convergence message is not; it passes on this branch and fails on `master`. `tests/test_expectation_maximisation.py` passes (5 passed, non-DuckDB dialects deselected), and `ruff check` / `ruff format --check` are clean.
