### PR TITLE
Warn when cluster studio sample_size exceeds available clusters (#1026)

### DIFF
--- a/splink/internals/cluster_studio.py
+++ b/splink/internals/cluster_studio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import random
 from typing import TYPE_CHECKING, Any, Literal, Optional
@@ -17,6 +18,8 @@ from splink.internals.unique_id_concat import (
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:
     from splink.internals.linker import Linker
+
+logger = logging.getLogger(__name__)
 
 SamplingMethods = Literal[
     "random", "by_cluster_size", "lowest_density_clusters_by_size"
@@ -170,7 +173,17 @@ def _get_random_cluster_ids(
     cluster_count = df_cluster_count.as_record_list()[0]["count"]
     df_cluster_count.drop_table_from_database_and_remove_from_cache()
 
-    proportion = sample_size / cluster_count
+    if sample_size >= cluster_count:
+        logger.warning(
+            f"The requested sample_size ({sample_size}) is greater than or equal "
+            f"to the number of distinct clusters ({cluster_count}), so all "
+            f"{cluster_count} clusters will be returned. This can be a sign "
+            "that your clustering threshold is too low, or that your model "
+            "is overly 'matchy', resulting in fewer, larger clusters than "
+            "expected."
+        )
+
+    proportion = min(sample_size / cluster_count, 1.0)
 
     # Deterministic, hash-based sampling on cluster_id so the selected sample is
     # reproducible across runs (and identical for a given seed).
@@ -313,6 +326,13 @@ def _get_cluster_ids(
         )
         if len(cluster_id_infos) > sample_size:
             cluster_id_infos = random.sample(cluster_id_infos, k=sample_size)
+        elif len(cluster_id_infos) < sample_size:
+            logger.warning(
+                f"The requested sample_size ({sample_size}) is greater than the "
+                "number of distinct cluster sizes available "
+                f"({len(cluster_id_infos)}), so only {len(cluster_id_infos)} "
+                "clusters will be returned."
+            )
         cluster_names = [
             f"Cluster ID: {c['cluster_id']}, size:  {c['cluster_size']}"
             for c in cluster_id_infos
@@ -332,6 +352,13 @@ def _get_cluster_ids(
         )
         if len(cluster_id_infos) > sample_size:
             cluster_id_infos = random.sample(cluster_id_infos, k=sample_size)
+        elif len(cluster_id_infos) < sample_size:
+            logger.warning(
+                f"The requested sample_size ({sample_size}) is greater than the "
+                "number of distinct cluster sizes available "
+                f"({len(cluster_id_infos)}), so only {len(cluster_id_infos)} "
+                "clusters will be returned."
+            )
         cluster_names = [
             f"""Cluster ID: {c["cluster_id"]}, density (4dp): {c["density_4dp"]},
             size: {c["cluster_size"]}"""

--- a/tests/test_cluster_studio.py
+++ b/tests/test_cluster_studio.py
@@ -1,6 +1,57 @@
-from splink.internals.cluster_studio import _get_lowest_density_clusters
+import logging
+
+from splink.internals.cluster_studio import (
+    _get_lowest_density_clusters,
+    _get_random_cluster_ids,
+)
 from splink.internals.duckdb.database_api import DuckDBAPI
 from splink.internals.linker import Linker
+
+
+def _make_linker_with_clusters(cluster_ids):
+    person_ids = [i + 1 for i in range(len(cluster_ids))]
+    settings = {
+        "link_type": "dedupe_only",
+        "unique_id_column_name": "person_id",
+    }
+    db_api = DuckDBAPI()
+    df_sdf = db_api.register({"person_id": person_ids})
+    linker = Linker(df_sdf, settings)
+
+    df_clustered_nodes = linker.table_management.register_table(
+        {"person_id": person_ids, "cluster_id": cluster_ids},
+        "df_clustered_nodes",
+        overwrite=True,
+    )
+    return linker, df_clustered_nodes
+
+
+def test_random_sample_size_exceeds_cluster_count_warns(caplog):
+    # Only 3 distinct clusters exist
+    cluster_ids = ["A", "A", "B", "B", "C"]
+    linker, df_clustered_nodes = _make_linker_with_clusters(cluster_ids)
+
+    with caplog.at_level(logging.WARNING):
+        result = _get_random_cluster_ids(linker, df_clustered_nodes, sample_size=10)
+
+    assert sorted(result) == ["A", "B", "C"]
+    assert any(
+        "requested sample_size (10)" in record.message and "3" in record.message
+        for record in caplog.records
+    )
+
+
+def test_random_sample_size_within_cluster_count_no_warning(caplog):
+    cluster_ids = ["A", "A", "B", "B", "C"]
+    linker, df_clustered_nodes = _make_linker_with_clusters(cluster_ids)
+
+    with caplog.at_level(logging.WARNING):
+        result = _get_random_cluster_ids(linker, df_clustered_nodes, sample_size=2)
+
+    assert len(result) == 2
+    assert not any(
+        "requested sample_size" in record.message for record in caplog.records
+    )
 
 
 def test_density_sample():


### PR DESCRIPTION
Addresses #1026.

The original DuckDB crash reported in this issue (`Sample sample_size 133.3 out of range`) looks like it's already fixed on `master` — `SplinkDialect.proportion_sample_sql` now returns an empty `WHERE` filter for `proportion >= 1.0`, so it no longer errors when `sample_size` exceeds the number of available clusters.

What's still missing, and what this PR adds, is the actual feedback the issue asks for: previously that case silently returned *all* clusters with no indication anything was off. Now:

- `_get_random_cluster_ids` logs a warning naming the requested `sample_size`, the actual number of distinct clusters, and notes this can indicate an over-low clustering threshold or an overly "matchy" model — then clamps `proportion` to `min(sample_size / cluster_count, 1.0)` so the intent is explicit locally rather than relying on the dialect-level guard.
- The same silent-shortfall case in `_get_cluster_ids`'s `by_cluster_size` / `lowest_density_clusters_by_size` branches (which also returned fewer clusters than requested with no signal) gets a matching warning.

**Testing:** added `test_random_sample_size_exceeds_cluster_count_warns` and `test_random_sample_size_within_cluster_count_no_warning` to `tests/test_cluster_studio.py`, covering both the warning and the "no false-positive warning" case. Existing `test_density_sample` untouched. `ruff check`/`format` and `mypy` both clean.

I noticed the issue still carries a several-years-old self-assignment — flagging that here in case it's stale and someone else should take a look, happy to have this superseded if there's already work in progress I didn't find.
