### PR TITLE
feat: n_largest_blocks reports each block's share of total comparisons

### DIFF
--- a/docs/topic_guides/blocking/performance.md
+++ b/docs/topic_guides/blocking/performance.md
@@ -100,6 +100,25 @@ SettingsCreator(
 
 
 
+## Diagnosing Data Skew
+
+An efficient, equi-join blocking rule can still perform badly if the values it blocks on are unevenly distributed. Blocking on first name and surname is usually efficient, but if a handful of values (e.g. a common combination like "John Smith") account for a disproportionate share of the records, the block generated for those values alone can be large enough to dominate runtime or exhaust memory, even though every other block is a reasonable size.
+
+Use `n_largest_blocks()` to find which values are responsible before running a full job:
+
+```py
+from splink.blocking_analysis import n_largest_blocks
+
+n_largest_blocks(
+    splink_df,
+    blocking_rule=block_on("first_name", "surname"),
+    link_type="dedupe_only",
+    n_largest=5,
+).as_pandas_dataframe()
+```
+
+This returns the values generating the largest blocks, alongside `block_count` and each block's `proportion_of_comparisons` and `cumulative_proportion_of_comparisons` (the running share of every comparison this rule will generate). A single row responsible for the large majority of `cumulative_proportion_of_comparisons` is the concrete signal that this specific value, not the rule in general, is the problem: worth a targeted fix (a more specific rule for that value, or excluding it) rather than loosening or discarding the blocking rule as a whole.
+
 ??? note "Spark-specific Further Reading"
 
     Given the ability to parallelise operations in Spark, there are some additional configuration options which can improve performance of blocking. Please refer to the Spark Performance Topic Guides for more information.

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -749,7 +749,15 @@ def n_largest_blocks(
         n_largest (int, optional): How many rows to return. Defaults to 5.
 
     Returns:
-        SplinkDataFrame: A dataframe containing the n_largest blocks
+        SplinkDataFrame: A dataframe containing the n_largest blocks, plus
+            ``proportion_of_comparisons`` (this block's share of the rule's
+            total pre-filter comparisons) and
+            ``cumulative_proportion_of_comparisons`` (running total across
+            blocks, ordered from largest to smallest). Both are computed over
+            *all* blocks the rule generates, not just the returned
+            ``n_largest`` rows, so e.g. a cumulative value of 0.92 on the
+            first row means one single value is responsible for 92% of every
+            comparison this rule will generate.
     """
     db_api = get_db_api_from_inputs(splink_dataframe_or_dataframes)
 
@@ -778,11 +786,18 @@ def n_largest_blocks(
 
     keys = ", ".join(f"key_{i}" for i in range(len(join_conditions)))
     sql = f"""
-    select {keys}, count_l, count_r,  count_l * count_r as block_count
+    select {keys}, count_l, count_r, count_l * count_r as block_count,
+        (count_l * count_r) / cast(sum(count_l * count_r) over () as float)
+            as proportion_of_comparisons,
+        sum(count_l * count_r) over (
+            order by count_l * count_r desc, {keys}
+            rows between unbounded preceding and current row
+        ) / cast(sum(count_l * count_r) over () as float)
+            as cumulative_proportion_of_comparisons
     from __splink__count_comparisons_from_blocking_l
     inner join __splink__count_comparisons_from_blocking_r
     using ({keys})
-    order by count_l * count_r desc
+    order by count_l * count_r desc, {keys}
     limit {n_largest}
     """
 

--- a/splink/internals/blocking_analysis.py
+++ b/splink/internals/blocking_analysis.py
@@ -757,6 +757,17 @@ def n_largest_blocks(
         blocking_rule, db_api.sql_dialect.sql_dialect_str
     )
 
+    join_conditions = blocking_rule_as_br._equi_join_conditions
+    if not join_conditions:
+        raise ValueError(
+            f"Blocking rule {blocking_rule_as_br.blocking_rule_sql!r} has no "
+            "equi-join conditions, so it does not partition records into "
+            "discrete blocks and cannot be analysed by n_largest_blocks. This "
+            "happens for rules composed only of filter conditions (e.g. fuzzy "
+            "conditions like levenshtein) or rules combined with OR. Analyse "
+            "the equi-join parts individually instead."
+        )
+
     splink_df_dict = splink_dataframes_to_dict(splink_dataframe_or_dataframes)
 
     sqls = _count_comparisons_from_blocking_rule_pre_filter_conditions_sqls(
@@ -764,8 +775,6 @@ def n_largest_blocks(
     )
     pipeline = CTEPipeline()
     pipeline.enqueue_list_of_sqls(sqls)
-
-    join_conditions = blocking_rule_as_br._equi_join_conditions
 
     keys = ", ".join(f"key_{i}" for i in range(len(join_conditions)))
     sql = f"""

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -769,6 +769,43 @@ def test_n_largest_blocks(test_helpers, dialect):
     )
 
 
+def test_n_largest_blocks_raises_for_no_equi_join_rule():
+    """n_largest_blocks cannot analyse a rule with no equi-join conditions,
+    e.g. pure filter rules or an OR of two rules - these don't partition
+    records into discrete blocks, so there is no "key" to group by. Before
+    this raised a cryptic SplinkException wrapping a raw SQL parser error
+    (empty `select` / `using ()`) instead of a clear message."""
+    data = [
+        {"unique_id": 1, "name1": "john"},
+        {"unique_id": 2, "name1": "jon"},
+        {"unique_id": 3, "name1": "smith"},
+    ]
+
+    db_api = DuckDBAPI()
+    sdf = db_api.register(data)
+    filter_only_rule = CustomRule(
+        "levenshtein(l.name1, r.name1) <= 1", sql_dialect="duckdb"
+    )
+    with pytest.raises(ValueError, match="no equi-join conditions"):
+        n_largest_blocks(
+            sdf, blocking_rule=filter_only_rule, link_type="dedupe_only"
+        )
+
+    db_api_2 = DuckDBAPI()
+    sdf_2 = db_api_2.register(data)
+    or_rule = Or(block_on("name1"), block_on("name1"))
+    with pytest.raises(ValueError, match="no equi-join conditions"):
+        n_largest_blocks(sdf_2, blocking_rule=or_rule, link_type="dedupe_only")
+
+    # an ordinary equi-join rule must still work fine
+    db_api_3 = DuckDBAPI()
+    sdf_3 = db_api_3.register(data)
+    result = n_largest_blocks(
+        sdf_3, blocking_rule=block_on("name1"), link_type="dedupe_only"
+    )
+    assert len(result.as_record_list()) == 3
+
+
 def test_blocking_rule_parentheses_equivalence():
     """Test that different blocking rule formats produce identical results
     (issue #2501)"""

--- a/tests/test_analyse_blocking.py
+++ b/tests/test_analyse_blocking.py
@@ -611,10 +611,17 @@ def test_n_largest_blocks(test_helpers, dialect):
     from {df_1_sdf.physical_name}
     group by key_0, key_1)
 
