### PR TITLE
Improve duckdb profiling

### DIFF
--- a/splink/internals/duckdb/database_api_with_profiling.py
+++ b/splink/internals/duckdb/database_api_with_profiling.py
@@ -1,71 +1,141 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from os import PathLike
 from pathlib import Path
-from typing import Union
+from typing import Literal, Union
 
 import duckdb
 
 from .database_api import DuckDBAPI
-from .dataframe import DuckDBDataFrame
+
+DuckDBProfilingType = Literal["query_tree", "json", "query_tree_optimizer", "no_output"]
+DuckDBProfilingMode = Literal["standard", "detailed", "all"]
+DuckDBProfilingCoverage = Literal["SELECT", "ALL"]
 
 
 class DuckDBAPIWithProfiling(DuckDBAPI):
+    """DuckDB API that writes a profile for each table-creating query."""
+
     def __init__(
         self,
         connection: Union[str, duckdb.DuckDBPyConnection] = ":memory:",
         output_schema: str | None = None,
         query_profiling_dir: str | PathLike[str] = "tmp_query_profiling",
+        enable_profiling: DuckDBProfilingType = "query_tree",
+        profiling_mode: DuckDBProfilingMode = "detailed",
+        profiling_coverage: DuckDBProfilingCoverage = "SELECT",
     ):
+        """Create a DuckDB API that profiles table-creating queries.
+
+        Args:
+            enable_profiling: DuckDB profiling output format. Use ``"json"``
+                for machine-readable output, ``"query_tree"`` for text,
+                ``"query_tree_optimizer"`` for text with optimizer details,
+                or ``"no_output"`` to collect profiling without writing a
+                profile file.
+            profiling_mode: ``"standard"`` collects execution metrics and
+                ``"detailed"`` adds planner and optimizer timings. The
+                ``"all"`` mode is available in newer DuckDB versions.
+            profiling_coverage: ``"SELECT"`` profiles SELECT queries only;
+                ``"ALL"`` also profiles non-SELECT statements.
+        """
+        if enable_profiling not in (
+            "query_tree",
+            "json",
+            "query_tree_optimizer",
+            "no_output",
+        ):
+            raise ValueError(
+                "enable_profiling must be one of 'query_tree', 'json', "
+                "'query_tree_optimizer', or 'no_output'"
+            )
+        if profiling_mode not in ("standard", "detailed", "all"):
+            raise ValueError(
+                "profiling_mode must be one of 'standard', 'detailed', or 'all'"
+            )
+        if profiling_coverage not in ("SELECT", "ALL"):
+            raise ValueError("profiling_coverage must be either 'SELECT' or 'ALL'")
+
+        self._profiling_active = False
         super().__init__(connection=connection, output_schema=output_schema)
         self.query_profiling_dir = Path(query_profiling_dir)
         self.query_profiling_dir.mkdir(parents=True, exist_ok=True)
+        self.enable_profiling = enable_profiling
+        self.profiling_mode = profiling_mode
+        self.profiling_coverage = profiling_coverage
         self._query_profile_counter = 0
-        self._pending_profile_path: Path | None = None
-        self._pending_profile_sql: str | None = None
 
     def _should_profile_sql(self, sql: str) -> bool:
+        if self.profiling_coverage == "ALL":
+            return True
         stripped_sql = sql.lstrip().upper()
         return stripped_sql.startswith("SELECT") or stripped_sql.startswith("WITH")
 
     def _next_query_profile_path(self, templated_name: str) -> Path:
-        self._query_profile_counter += 1
         safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", templated_name).strip("_")
         if not safe_name:
             safe_name = "query"
-        filename = f"{self._query_profile_counter:04d}_{safe_name}_duckdb.txt"
-        return self.query_profiling_dir / filename
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        extension = "json" if self.enable_profiling == "json" else "txt"
+        while True:
+            self._query_profile_counter += 1
+            filename = (
+                f"{timestamp}_{self._query_profile_counter:04d}_"
+                f"{safe_name}_duckdb.{extension}"
+            )
+            profile_path = self.query_profiling_dir / filename
+            if not profile_path.exists():
+                return profile_path
+
+    def _disable_profiling(self) -> None:
+        self._profiling_active = False
+        super()._execute_sql_against_backend("PRAGMA disable_profiling")
 
     def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
+        final_sql = super()._setup_for_execute_sql(sql, physical_name)
         if self._should_profile_sql(sql):
