### PR TITLE
Invalidate cache when deleting Splink tables from the database

### DIFF
--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -401,9 +401,12 @@ class DatabaseAPI(ABC, Generic[TablishType]):
     def remove_splinkdataframe_from_cache(
         self, splink_dataframe: SplinkDataFrame
     ) -> None:
+        self._remove_physical_name_from_cache(splink_dataframe.physical_name)
+
+    def _remove_physical_name_from_cache(self, physical_name: str) -> None:
         keys_to_delete = set()
         for key, df in self._intermediate_table_cache.items():
-            if df.physical_name == splink_dataframe.physical_name:
+            if df.physical_name == physical_name:
                 keys_to_delete.add(key)
 
         for k in keys_to_delete:
@@ -415,6 +418,10 @@ class DatabaseAPI(ABC, Generic[TablishType]):
         for physical_name in list(self._created_tables):
             self.delete_table_from_database(physical_name)
             self._created_tables.discard(physical_name)
+            # Also drop any cached SplinkDataFrame that points at the table we
+            # just deleted, so later operations don't reference a table that no
+            # longer exists in the database (issue #3197).
+            self._remove_physical_name_from_cache(physical_name)
 
     def _bind_templated_alias_to_physical(self, templated: str, physical: str) -> None:
         """Expose the physical table via a backend-specific temp view."""

--- a/tests/test_profile_data.py
+++ b/tests/test_profile_data.py
@@ -3,6 +3,9 @@ import sqlite3
 import pyarrow as pa
 import pytest
 
+import splink.comparison_library as cl
+from splink import Linker, SettingsCreator, block_on
+from splink.internals.datasets import splink_dataset_labels
 from splink.internals.duckdb.database_api import DuckDBAPI
 from splink.internals.exceptions import SplinkException
 from splink.internals.misc import ensure_is_list
@@ -28,6 +31,36 @@ def generate_raw_profile_dataset(table, columns_to_profile, db_api):
     pipeline.enqueue_sql(sql, "__splink__df_all_column_value_frequencies")
 
     return db_api.sql_pipeline_to_splink_dataframe(pipeline).as_record_list()
+
+
+@mark_with_dialects_including("duckdb")
+def test_accuracy_analysis_after_profile_columns(fake_1000):
+    # profile_columns() deletes Splink-created tables from the database; it must
+    # also invalidate the cache, otherwise a later step that reuses a cached
+    # term-frequency table queries a table that no longer exists (issue #3197).
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[
+            cl.ExactMatch("first_name").configure(term_frequency_adjustments=True),
+            cl.ExactMatch("surname"),
+            cl.ExactMatch("city").configure(term_frequency_adjustments=True),
+        ],
+        blocking_rules_to_generate_predictions=[block_on("first_name")],
+    )
+    db_api = DuckDBAPI()
+    sdf = db_api.register(fake_1000)
+    linker = Linker(sdf, settings)
+    linker.training.estimate_parameters_using_expectation_maximisation(
+        block_on("first_name")
+    )
+
+    # This deletes the tables Splink created, including the cached tf tables
+    profile_columns(sdf, ["surname"])
+
+    # Reusing the cached term-frequency tables must not reference a table that
+    # profile_columns has deleted from the database.
+    sdf_labels = db_api.register(splink_dataset_labels.fake_1000_labels)
+    linker.evaluation.accuracy_analysis_from_labels_table(sdf_labels)
 
 
 @mark_with_dialects_including("duckdb")


### PR DESCRIPTION
Closes #3197.

### Problem
`accuracy_analysis_from_labels_table` fails if it is run after `profile_columns` (when term-frequency adjustments are in play), with an error like:

```
Catalog Error: Table with name __splink__df_tf_city_... does not exist!
```

`profile_columns` finishes by calling `db_api.delete_tables_created_by_splink_from_db()` to clean up. That method drops each table from the database and removes it from `_created_tables`, but it does **not** evict the corresponding `SplinkDataFrame` from `_intermediate_table_cache`. So the linker's cached term-frequency tables are deleted from the database while stale cache entries still point at them; the next step that reuses one (here, accuracy analysis) then queries a table that no longer exists.

### Fix
As suggested in the issue, evict the matching cache entry as each table is deleted. `remove_splinkdataframe_from_cache` already did this for a given `SplinkDataFrame`; I factored its body into a small `_remove_physical_name_from_cache(physical_name)` helper and call it from `delete_tables_created_by_splink_from_db`, so a deleted table can never be left behind in the cache.

### Verification
Reproduced the issue's reprex (EM training with term-frequency adjustments → `profile_columns` → `accuracy_analysis_from_labels_table`): it raises on `master` and succeeds with this change. Added `test_accuracy_analysis_after_profile_columns` (DuckDB) which encodes that workflow — it passes on this branch and fails on `master`. `tests/test_profile_data.py` passes (7 passed, non-DuckDB dialects deselected) and `ruff check` / `ruff format --check` are clean.