-    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count,
+        (a.c * b.c) / cast(sum(a.c * b.c) over () as float)
+            as proportion_of_comparisons,
+        sum(a.c * b.c) over (
+            order by a.c * b.c desc, a.key_0, a.key_1
+            rows between unbounded preceding and current row
+        ) / cast(sum(a.c * b.c) over () as float)
+            as cumulative_proportion_of_comparisons
     from a inner join b
     on a.key_0 = b.key_0 and a.key_1 = b.key_1
-    order by block_count desc
+    order by block_count desc, a.key_0, a.key_1
     """
     n_largest_manual_dedupe_only = db_api.query_sql(sql)
 
@@ -647,10 +654,17 @@ def test_n_largest_blocks(test_helpers, dialect):
     )
     group by key_0, key_1)
 
-    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count,
+        (a.c * b.c) / cast(sum(a.c * b.c) over () as float)
+            as proportion_of_comparisons,
+        sum(a.c * b.c) over (
+            order by a.c * b.c desc, a.key_0, a.key_1
+            rows between unbounded preceding and current row
+        ) / cast(sum(a.c * b.c) over () as float)
+            as cumulative_proportion_of_comparisons
     from a inner join b
     on a.key_0 = b.key_0 and a.key_1 = b.key_1
-    order by block_count desc
+    order by block_count desc, a.key_0, a.key_1
     """
     n_largest_manual_link_and_dedupe = db_api.query_sql(sql)
 
@@ -678,10 +692,17 @@ def test_n_largest_blocks(test_helpers, dialect):
     from {df_2_sdf.physical_name}
     group by key_0, key_1)
 
-    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count,
+        (a.c * b.c) / cast(sum(a.c * b.c) over () as float)
+            as proportion_of_comparisons,
+        sum(a.c * b.c) over (
+            order by a.c * b.c desc, a.key_0, a.key_1
+            rows between unbounded preceding and current row
+        ) / cast(sum(a.c * b.c) over () as float)
+            as cumulative_proportion_of_comparisons
     from a inner join b
     on a.key_0 = b.key_0 and a.key_1 = b.key_1
-    order by block_count desc
+    order by block_count desc, a.key_0, a.key_1
     """
     n_largest_manual_link_only = db_api.query_sql(sql)
 
@@ -718,10 +739,17 @@ def test_n_largest_blocks(test_helpers, dialect):
     )
     group by key_0, key_1)
 
-    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count,
+        (a.c * b.c) / cast(sum(a.c * b.c) over () as float)
+            as proportion_of_comparisons,
+        sum(a.c * b.c) over (
+            order by a.c * b.c desc, a.key_0, a.key_1
+            rows between unbounded preceding and current row
+        ) / cast(sum(a.c * b.c) over () as float)
+            as cumulative_proportion_of_comparisons
     from a inner join b
     on a.key_0 = b.key_0 and a.key_1 = b.key_1
-    order by block_count desc
+    order by block_count desc, a.key_0, a.key_1
     """
     n_largest_manual_link_only_3 = db_api.query_sql(sql)
 