-            self._pending_profile_path = self._next_query_profile_path(physical_name)
-            self._pending_profile_sql = sql
-        else:
-            self._pending_profile_path = None
-            self._pending_profile_sql = None
-
-        return super()._setup_for_execute_sql(sql, physical_name)
-
-    def _cleanup_for_execute_sql(
-        self, table: duckdb.DuckDBPyRelation, templated_name: str, physical_name: str
-    ) -> DuckDBDataFrame:
-        try:
-            output_df = self.table_to_splink_dataframe(templated_name, physical_name)
-            if self._pending_profile_path is not None and self._pending_profile_sql:
-                explain_result = super()._execute_sql_against_backend(
-                    f"EXPLAIN ANALYZE {self._pending_profile_sql}"
+            profile_path = self._next_query_profile_path(physical_name)
+            escaped_path = str(profile_path).replace("'", "''")
+            try:
+                super()._execute_sql_against_backend(
+                    "PRAGMA enable_profiling='no_output'"
                 )
-                rows = explain_result.fetchall()
-                if len(rows) == 1 and len(rows[0]) == 2:
-                    profile_text = rows[0][1]
-                else:
-                    profile_text = "\n".join(
-                        " | ".join("" if value is None else str(value) for value in row)
-                        for row in rows
-                    )
-                self._pending_profile_path.write_text(profile_text, encoding="utf-8")
-            return output_df
-        finally:
-            self._pending_profile_path = None
-            self._pending_profile_sql = None
+                super()._execute_sql_against_backend(
+                    f"PRAGMA profiling_mode='{self.profiling_mode}'"
+                )
+                super()._execute_sql_against_backend(
+                    f"PRAGMA profiling_coverage='{self.profiling_coverage}'"
+                )
+                super()._execute_sql_against_backend(
+                    f"PRAGMA profiling_output='{escaped_path}'"
+                )
+                super()._execute_sql_against_backend(
+                    f"PRAGMA enable_profiling='{self.enable_profiling}'"
+                )
+            except BaseException:
+                try:
+                    self._disable_profiling()
+                except Exception:
+                    pass
+                raise
+            self._profiling_active = True
+
+        return final_sql
+
+    def _execute_sql_against_backend(self, final_sql: str) -> duckdb.DuckDBPyRelation:
+        if not self._profiling_active:
+            return super()._execute_sql_against_backend(final_sql)
+
+        try:
+            result = super()._execute_sql_against_backend(final_sql)
+        except BaseException:
+            try:
+                self._disable_profiling()
+            except Exception:
+                pass
+            raise
+        else:
+            self._disable_profiling()
+            return result

--- a/splink/internals/duckdb/database_api_with_profiling.py
+++ b/splink/internals/duckdb/database_api_with_profiling.py
@@ -23,9 +23,9 @@ class DuckDBAPIWithProfiling(DuckDBAPI):
         connection: Union[str, duckdb.DuckDBPyConnection] = ":memory:",
         output_schema: str | None = None,
         query_profiling_dir: str | PathLike[str] = "tmp_query_profiling",
-        enable_profiling: DuckDBProfilingType = "query_tree",
-        profiling_mode: DuckDBProfilingMode = "detailed",
-        profiling_coverage: DuckDBProfilingCoverage = "SELECT",
+        enable_profiling: DuckDBProfilingType = "json",
+        profiling_mode: DuckDBProfilingMode = "standard",
+        profiling_coverage: DuckDBProfilingCoverage = "ALL",
     ):
         """Create a DuckDB API that profiles table-creating queries.
 
@@ -39,7 +39,8 @@ class DuckDBAPIWithProfiling(DuckDBAPI):
                 ``"detailed"`` adds planner and optimizer timings. The
                 ``"all"`` mode is available in newer DuckDB versions.
             profiling_coverage: ``"SELECT"`` profiles SELECT queries only;
-                ``"ALL"`` also profiles non-SELECT statements.
+                ``"ALL"`` also profiles non-SELECT statements. DuckDB versions
+                before this setting was introduced use their native coverage.
         """
         if enable_profiling not in (
             "query_tree",
@@ -105,9 +106,13 @@ class DuckDBAPIWithProfiling(DuckDBAPI):
                 super()._execute_sql_against_backend(
                     f"PRAGMA profiling_mode='{self.profiling_mode}'"
                 )
-                super()._execute_sql_against_backend(
-                    f"PRAGMA profiling_coverage='{self.profiling_coverage}'"
-                )
+                try:
+                    super()._execute_sql_against_backend(
+                        f"PRAGMA profiling_coverage='{self.profiling_coverage}'"
+                    )
+                except duckdb.CatalogException as exc:
+                    if "profiling_coverage" not in str(exc):
+                        raise
                 super()._execute_sql_against_backend(
                     f"PRAGMA profiling_output='{escaped_path}'"
                 )


### PR DESCRIPTION
Summary
Improve DuckDBAPIWithProfiling so it profiles the actual `CREATE TABLE AS` operations executed by Splink, rather than rerunning queries with `EXPLAIN ANALYZE`.

Profiles now default to JSON with standard detail and all-statement coverage. Users can configure DuckDB’s profiling format, mode, coverage, and output directory. This produces more accurate profiles while avoiding duplicate query execution.

Also improves the filename profiles output to.