### PR TITLE
Move `igraph` to an optional `graphs` extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `igraph` is now an optional extra (`pip install 'splink[graphs]'`) rather than a required dependency; it is only used by the `is_bridge` edge metric, which degrades gracefully when it is not installed
+
 ### Fixed
 
 - Updated `.jar` (0.2.1) with newer dependency versions [#3098](https://github.com/moj-analytical-services/splink/pull/3098)

--- a/docs/topic_guides/evaluation/clusters/how_to_compute_metrics.nb.py
+++ b/docs/topic_guides/evaluation/clusters/how_to_compute_metrics.nb.py
@@ -69,7 +69,7 @@
 # * Cluster density
 # * Cluster centrality
 #
-# All of these metrics are calculated by default. If you are unable to install the `igraph` package required for 'is bridge', this metric won't be calculated, however all other metrics will still be generated.
+# All of these metrics are calculated by default. The 'is bridge' metric requires the `igraph` package, which is an optional extra (install with `pip install 'splink[graphs]'`); without it, this metric won't be calculated, however all other metrics will still be generated.
 #
 #
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,13 @@ dependencies = [
     "sqlglot>=17.6.0",
     "altair>=5.0.1",
     "Jinja2>=3.0.3",
-    "igraph>=0.11.2",
 ]
 
 [project.optional-dependencies]
+# igraph is only used for the optional 'is_bridge' edge metric in
+# graph metrics; everything else works without it. It is GPL-licensed,
+# so keeping it optional also matters for users who redistribute.
+graphs = ["igraph>=0.11.2"]
 pyspark = ["pyspark>=3.5.0"]
 spark = ["pyspark>=3.5.0"]
 # sqlite doesn't _require_ this functionality, but it's used if we want to use fuzzy levels
@@ -66,6 +69,7 @@ docs = [
     "neoteroi-mkdocs>=1.1.2",
     "pymdown-extensions>=10.15",
 ]
+graphs = ["igraph>=0.11.2"]
 linting = ["ruff>=0.15.18"]
 pandas = ["pandas>=1.3.5", "numpy>=1.19.3"]
 postgres = [
@@ -81,6 +85,7 @@ testing-core = [
     "networkx>=2.5.1",
     "pytest-cov>=5.0.0",
     "pytest-xdist>=3.0.0",
+    { "include-group" = "graphs" },
     { "include-group" = "postgres" },
     { "include-group" = "sqlite" },
 ]

--- a/splink/internals/edge_metrics.py
+++ b/splink/internals/edge_metrics.py
@@ -42,7 +42,8 @@ def compute_edge_metrics(
         )
     except MissingDependencyException:
         logger.warning(
-            "To compute edge metrics you must install the `igraph` package. "
+            "To compute edge metrics you must install the `igraph` package "
+            "(e.g. `pip install 'splink[graphs]'`). "
             "Continuing without computing edge metrics."
         )
         df_edge_metrics = compute_basic_edge_metrics(
@@ -84,7 +85,8 @@ def compute_igraph_metrics(
     except ImportError:
         raise MissingDependencyException(
             "You need to install the 'igraph' package to compute "
-            "the edge metric 'is_bridge'."
+            "the edge metric 'is_bridge' "
+            "(e.g. `pip install 'splink[graphs]'`)."
         ) from None
     uid_cols = linker._settings_obj.column_info_settings.unique_id_input_columns
     # need composite unique ids

--- a/uv.lock
+++ b/uv.lock
@@ -3070,12 +3070,14 @@ source = { editable = "." }
 dependencies = [
     { name = "altair" },
     { name = "duckdb" },
-    { name = "igraph" },
     { name = "jinja2" },
     { name = "sqlglot" },
 ]
 
 [package.optional-dependencies]
+graphs = [
+    { name = "igraph" },
+]
 postgres = [
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
@@ -3101,6 +3103,7 @@ core = [
     { name = "sqlglot" },
 ]
 dev = [
+    { name = "igraph" },
     { name = "mypy" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
@@ -3128,6 +3131,9 @@ docs = [
     { name = "neoteroi-mkdocs", marker = "python_full_version >= '3.13' or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
     { name = "pymdown-extensions", marker = "python_full_version >= '3.13' or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
 ]
+graphs = [
+    { name = "igraph" },
+]
 linting = [
     { name = "ruff" },
 ]
@@ -3152,6 +3158,7 @@ sqlite = [
     { name = "rapidfuzz" },
 ]
 testing = [
+    { name = "igraph" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra != 'group-6-splink-spark-3') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra != 'group-6-splink-spark-3') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
     { name = "psycopg2-binary" },
@@ -3164,6 +3171,7 @@ testing = [
     { name = "sqlalchemy" },
 ]
 testing-core = [
+    { name = "igraph" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-spark-4') or (extra == 'group-6-splink-spark-3' and extra == 'group-6-splink-testing')" },
     { name = "psycopg2-binary" },
@@ -3185,7 +3193,7 @@ typechecking-dev = [
 requires-dist = [
     { name = "altair", specifier = ">=5.0.1" },
     { name = "duckdb", specifier = ">=0.9.2" },
-    { name = "igraph", specifier = ">=0.11.2" },
+    { name = "igraph", marker = "extra == 'graphs'", specifier = ">=0.11.2" },
     { name = "jinja2", specifier = ">=3.0.3" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.0" },
     { name = "pyarrow", marker = "extra == 'pyarrow'", specifier = ">=15.0.0" },
@@ -3195,7 +3203,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0.0" },
     { name = "sqlglot", specifier = ">=17.6.0" },
 ]
-provides-extras = ["pyspark", "spark", "sqlite", "postgres", "pyarrow"]
+provides-extras = ["graphs", "pyspark", "spark", "sqlite", "postgres", "pyarrow"]
 
 [package.metadata.requires-dev]
 core = [
@@ -3203,6 +3211,7 @@ core = [
     { name = "sqlglot" },
 ]
 dev = [
+    { name = "igraph", specifier = ">=0.11.2" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "networkx", specifier = ">=2.5.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
@@ -3229,6 +3238,7 @@ docs = [
     { name = "neoteroi-mkdocs", marker = "python_full_version >= '3.13'", specifier = ">=1.1.2" },
     { name = "pymdown-extensions", marker = "python_full_version >= '3.13'", specifier = ">=10.15" },
 ]
+graphs = [{ name = "igraph", specifier = ">=0.11.2" }]
 linting = [{ name = "ruff", specifier = ">=0.15.18" }]
 pandas = [
     { name = "numpy", specifier = ">=1.19.3" },
@@ -3242,6 +3252,7 @@ spark-3 = [{ name = "pyspark", marker = "python_full_version < '3.12'", specifie
 spark-4 = [{ name = "pyspark", specifier = ">=4.0.0" }]
 sqlite = [{ name = "rapidfuzz", specifier = ">=3.10.0" }]
 testing = [
+    { name = "igraph", specifier = ">=0.11.2" },
     { name = "networkx", specifier = ">=2.5.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pyarrow", specifier = ">=15.0.0" },
@@ -3253,6 +3264,7 @@ testing = [
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
 testing-core = [
+    { name = "igraph", specifier = ">=0.11.2" },
     { name = "networkx", specifier = ">=2.5.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pyarrow", specifier = ">=15.0.0" },


### PR DESCRIPTION
Fixes #3235.

`igraph` is GPL-2.0-or-later, while Splink itself is MIT. As a mandatory dependency it makes Splink unusable for anyone who redistributes it inside a non-GPL product, even though it only serves the optional `is_bridge` edge metric — a single lazy import in `edge_metrics.py` with graceful degradation that is already tested (`test_edges_without_igraph`) and documented.

This PR moves it to an optional extra, restoring the original intent described in #2427 (it was meant to be optional and became required through a packaging accident, later formalised in #2551 before the license angle had been raised):

- **`pyproject.toml`**: `igraph` moves from `dependencies` to `[project.optional-dependencies] graphs = ["igraph>=0.11.2"]` (the extras name suggested in #2427). A matching `graphs` dependency-group is included in `testing-core` — same pattern as `postgres`/`sqlite` — so CI still installs igraph and exercises both the with-igraph path and the mocked-absent path.
- **`uv.lock`**: regenerated; the only change is igraph moving from core to the extra/groups.
- **`edge_metrics.py`**: the existing warning and `MissingDependencyException` messages now mention `pip install 'splink[graphs]'`.
- **`docs/topic_guides/evaluation/clusters/how_to_compute_metrics.nb.py`**: the existing note about running without igraph now names the extra.
- **`CHANGELOG.md`**: entry under Unreleased → Changed.

No runtime code paths change: with the extra installed, behaviour is identical; without it, behaviour is exactly today's already-tested degradation (all metrics except `is_bridge`).

One follow-up outside this PR, flagged in #2551: the conda recipe should be updated to match (igraph out of run requirements).
