### PR TITLE
fix athena database check to paginate past 100 databases

### DIFF
--- a/splink/internals/athena/athena_helpers/athena_utils.py
+++ b/splink/internals/athena/athena_helpers/athena_utils.py
@@ -19,7 +19,15 @@ def athena_warning_text(database_bucket_txt, do_does_grammar):
 def _verify_athena_inputs(database, bucket, boto3_session):
     errors = []
 
-    if database not in wr.catalog.databases(boto3_session=boto3_session).values:
+    # wr.catalog.databases() truncates to its `limit` arg (100 by default), so
+    # accounts with more than that many databases can get a false "does not
+    # exist" here. wr.catalog.get_databases() walks the full Glue paginator
+    # instead, the same pattern already used for tables in
+    # _garbage_collection() below.
+    existing_databases = (
+        db["Name"] for db in wr.catalog.get_databases(boto3_session=boto3_session)
+    )
+    if database not in existing_databases:
         errors.append(f"database '{database}'")
 
     if bucket not in wr.s3.list_buckets(boto3_session=boto3_session):

--- a/tests/test_athena_utils.py
+++ b/tests/test_athena_utils.py
@@ -1,0 +1,75 @@
+import pytest
+
+pytest.importorskip("awswrangler")
+# ruff: noqa: E402 (module level import not at top of file)
+
+from unittest.mock import patch
+
+from splink.internals.athena.athena_helpers.athena_utils import (
+    _verify_athena_inputs,
+)
+from splink.internals.exceptions import InvalidAWSBucketOrDatabase
+
+DATABASE = "my_database"
+BUCKET = "my_bucket"
+
+
+def _glue_databases(count, target_name=None, target_index=None):
+    # Mimics the dicts yielded by wr.catalog.get_databases(), which walks
+    # the full Glue paginator (as opposed to wr.catalog.databases(), which
+    # truncates to its `limit` arg, 100 by default).
+    databases = [{"Name": f"other_db_{i}", "Description": ""} for i in range(count)]
+    if target_name is not None:
+        databases[target_index] = {"Name": target_name, "Description": ""}
+    return databases
+
+
+@patch("awswrangler.s3.list_buckets", return_value=[BUCKET])
+@patch("awswrangler.catalog.get_databases")
+def test_verify_athena_inputs_small_database_list_unchanged(
+    mock_get_databases, mock_list_buckets
+):
+    # Baseline case, well under the old wr.catalog.databases() default of
+    # limit=100: behaviour should be unchanged.
+    mock_get_databases.return_value = iter(_glue_databases(5, DATABASE, 2))
+
+    _verify_athena_inputs(database=DATABASE, bucket=BUCKET, boto3_session=None)
+
+
+@patch("awswrangler.s3.list_buckets", return_value=[BUCKET])
+@patch("awswrangler.catalog.get_databases")
+def test_verify_athena_inputs_finds_database_beyond_first_hundred(
+    mock_get_databases, mock_list_buckets
+):
+    # Regression test for #3001: with more than 100 databases in the
+    # catalog, a target database sitting beyond the old default `limit=100`
+    # must still be recognised as existing.
+    mock_get_databases.return_value = iter(_glue_databases(150, DATABASE, 120))
+
+    _verify_athena_inputs(database=DATABASE, bucket=BUCKET, boto3_session=None)
+
+
+@patch("awswrangler.s3.list_buckets", return_value=[BUCKET])
+@patch("awswrangler.catalog.get_databases")
+def test_verify_athena_inputs_missing_database_still_raises(
+    mock_get_databases, mock_list_buckets
+):
+    # A database that genuinely does not exist anywhere in the (paginated)
+    # catalog must NOT be silently accepted.
+    mock_get_databases.return_value = iter(_glue_databases(150))
+
+    with pytest.raises(InvalidAWSBucketOrDatabase, match=DATABASE):
+        _verify_athena_inputs(database=DATABASE, bucket=BUCKET, boto3_session=None)
+
+
+@patch("awswrangler.s3.list_buckets", return_value=[])
+@patch("awswrangler.catalog.get_databases")
+def test_verify_athena_inputs_missing_bucket_still_raises(
+    mock_get_databases, mock_list_buckets
+):
+    # Secondary path, untouched by this fix: the bucket check must keep
+    # raising when the bucket is absent.
+    mock_get_databases.return_value = iter(_glue_databases(5, DATABASE, 2))
+
+    with pytest.raises(InvalidAWSBucketOrDatabase, match=BUCKET):
+        _verify_athena_inputs(database=DATABASE, bucket=BUCKET, boto3_session=None)


### PR DESCRIPTION
### Type of PR

- [x] BUG
- [ ] FEAT
- [ ] MAINT
- [ ] DOC

### Is your Pull Request linked to an existing Issue or Pull Request?

Closes #3001

### Give a brief description for the solution you have provided

`wr.catalog.databases()` truncates results to its `limit` argument (100 by
default: `itertools.islice(get_databases(...), limit)` internally).
`_verify_athena_inputs()` calls it with no `limit`, so on any AWS account
with more than 100 Glue databases, a database that exists but sits on a
later page gets reported as missing — matching the reporter's own
diagnosis (manually passing `limit=200` made it visible).

This switches to `wr.catalog.get_databases()`, the unbounded paginated
generator that walks the full Glue catalog. It's the same function this
file already uses for tables in `_garbage_collection()` a few lines
below, so the fix follows an existing pattern rather than introducing a
new one. Membership is checked with a short-circuiting generator
expression, so a match is still found immediately rather than
materialising the whole catalog first.

This targets `splink4_maintenance` rather than `master`: Athena support
was dropped from `master` in #2858 (Splink 5), so the affected code only
exists on the 4.x maintenance line, which `splink4_maintenance` still
actively receives fixes for.

**Known limitation:** confirming a database does *not* exist still
requires walking the entire paginated catalog — same cost as the
`limit=200` workaround in the issue, just without an artificial ceiling
(no false negatives at any catalog size). A natural follow-up would be a
direct `boto3` `glue.get_database(Name=...)` call catching
`EntityNotFoundException` instead of a full listing, but that would
depart from this file's existing exclusive use of the
`awswrangler.catalog` helper layer, so it's left out of this fix.

Added `tests/test_athena_utils.py`: a small-catalog baseline (unchanged
behaviour), the >100-database regression from this issue, a genuine
missing-database negative case, and the untouched missing-bucket
secondary path — all mocking `awswrangler.catalog.get_databases`
directly, guarded by `pytest.importorskip("awswrangler")` to match the
existing `postgres`/`spark` optional-dependency test pattern in this repo
(the `athena` extra isn't in the default dependency groups).

### PR Checklist

- [ ] Added documentation for changes
- [ ] Added feature to example notebooks or tutorial (if appropriate)
- [x] Added tests (if appropriate)
- [ ] Updated CHANGELOG.md (if appropriate)
- [x] Made changes based off the latest version of Splink
- [x] Run the linter
- [ ] Run the spellchecker (if appropriate)
