### PR TITLE
Prefilter when chunking

### DIFF
--- a/splink/internals/duckdb/pruned_prediction.py
+++ b/splink/internals/duckdb/pruned_prediction.py
@@ -1,4 +1,4 @@
-"""DuckDB-specific registered-pair prediction.
+"""DuckDB-specific source-pruned prediction.
 
 This planner workaround is kept separate so it can be removed without changing the
 normal prediction path.
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class _RegisteredPredictInputs:
+class _PrunedPredictInputs:
     left: SplinkDataFrame
     right: SplinkDataFrame
 
@@ -44,7 +44,7 @@ class _RegisteredPredictInputs:
             dataframe.drop_table_from_database_and_remove_from_cache()
 
 
-def _materialize_registered_pair_input(
+def _materialise_pruned_predict_input(
     linker: Linker,
     blocked_pairs: SplinkDataFrame,
     side: Literal["l", "r"],
@@ -59,38 +59,47 @@ def _materialize_registered_pair_input(
         linker._input_tables_dict,
         source_dataset_input_column=column_info.source_dataset_input_column,
     )
+    # the semi join filters down the source records to only those that exist in
+    # the blocked pairs
     sql = f"""
     select source.*
     from ({concat_sql}) as source
     semi join {blocked_pairs.physical_name} as pairs
     on {uid_expr} = pairs.join_key_{side}
     """
-    templated_name = f"__splink__df_registered_predict_input_{side}"
+    templated_name = f"__splink__df_pruned_predict_input_{side}"
     pipeline = CTEPipeline()
     pipeline.enqueue_sql(sql, templated_name)
     return linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
 
-def _materialize_registered_pair_inputs(
+def _materialise_pruned_predict_inputs(
     linker: Linker,
     blocked_pairs: SplinkDataFrame,
-) -> _RegisteredPredictInputs:
-    left = _materialize_registered_pair_input(linker, blocked_pairs, "l")
+) -> _PrunedPredictInputs:
+    inputs = []
+
     try:
-        right = _materialize_registered_pair_input(linker, blocked_pairs, "r")
+        left = _materialise_pruned_predict_input(linker, blocked_pairs, "l")
+        inputs.append(left)
+
+        right = _materialise_pruned_predict_input(linker, blocked_pairs, "r")
+        inputs.append(right)
+
+        return _PrunedPredictInputs(left=left, right=right)
     except Exception:
-        left.drop_table_from_database_and_remove_from_cache()
+        for dataframe in reversed(inputs):
+            dataframe.drop_table_from_database_and_remove_from_cache()
         raise
-    return _RegisteredPredictInputs(left=left, right=right)
 
 
-def _enqueue_registered_inputs_with_tf(
+def _enqueue_pruned_inputs_with_tf(
     linker: Linker,
     pipeline: CTEPipeline,
-    inputs: _RegisteredPredictInputs,
+    inputs: _PrunedPredictInputs,
 ) -> tuple[str, str]:
     append_term_frequencies_to_pipeline(linker, pipeline)
-    left_name = "__splink__df_registered_predict_input_with_tf_l"
+    left_name = "__splink__df_pruned_predict_input_with_tf_l"
     pipeline.enqueue_sql(
         _join_tf_to_input_table_sql(
             linker,
@@ -99,10 +108,7 @@ def _enqueue_registered_inputs_with_tf(
         ),
         left_name,
     )
-    if inputs.left.physical_name == inputs.right.physical_name:
-        return left_name, left_name
-
-    right_name = "__splink__df_registered_predict_input_with_tf_r"
+    right_name = "__splink__df_pruned_predict_input_with_tf_r"
     pipeline.enqueue_sql(
         _join_tf_to_input_table_sql(
             linker,
@@ -114,29 +120,26 @@ def _enqueue_registered_inputs_with_tf(
     return left_name, right_name
 
 
-def predict_from_blocked_pairs_duckdb(
+def predict_from_blocked_pairs_with_source_pruning(
     linker: Linker,
     blocked_pairs: SplinkDataFrame,
     threshold_match_probability: float | None,
     threshold_match_weight: float | None,
-    emit_warning: bool,
 ) -> SplinkDataFrame:
     if linker._sql_dialect_str != "duckdb":
-        raise SplinkException(
-            "Registered-pair source pruning is currently supported only by DuckDB."
-        )
+        raise SplinkException("Source pruning is currently supported only by DuckDB.")
 
-    registered_inputs = _materialize_registered_pair_inputs(linker, blocked_pairs)
+    # Filter down input records to only those that appear in the blocked pairs
+    # and materialise
+    start_time = time.time()
+    pruned_inputs = _materialise_pruned_predict_inputs(linker, blocked_pairs)
     try:
         settings = linker._settings_obj
-        pipeline = CTEPipeline(
-            [blocked_pairs, registered_inputs.left, registered_inputs.right]
-        )
-        input_tablename_l, input_tablename_r = _enqueue_registered_inputs_with_tf(
-            linker, pipeline, registered_inputs
+        pipeline = CTEPipeline([blocked_pairs, pruned_inputs.left, pruned_inputs.right])
+        input_tablename_l, input_tablename_r = _enqueue_pruned_inputs_with_tf(
+            linker, pipeline, pruned_inputs
         )
 
-        start_time = time.time()
         pipeline.enqueue_list_of_sqls(
             compute_comparison_vector_values_from_id_pairs_sqls(
                 settings._columns_to_select_for_blocking,
@@ -160,28 +163,6 @@ def predict_from_blocked_pairs_duckdb(
         predict_time = time.time() - start_time
         logger.info(f"Predict time (post-blocking): {predict_time:.2f} seconds")
     finally:
-        registered_inputs.drop()
-
-    if emit_warning:
-        linker._predict_warning()
+        pruned_inputs.drop()
 
     return predictions
-
-
-def predict_from_registered_pairs_duckdb(
-    linker: Linker,
-    blocked_pairs_cache_key: str,
-    threshold_match_probability: float | None,
-    threshold_match_weight: float | None,
-    emit_warning: bool,
-) -> SplinkDataFrame:
-    blocked_pairs = linker._intermediate_table_cache.get_with_logging(
-        blocked_pairs_cache_key
-    )
-    return predict_from_blocked_pairs_duckdb(
-        linker,
-        blocked_pairs,
-        threshold_match_probability,
-        threshold_match_weight,
-        emit_warning,
-    )

--- a/splink/internals/duckdb/pruned_prediction.py
+++ b/splink/internals/duckdb/pruned_prediction.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from splink.internals.blocking import combine_unique_id_input_columns
@@ -32,16 +31,6 @@ if TYPE_CHECKING:
     from splink.internals.linker import Linker
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class _PrunedPredictInputs:
-    left: SplinkDataFrame
-    right: SplinkDataFrame
-
-    def drop(self) -> None:
-        for dataframe in (self.right, self.left):
-            dataframe.drop_table_from_database_and_remove_from_cache()
 
 
 def _materialise_pruned_predict_input(
@@ -73,38 +62,19 @@ def _materialise_pruned_predict_input(
     return linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
 
 
-def _materialise_pruned_predict_inputs(
-    linker: Linker,
-    blocked_pairs: SplinkDataFrame,
-) -> _PrunedPredictInputs:
-    inputs = []
-
-    try:
-        left = _materialise_pruned_predict_input(linker, blocked_pairs, "l")
-        inputs.append(left)
-
-        right = _materialise_pruned_predict_input(linker, blocked_pairs, "r")
-        inputs.append(right)
-
-        return _PrunedPredictInputs(left=left, right=right)
-    except Exception:
-        for dataframe in reversed(inputs):
-            dataframe.drop_table_from_database_and_remove_from_cache()
-        raise
-
-
 def _enqueue_pruned_inputs_with_tf(
     linker: Linker,
     pipeline: CTEPipeline,
-    inputs: _PrunedPredictInputs,
+    left_input: SplinkDataFrame,
+    right_input: SplinkDataFrame,
 ) -> tuple[str, str]:
     append_term_frequencies_to_pipeline(linker, pipeline)
     left_name = "__splink__df_pruned_predict_input_with_tf_l"
     pipeline.enqueue_sql(
         _join_tf_to_input_table_sql(
             linker,
-            inputs.left.templated_name,
-            inputs.left,
+            left_input.templated_name,
+            left_input,
         ),
         left_name,
     )
@@ -112,8 +82,8 @@ def _enqueue_pruned_inputs_with_tf(
     pipeline.enqueue_sql(
         _join_tf_to_input_table_sql(
             linker,
-            inputs.right.templated_name,
-            inputs.right,
+            right_input.templated_name,
+            right_input,
         ),
         right_name,
     )
@@ -132,12 +102,13 @@ def predict_from_blocked_pairs_with_source_pruning(
     # Filter down input records to only those that appear in the blocked pairs
     # and materialise
     start_time = time.time()
-    pruned_inputs = _materialise_pruned_predict_inputs(linker, blocked_pairs)
+    left_input = _materialise_pruned_predict_input(linker, blocked_pairs, "l")
+    right_input = _materialise_pruned_predict_input(linker, blocked_pairs, "r")
     try:
         settings = linker._settings_obj
-        pipeline = CTEPipeline([blocked_pairs, pruned_inputs.left, pruned_inputs.right])
+        pipeline = CTEPipeline([blocked_pairs, left_input, right_input])
         input_tablename_l, input_tablename_r = _enqueue_pruned_inputs_with_tf(
-            linker, pipeline, pruned_inputs
+            linker, pipeline, left_input, right_input
         )
 
         pipeline.enqueue_list_of_sqls(
@@ -163,6 +134,7 @@ def predict_from_blocked_pairs_with_source_pruning(
         predict_time = time.time() - start_time
         logger.info(f"Predict time (post-blocking): {predict_time:.2f} seconds")
     finally:
-        pruned_inputs.drop()
+        right_input.drop_table_from_database_and_remove_from_cache()
+        left_input.drop_table_from_database_and_remove_from_cache()
 
     return predictions

--- a/splink/internals/duckdb/registered_pair_prediction.py
+++ b/splink/internals/duckdb/registered_pair_prediction.py
@@ -1,0 +1,187 @@
+"""DuckDB-specific registered-pair prediction.
+
+This planner workaround is kept separate so it can be removed without changing the
+normal prediction path.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from splink.internals.blocking import combine_unique_id_input_columns
+from splink.internals.comparison_vector_values import (
+    compute_comparison_vector_values_from_id_pairs_sqls,
+)
+from splink.internals.exceptions import SplinkException
+from splink.internals.pipeline import CTEPipeline
+from splink.internals.predict import (
+    predict_from_comparison_vectors_sqls_using_settings,
+)
+from splink.internals.splink_dataframe import SplinkDataFrame
+from splink.internals.term_frequencies import (
+    _join_tf_to_input_table_sql,
+    append_term_frequencies_to_pipeline,
+)
+from splink.internals.unique_id_concat import _composite_unique_id_from_nodes_sql
+from splink.internals.vertically_concatenate import vertically_concatenate_sql
+
+if TYPE_CHECKING:
+    from splink.internals.linker import Linker
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _RegisteredPredictInputs:
+    left: SplinkDataFrame
+    right: SplinkDataFrame
+
+    def drop(self) -> None:
+        for dataframe in (self.right, self.left):
+            dataframe.drop_table_from_database_and_remove_from_cache()
+
+
+def _materialize_registered_pair_input(
+    linker: Linker,
+    blocked_pairs: SplinkDataFrame,
+    side: Literal["l", "r"],
+) -> SplinkDataFrame:
+    column_info = linker._settings_obj.column_info_settings
+    unique_id_columns = combine_unique_id_input_columns(
+        column_info.source_dataset_input_column,
+        column_info.unique_id_input_column,
+    )
+    uid_expr = _composite_unique_id_from_nodes_sql(unique_id_columns, "source")
+    concat_sql = vertically_concatenate_sql(
+        linker._input_tables_dict,
+        source_dataset_input_column=column_info.source_dataset_input_column,
+    )
+    sql = f"""
+    select source.*
+    from ({concat_sql}) as source
+    semi join {blocked_pairs.physical_name} as pairs
+    on {uid_expr} = pairs.join_key_{side}
+    """
+    templated_name = f"__splink__df_registered_predict_input_{side}"
+    pipeline = CTEPipeline()
+    pipeline.enqueue_sql(sql, templated_name)
+    return linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
+
+
+def _materialize_registered_pair_inputs(
+    linker: Linker,
+    blocked_pairs: SplinkDataFrame,
+) -> _RegisteredPredictInputs:
+    left = _materialize_registered_pair_input(linker, blocked_pairs, "l")
+    try:
+        right = _materialize_registered_pair_input(linker, blocked_pairs, "r")
+    except Exception:
+        left.drop_table_from_database_and_remove_from_cache()
+        raise
+    return _RegisteredPredictInputs(left=left, right=right)
+
+
+def _enqueue_registered_inputs_with_tf(
+    linker: Linker,
+    pipeline: CTEPipeline,
+    inputs: _RegisteredPredictInputs,
+) -> tuple[str, str]:
+    append_term_frequencies_to_pipeline(linker, pipeline)
+    left_name = "__splink__df_registered_predict_input_with_tf_l"
+    pipeline.enqueue_sql(
+        _join_tf_to_input_table_sql(
+            linker,
+            inputs.left.templated_name,
+            inputs.left,
+        ),
+        left_name,
+    )
+    if inputs.left.physical_name == inputs.right.physical_name:
+        return left_name, left_name
+
+    right_name = "__splink__df_registered_predict_input_with_tf_r"
+    pipeline.enqueue_sql(
+        _join_tf_to_input_table_sql(
+            linker,
+            inputs.right.templated_name,
+            inputs.right,
+        ),
+        right_name,
+    )
+    return left_name, right_name
+
+
+def predict_from_blocked_pairs_duckdb(
+    linker: Linker,
+    blocked_pairs: SplinkDataFrame,
+    threshold_match_probability: float | None,
+    threshold_match_weight: float | None,
+    emit_warning: bool,
+) -> SplinkDataFrame:
+    if linker._sql_dialect_str != "duckdb":
+        raise SplinkException(
+            "Registered-pair source pruning is currently supported only by DuckDB."
+        )
+
+    registered_inputs = _materialize_registered_pair_inputs(linker, blocked_pairs)
+    try:
+        settings = linker._settings_obj
+        pipeline = CTEPipeline(
+            [blocked_pairs, registered_inputs.left, registered_inputs.right]
+        )
+        input_tablename_l, input_tablename_r = _enqueue_registered_inputs_with_tf(
+            linker, pipeline, registered_inputs
+        )
+
+        start_time = time.time()
+        pipeline.enqueue_list_of_sqls(
+            compute_comparison_vector_values_from_id_pairs_sqls(
+                settings._columns_to_select_for_blocking,
+                settings._columns_to_select_for_comparison_vector_values,
+                input_tablename_l=input_tablename_l,
+                input_tablename_r=input_tablename_r,
+                source_dataset_input_column=settings.column_info_settings.source_dataset_input_column,
+                unique_id_input_column=settings.column_info_settings.unique_id_input_column,
+                link_type=settings._link_type,
+                sql_dialect_str=linker._sql_dialect_str,
+            )
+        )
+        pipeline.enqueue_list_of_sqls(
+            predict_from_comparison_vectors_sqls_using_settings(
+                settings,
+                threshold_match_probability,
+                threshold_match_weight,
+            )
+        )
+        predictions = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
+        predict_time = time.time() - start_time
+        logger.info(f"Predict time (post-blocking): {predict_time:.2f} seconds")
+    finally:
+        registered_inputs.drop()
+
+    if emit_warning:
+        linker._predict_warning()
+
+    return predictions
+
+
+def predict_from_registered_pairs_duckdb(
+    linker: Linker,
+    blocked_pairs_cache_key: str,
+    threshold_match_probability: float | None,
+    threshold_match_weight: float | None,
+    emit_warning: bool,
+) -> SplinkDataFrame:
+    blocked_pairs = linker._intermediate_table_cache.get_with_logging(
+        blocked_pairs_cache_key
+    )
+    return predict_from_blocked_pairs_duckdb(
+        linker,
+        blocked_pairs,
+        threshold_match_probability,
+        threshold_match_weight,
+        emit_warning,
+    )

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -19,6 +19,10 @@ from splink.internals.chunking import _blocked_pairs_cache_key
 from splink.internals.comparison_vector_values import (
     compute_comparison_vector_values_from_id_pairs_sqls,
 )
+from splink.internals.duckdb.registered_pair_prediction import (
+    predict_from_blocked_pairs_duckdb,
+    predict_from_registered_pairs_duckdb,
+)
 from splink.internals.exceptions import SplinkException
 from splink.internals.find_matches_to_new_records import (
     add_unique_id_and_source_dataset_cols_if_needed,
@@ -364,6 +368,18 @@ class LinkerInference:
                 "arguments to score the registered table."
             )
 
+        if (
+            registered_blocked_pairs_cache_keys
+            and self._linker._sql_dialect_str == "duckdb"
+        ):
+            return predict_from_registered_pairs_duckdb(
+                self._linker,
+                blocked_pairs_cache_key=registered_blocked_pairs_cache_keys[0],
+                threshold_match_probability=threshold_match_probability,
+                threshold_match_weight=threshold_match_weight,
+                emit_warning=warning_mode in {"auto", "always"},
+            )
+
         # Default to (1, 1) chunking if not specified
         n_left = num_chunks_left if num_chunks_left is not None else 1
         n_right = num_chunks_right if num_chunks_right is not None else 1
@@ -531,6 +547,23 @@ class LinkerInference:
                 right_chunk=right_chunk,
             )
         )
+
+        effective_chunk = any(
+            chunk is not None and chunk[1] > 1
+            for chunk in (left_chunk, right_chunk)
+        )
+        if effective_chunk and self._linker._sql_dialect_str == "duckdb":
+            try:
+                return predict_from_blocked_pairs_duckdb(
+                    self._linker,
+                    blocked_pairs,
+                    threshold_match_probability,
+                    threshold_match_weight,
+                    warning_mode in {"auto", "always"},
+                )
+            finally:
+                if not blocked_pairs_from_cache:
+                    blocked_pairs.drop_table_from_database_and_remove_from_cache()
 
         settings = self._linker._settings_obj
 

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -549,8 +549,7 @@ class LinkerInference:
         )
 
         effective_chunk = any(
-            chunk is not None and chunk[1] > 1
-            for chunk in (left_chunk, right_chunk)
+            chunk is not None and chunk[1] > 1 for chunk in (left_chunk, right_chunk)
         )
         if effective_chunk and self._linker._sql_dialect_str == "duckdb":
             try:

--- a/splink/internals/linker_components/inference.py
+++ b/splink/internals/linker_components/inference.py
@@ -19,9 +19,8 @@ from splink.internals.chunking import _blocked_pairs_cache_key
 from splink.internals.comparison_vector_values import (
     compute_comparison_vector_values_from_id_pairs_sqls,
 )
-from splink.internals.duckdb.registered_pair_prediction import (
-    predict_from_blocked_pairs_duckdb,
-    predict_from_registered_pairs_duckdb,
+from splink.internals.duckdb.pruned_prediction import (
+    predict_from_blocked_pairs_with_source_pruning,
 )
 from splink.internals.exceptions import SplinkException
 from splink.internals.find_matches_to_new_records import (
@@ -368,18 +367,6 @@ class LinkerInference:
                 "arguments to score the registered table."
             )
 
-        if (
-            registered_blocked_pairs_cache_keys
-            and self._linker._sql_dialect_str == "duckdb"
-        ):
-            return predict_from_registered_pairs_duckdb(
-                self._linker,
-                blocked_pairs_cache_key=registered_blocked_pairs_cache_keys[0],
-                threshold_match_probability=threshold_match_probability,
-                threshold_match_weight=threshold_match_weight,
-                emit_warning=warning_mode in {"auto", "always"},
-            )
-
         # Default to (1, 1) chunking if not specified
         n_left = num_chunks_left if num_chunks_left is not None else 1
         n_right = num_chunks_right if num_chunks_right is not None else 1
@@ -551,52 +538,54 @@ class LinkerInference:
         effective_chunk = any(
             chunk is not None and chunk[1] > 1 for chunk in (left_chunk, right_chunk)
         )
-        if effective_chunk and self._linker._sql_dialect_str == "duckdb":
-            try:
-                return predict_from_blocked_pairs_duckdb(
+        settings = self._linker._settings_obj
+
+        use_source_pruning = self._linker._sql_dialect_str == "duckdb" and (
+            effective_chunk
+            or blocked_pairs.metadata.get("registered_for_predict", False)
+        )
+        try:
+            if use_source_pruning:
+                predictions = predict_from_blocked_pairs_with_source_pruning(
                     self._linker,
                     blocked_pairs,
                     threshold_match_probability,
                     threshold_match_weight,
-                    warning_mode in {"auto", "always"},
                 )
-            finally:
-                if not blocked_pairs_from_cache:
-                    blocked_pairs.drop_table_from_database_and_remove_from_cache()
+            else:
+                pipeline = CTEPipeline([blocked_pairs])
+                enqueue_df_concat_with_tf(self._linker, pipeline)
 
-        settings = self._linker._settings_obj
+                start_time = time.time()
 
-        pipeline = CTEPipeline([blocked_pairs])
-        enqueue_df_concat_with_tf(self._linker, pipeline)
+                sqls = compute_comparison_vector_values_from_id_pairs_sqls(
+                    self._linker._settings_obj._columns_to_select_for_blocking,
+                    self._linker._settings_obj._columns_to_select_for_comparison_vector_values,
+                    input_tablename_l="__splink__df_concat_with_tf",
+                    input_tablename_r="__splink__df_concat_with_tf",
+                    source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
+                    unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
+                    link_type=settings._link_type,
+                    sql_dialect_str=self._linker._sql_dialect_str,
+                )
+                pipeline.enqueue_list_of_sqls(sqls)
 
-        start_time = time.time()
+                sqls = predict_from_comparison_vectors_sqls_using_settings(
+                    self._linker._settings_obj,
+                    threshold_match_probability,
+                    threshold_match_weight,
+                )
+                pipeline.enqueue_list_of_sqls(sqls)
 
-        sqls = compute_comparison_vector_values_from_id_pairs_sqls(
-            self._linker._settings_obj._columns_to_select_for_blocking,
-            self._linker._settings_obj._columns_to_select_for_comparison_vector_values,
-            input_tablename_l="__splink__df_concat_with_tf",
-            input_tablename_r="__splink__df_concat_with_tf",
-            source_dataset_input_column=self._linker._settings_obj.column_info_settings.source_dataset_input_column,
-            unique_id_input_column=self._linker._settings_obj.column_info_settings.unique_id_input_column,
-            link_type=settings._link_type,
-            sql_dialect_str=self._linker._sql_dialect_str,
-        )
-        pipeline.enqueue_list_of_sqls(sqls)
+                predictions = self._linker._db_api.sql_pipeline_to_splink_dataframe(
+                    pipeline
+                )
 
-        sqls = predict_from_comparison_vectors_sqls_using_settings(
-            self._linker._settings_obj,
-            threshold_match_probability,
-            threshold_match_weight,
-        )
-        pipeline.enqueue_list_of_sqls(sqls)
-
-        predictions = self._linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)
-
-        predict_time = time.time() - start_time
-        logger.info(f"Predict time (post-blocking): {predict_time:.2f} seconds")
-
-        if not blocked_pairs_from_cache:
-            blocked_pairs.drop_table_from_database_and_remove_from_cache()
+                predict_time = time.time() - start_time
+                logger.info(f"Predict time (post-blocking): {predict_time:.2f} seconds")
+        finally:
+            if not blocked_pairs_from_cache:
+                blocked_pairs.drop_table_from_database_and_remove_from_cache()
 
         if warning_mode in {"auto", "always"}:
             self._linker._predict_warning()

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -12,6 +12,9 @@ from unittest.mock import patch
 import pytest
 
 from splink.internals.duckdb.database_api import DuckDBAPI
+from splink.internals.duckdb.pruned_prediction import (
+    predict_from_blocked_pairs_with_source_pruning,
+)
 from splink.internals.exceptions import SplinkException
 from splink.internals.linker import Linker
 
@@ -247,6 +250,49 @@ def test_registered_chunked_blocked_pairs_match_from_scratch(fake_1000):
     assert loaded_match_weight_sum == pytest.approx(
         baseline_match_weight_sum, rel=1e-12, abs=1e-12
     )
+
+
+def test_duckdb_source_pruning_routing(fake_1000):
+    """Test source pruning is selected for chunked and registered predictions."""
+    settings = get_settings_dict()
+    db_api = DuckDBAPI()
+    df_sdf = db_api.register(fake_1000)
+    linker = Linker(df_sdf, settings)
+
+    with patch(
+        "splink.internals.linker_components.inference.predict_from_blocked_pairs_with_source_pruning",
+        wraps=predict_from_blocked_pairs_with_source_pruning,
+    ) as source_pruning:
+        linker.inference.predict(threshold_match_weight=-10)
+        source_pruning.assert_not_called()
+
+        linker.table_management.invalidate_cache()
+        linker.inference.predict(
+            threshold_match_weight=-10,
+            num_chunks_left=2,
+            num_chunks_right=2,
+        )
+        assert source_pruning.call_count == 4
+
+    db_api_source = DuckDBAPI()
+    df_sdf_source = db_api_source.register(fake_1000)
+    linker_source = Linker(df_sdf_source, settings)
+    blocked_pairs_arrow = (
+        linker_source.inference.compute_blocked_pairs_for_predict().as_pyarrow_table()
+    )
+
+    db_api_target = DuckDBAPI()
+    df_sdf_target = db_api_target.register(fake_1000)
+    linker_target = Linker(df_sdf_target, settings)
+    blocked_pairs = db_api_target.register(blocked_pairs_arrow)
+    linker_target.table_management.register_blocked_pairs_for_predict(blocked_pairs)
+
+    with patch(
+        "splink.internals.linker_components.inference.predict_from_blocked_pairs_with_source_pruning",
+        wraps=predict_from_blocked_pairs_with_source_pruning,
+    ) as source_pruning:
+        linker_target.inference.predict(threshold_match_weight=-10)
+        source_pruning.assert_called_once()
 
 
 def test_cache_is_hit_for_chunked_blocked_pairs(fake_1000):


### PR DESCRIPTION
If blocked pairs are a subset of all nodes this currently results in an inefficient DuckDB query plan.  **Importantly the current query plan negates a lot of the benefits of chunking by hydrating the full input dataset**.  

In particular, without the PR, it cases all nodes to be 'hydrated' (i.e. read) irrespective of whether they belong to the blocked pairs.

This doesn't matter much if the input data is small (e.g. less than a million records), but it causes a lot of inefficiency if the input nodes are large (e.g. hundreds of millions of records or more) and the chunk is small.

This PR includes an alternative code path where we deliberately pre-filter the nodes down to only those in the blocked pairs, preventing all nodes being hydrated.

We then use a simple heuristic to choose which code path to use, applicable to DuckDB only:
- If the user calls `predict()` with no chunking, use the original path.
- If the user calls `predict_chunk()` asking for anything but no chunks, or calls `predict()` with chunking, use the new pre-filtered path.
- If the user has pre-registered blocked pairs, use the new pre-filtered path.  The idea here is that usually when predicting from blocked pairs, these will be a subset of all records.  And if they're not, the new plan is not dramatically worse anyway.

This PR is the result of a lot of benchmarking workloads on large EC2 instances.  On a 192-vCPU EC2 run this branch completed the 100.4M predictions in 20.788s versus 57.951s on master, a 2.79× speedup.  


A subsequent PR could make this path optional for pre-registered blocked pairs, but I wanted to get the main implementation in first



I've deliberately kept this new implementation contained to a separate file so this change is not too intertwined with the rest of Splink.  For instance, a new duckdb version could cause a change in the query planner that makes this new code path unnecessary, so i wanted to make it as easy as possible to delete