@@ -754,10 +782,17 @@ def test_n_largest_blocks(test_helpers, dialect):
     )
     group by key_0, key_1)
 
-    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count
+    select a.key_0, a.key_1, a.c as count_l, b.c as count_r, a.c * b.c as block_count,
+        (a.c * b.c) / cast(sum(a.c * b.c) over () as float)
+            as proportion_of_comparisons,
+        sum(a.c * b.c) over (
+            order by a.c * b.c desc, a.key_0, a.key_1
+            rows between unbounded preceding and current row
+        ) / cast(sum(a.c * b.c) over () as float)
+            as cumulative_proportion_of_comparisons
     from a inner join b
     on a.key_0 = b.key_0 and a.key_1 = b.key_1
-    order by block_count desc
+    order by block_count desc, a.key_0, a.key_1
     """
     n_largest_manual_link_and_dedupe_inverted = db_api.query_sql(sql)
 
@@ -767,6 +802,56 @@ def test_n_largest_blocks(test_helpers, dialect):
         n_largest_link_and_dedupe_inverted.query_sql(order_sql).as_dict()
         == n_largest_manual_link_and_dedupe_inverted.query_sql(order_sql).as_dict()
     )
+
+
+@mark_with_dialects_excluding()
+def test_n_largest_blocks_proportions(test_helpers, dialect):
+    """proportion_of_comparisons and cumulative_proportion_of_comparisons must
+    reflect ALL blocks the rule generates, not just the n_largest returned -
+    otherwise the "this one value is 92% of everything" reading is wrong
+    whenever the result is truncated."""
+    helper = test_helpers[dialect]
+    db_api = helper.db_api()
+
+    # Deliberately skewed, no ties: block_counts are 36, 4, 1 (total 41)
+    data = (
+        [{"unique_id": i, "first_name": "John", "surname": "Smith"} for i in range(6)]
+        + [
+            {"unique_id": i, "first_name": "Mary", "surname": "Jones"}
+            for i in range(6, 8)
+        ]
+        + [{"unique_id": 8, "first_name": "Tom", "surname": "Brown"}]
+    )
+    sdf = db_api.register(data)
+
+    result = n_largest_blocks(
+        sdf,
+        blocking_rule=block_on("first_name", "surname"),
+        link_type="dedupe_only",
+        n_largest=5,
+    ).as_record_list()
+
+    assert [row["block_count"] for row in result] == [36, 4, 1]
+    assert [row["proportion_of_comparisons"] for row in result] == pytest.approx(
+        [36 / 41, 4 / 41, 1 / 41]
+    )
+    assert [
+        row["cumulative_proportion_of_comparisons"] for row in result
+    ] == pytest.approx([36 / 41, 40 / 41, 1.0])
+
+    # Truncating to n_largest=1 must not change the proportions: they're a
+    # share of ALL 41 comparisons the rule generates, not just what's returned.
+    result_truncated = n_largest_blocks(
+        sdf,
+        blocking_rule=block_on("first_name", "surname"),
+        link_type="dedupe_only",
+        n_largest=1,
+    ).as_record_list()
+    assert len(result_truncated) == 1
+    assert result_truncated[0]["proportion_of_comparisons"] == pytest.approx(36 / 41)
+    assert result_truncated[0][
+        "cumulative_proportion_of_comparisons"
+    ] == pytest.approx(36 / 41)
 
 
 def test_n_largest_blocks_raises_for_no_equi_join_rule():


### PR DESCRIPTION
## Summary

Related to #1946 - see my comment there. Stacks on #3223 (the equi-join error fix), which shows as included here until that merges.

`n_largest_blocks` (#2260) returns raw `block_count` per block, but not what fraction of the rule's total comparisons that block represents. That fraction is usually the number that actually matters for diagnosing skew: in my own case, a `legal_form` blocking rule where one value was 92% of everything, generating an estimated 23 billion comparisons and hanging for 3+ hours. Getting that percentage today needs a second `count_comparisons_from_blocking_rules` call and manual division.

## Change

Added `proportion_of_comparisons` and `cumulative_proportion_of_comparisons` columns, computed via window functions over *all* blocks the rule generates (not just the returned `n_largest` rows), so the cumulative share stays meaningful even when the output is truncated - verified with a fixture wider than `n_largest` that truncating doesn't change the proportions.

Also added the topic-guide section the function's own docstring already links to (`performance.md`) but which never actually mentioned the function.

## Why draft

This adds columns to a public function's output. I asked in #1946 whether that should be unconditional (as implemented here) or opt-in via a kwarg, and wanted to open this for visibility/feedback rather than presenting the schema change as settled. Happy to adjust based on preference.

## Testing

Updated the 4 hand-written comparison-SQL blocks in the existing `test_n_largest_blocks` (exact `as_dict()` equality) to compute the same columns, added `test_n_largest_blocks_proportions` with a deliberately skewed fixture and exact expected values (including the truncation case above). Ran the affected tests against both `duckdb` and `sqlite` locally, plus `ruff check` and `mypy` on the changed module.