### PR TITLE
Fix trusted publishing permission

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -15,6 +15,7 @@ jobs:
       name: release
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         id: checkout


### PR DESCRIPTION
Same issue as #3027, just that didn't make it to Splink 4 branch