### PR TITLE
Fix OOM issue when input table is large

### DIFF
--- a/splink/internals/comparison_vector_values.py
+++ b/splink/internals/comparison_vector_values.py
@@ -65,20 +65,13 @@ def compute_comparison_vector_values_from_id_pairs_sqls(
     select_columns = [*columns_to_select_for_blocking, "b.match_key"]
     select_cols_expr = ",\n".join(indent_sql(col) for col in select_columns)
 
-    # Where there are large numbers of unmatched records, the DuckDB query planner
-    # can struggle with the double inner join below.  It should
-    # push the filters down to the input tables, but it doesn't always do this.
-    # This forces it.  it is only really relevant in the link only case,
-    # where one dataset is much larger than the other
-    # This optimisation is here due to poor performance observed in
-    # the `uk_address_matcher` package
-    # TODO: Once DuckDB 1.5 is released, check this is still needed
+    # DuckDB may materialise the complete shared input CTE when it is joined twice
+    # below. Filtering it to endpoints in the current blocked-pairs table prevents
+    # that materialisation across link types. This was reproduced with DuckDB 1.5.x.
+    # This optimisation was originally added due to poor performance observed in
+    # the `uk_address_matcher` package.
     # ref https://github.com/moj-analytical-services/uk_address_matcher/issues/226
-    if (
-        input_tablename_l == input_tablename_r
-        and link_type == "two_dataset_link_only"
-        and sql_dialect_str == "duckdb"
-    ):
+    if input_tablename_l == input_tablename_r and sql_dialect_str == "duckdb":
         uid_expr = _composite_unique_id_from_nodes_sql(unique_id_columns)
         sql = f"""
         select *


### PR DESCRIPTION
## Summary

This generalizes an existing DuckDB optimization so prediction only materializes
the input records referenced by the current blocked-pairs table.

## The issue

DuckDB prediction could use memory proportional to the complete input nodes table,
even when scoring only a small registered blocked-pairs table.

## Reproduction

1. Create a DuckDB-backed linker over a wide nodes table containing several
   million records. The measured reproduction used 8,029,776 records.
2. Register a blocked-pairs table containing only 1,000 pairs with
   `register_blocked_pairs_for_predict()`.
3. Call `linker.inference.predict()` and record DuckDB's
   `system_peak_buffer_memory`.

Despite scoring only 1,000 pairs, the existing path materialized all 8,029,776
node records and used 2.86 GB of peak DuckDB buffer memory. The pairs referenced
only approximately 1,001 distinct node records.

<details>
<summary>Generated SQL and root cause</summary>

Prediction joins the blocked-pairs table to the same shared input relation twice:

```sql
from __splink__blocked_id_pairs as b
inner join __splink__df_concat_with_tf as l
  on l.unique_id = b.join_key_l
inner join __splink__df_concat_with_tf as r
  on r.unique_id = b.join_key_r
```

On DuckDB 1.5.x, the complete shared `__splink__df_concat_with_tf` CTE can be
materialized before these joins. Memory therefore scales with the complete nodes
table rather than the records referenced by the current pair slice.

Splink already contains an exact-ID prefilter for `two_dataset_link_only`:

```sql
select *
from __splink__df_concat_with_tf
where unique_id in (
  select join_key_l from __splink__blocked_id_pairs
)
or unique_id in (
  select join_key_r from __splink__blocked_id_pairs
)
```

The same materialization issue is reproducible with other link types.

</details>

## The fix

The existing exact-ID prefilter now applies whenever both joins use the same input
table and the backend is DuckDB. It is no longer restricted to
`two_dataset_link_only`.

For the reproduction described above, the filtered path materialized approximately
1,001 distinct endpoint records, reduced peak buffer memory from 2.86 GB to
96.6 MB, and produced identical predictions.

There are no changes to blocking or prediction semantics, composite-ID handling,
public APIs, or non-DuckDB backends.

## Tests

- Covers `dedupe_only`, `link_only`, `link_and_dedupe`, and
  `two_dataset_link_only`.
- Verifies the optimization is not generated for different input tables or
  non-DuckDB dialects.
- Compares complete filtered and unfiltered prediction output.
- Covers repeated endpoints and composite source-dataset/unique IDs.
- Verifies that 1,000 pairs over 20,000 nodes materialize only the 1,001 referenced
  endpoints.

Validation: `make check` passed; `make test` passed with 380 tests and 13 skips.