### PR TITLE
fix: n_largest_blocks raises a clear error for rules with no equi-join conditions

### DIFF
--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -757,6 +757,17 @@ def n_largest_blocks(
         blocking_rule, db_api.sql_dialect.sql_dialect_str
     )
 
+    join_conditions = blocking_rule_as_br._equi_join_conditions
+    if not join_conditions:
+        raise ValueError(
+            f"Blocking rule {blocking_rule_as_br.blocking_rule_sql!r} has no "
+            "equi-join conditions, so it does not partition records into "
+            "discrete blocks and cannot be analysed by n_largest_blocks. This "
+            "happens for rules composed only of filter conditions (e.g. fuzzy "
+            "conditions like levenshtein) or rules combined with OR. Analyse "
+            "the equi-join parts individually instead."
+        )
+
     splink_df_dict = splink_dataframes_to_dict(splink_dataframe_or_dataframes)
 
     sqls = _count_comparisons_from_blocking_rule_pre_filter_conditions_sqls(
@@ -764,8 +775,6 @@ def n_largest_blocks(
     )
     pipeline = CTEPipeline()
     pipeline.enqueue_list_of_sqls(sqls)
-
-    join_conditions = blocking_rule_as_br._equi_join_conditions
 
     keys = ", ".join(f"key_{i}" for i in range(len(join_conditions)))
     sql = f"""

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -769,6 +769,43 @@ def test_n_largest_blocks(test_helpers, dialect):
     )
 
 
+def test_n_largest_blocks_raises_for_no_equi_join_rule():
+    """n_largest_blocks cannot analyse a rule with no equi-join conditions,
+    e.g. pure filter rules or an OR of two rules - these don't partition
+    records into discrete blocks, so there is no "key" to group by. Before
+    this raised a cryptic SplinkException wrapping a raw SQL parser error
+    (empty `select` / `using ()`) instead of a clear message."""
+    data = [
+        {"unique_id": 1, "name1": "john"},
+        {"unique_id": 2, "name1": "jon"},
+        {"unique_id": 3, "name1": "smith"},
+    ]
+
+    db_api = DuckDBAPI()
+    sdf = db_api.register(data)
+    filter_only_rule = CustomRule(
+        "levenshtein(l.name1, r.name1) <= 1", sql_dialect="duckdb"
+    )
+    with pytest.raises(ValueError, match="no equi-join conditions"):
+        n_largest_blocks(
+            sdf, blocking_rule=filter_only_rule, link_type="dedupe_only"
+        )
+
+    db_api_2 = DuckDBAPI()
+    sdf_2 = db_api_2.register(data)
+    or_rule = Or(block_on("name1"), block_on("name1"))
+    with pytest.raises(ValueError, match="no equi-join conditions"):
+        n_largest_blocks(sdf_2, blocking_rule=or_rule, link_type="dedupe_only")
+
+    # an ordinary equi-join rule must still work fine
+    db_api_3 = DuckDBAPI()
+    sdf_3 = db_api_3.register(data)
+    result = n_largest_blocks(
+        sdf_3, blocking_rule=block_on("name1"), link_type="dedupe_only"
+    )
+    assert len(result.as_record_list()) == 3
+
+
 def test_blocking_rule_parentheses_equivalence():
     """Test that different blocking rule formats produce identical results
     (issue #2501)"""


### PR DESCRIPTION
## Summary

Related to #1946 (see my comment there for context).

`n_largest_blocks` assumes a blocking rule has at least one equi-join condition to group by. For rules composed only of filter conditions (e.g. `levenshtein(l.name, r.name) <= 1`) or combined with `Or`, `_equi_join_conditions` is empty, and the function silently built invalid SQL from it: an empty `select` list and an empty `USING ()` clause. This surfaces as a raw `SplinkException` wrapping a DuckDB parser error (`syntax error at or near ","`), with no indication of the actual cause.

## Fix

Moved the equi-join lookup earlier in the function and raise a clear `ValueError` explaining why the rule can't be analysed this way, before any SQL is built.

## Testing

Reproduced the original crash locally before fixing (both a `CustomRule` pure-filter rule and an `Or` of two rules). Added `test_n_largest_blocks_raises_for_no_equi_join_rule` covering both cases plus a normal equi-join rule to confirm it's unaffected. Ran the full `test_analyse_blocking.py` file (14 tests, all pass), `ruff check`, and `mypy` on the changed files.