### PR TITLE
Less flaky notebook renders

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Render notebooks
         id: render_notebooks
-        run: cd docs/demos && ./render_notebooks.sh
+        run: cd docs/demos && ./render_notebooks.sh -j 4
 
       - name: Build documentation
         id: build_documentation

--- a/docs/demos/render_notebooks.sh
+++ b/docs/demos/render_notebooks.sh
@@ -27,21 +27,42 @@ pids=()
 files=()
 i=0
 
+# Runs jupytext with a 300s timeout (enough headroom above any legitimate notebook runtime)
+# to ensure ZMQ kernel-connection hangs are detected rather than blocking indefinitely.
+_jupytext_exec() {
+  local f="$1" logfile="$2" out="${1%.nb.py}.ipynb"
+  if command -v timeout &>/dev/null; then
+    timeout 300 uv run jupytext --to notebook --execute --run-path . --set-kernel python3 --output "$out" "$f" >> "$logfile" 2>&1
+  else
+    uv run jupytext --to notebook --execute --run-path . --set-kernel python3 --output "$out" "$f" >> "$logfile" 2>&1
+  fi
+}
+
 run_notebook() {
   local f="$1" idx="$2"
-  local out="${f%.nb.py}.ipynb"
-  local nb_start nb_end elapsed
+  local logfile="$TMP/$idx.log"
+  local nb_start nb_end
 
   nb_start=$(date +%s)
-  if uv run jupytext --to notebook --execute --run-path . --set-kernel python3 --output "$out" "$f" > "$TMP/$idx.log" 2>&1; then
+  if _jupytext_exec "$f" "$logfile"; then
     nb_end=$(date +%s)
-    elapsed=$(( nb_end - nb_start ))
-    echo "success:$elapsed" > "$TMP/$idx.result"
-  else
-    nb_end=$(date +%s)
-    elapsed=$(( nb_end - nb_start ))
-    echo "fail:$elapsed" > "$TMP/$idx.result"
+    echo "success:$(( nb_end - nb_start ))" > "$TMP/$idx.result"
+    return
   fi
+
+  # Retry if jupytext never started reading the file — the ZMQ kernel-connection failure
+  # signature. A genuine notebook failure will have "[jupytext] Reading" in the log.
+  if ! grep -q '\[jupytext\] Reading' "$logfile"; then
+    echo "[retry: kernel connection failure, retrying once]" >> "$logfile"
+    if _jupytext_exec "$f" "$logfile"; then
+      nb_end=$(date +%s)
+      echo "success:$(( nb_end - nb_start ))" > "$TMP/$idx.result"
+      return
+    fi
+  fi
+
+  nb_end=$(date +%s)
+  echo "fail:$(( nb_end - nb_start ))" > "$TMP/$idx.result"
 }
 
 while IFS= read -r f; do

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,20 @@ plugins:
 hooks:
   - docs/hooks/__init__.py
 
+exclude_docs: |
+  *
+  # Keep source pages
+  !*.md
+  !**/*.md
+  !**/*.ipynb
+  # And the assets we have
+  !**/*.png
+  !**/*.ico
+  !**/*.mp4
+  !**/*.html
+  !**/*.css
+  !**/*.js
+
 markdown_extensions:
   # add id/style etc to markdown elements - see getting started button in docs/index.md
   # markdown


### PR DESCRIPTION
Follow-up to #3249.

There are a couple of issues with running the render script in CI which can cause the workflow to fail or hang to do with getting hold of kernel ports. Running the workflow for 15 trials off the current `master` we get:
* 8 passes
* 3 fails
* 4 hangs
We can re-run attempts, but it's not really a reasonable failure rate for part of our core infrastructure.

So here we do a couple of things:
* run fewer at a time
* timeout a hanging notebook after 5m

Running that 19 times there have been 0 failures, and only 1 'long' run (8min), with the rest around the 3.5-4min mark.

I also trim down the number of files we include in our `mkdocs` build.