### PR TITLE
duckdb parquet materialisation

### DIFF
--- a/splink/backends/duckdb.py
+++ b/splink/backends/duckdb.py
@@ -2,5 +2,6 @@ from splink.internals.duckdb.database_api import DuckDBAPI
 from splink.internals.duckdb.database_api_with_profiling import (
     DuckDBAPIWithProfiling,
 )
+from splink.internals.duckdb.parquet_write_options import ParquetWriteOptions
 
-__all__ = ["DuckDBAPI", "DuckDBAPIWithProfiling"]
+__all__ = ["DuckDBAPI", "DuckDBAPIWithProfiling", "ParquetWriteOptions"]

--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -123,11 +123,22 @@ class DatabaseAPI(ABC, Generic[TablishType]):
 
         Returns a SplinkDataFrame which also uses templated_name
         """
-        sql = self._setup_for_execute_sql(sql, physical_name)
-        spark_df = self._log_and_run_sql_execution(sql, templated_name, physical_name)
-        output_df = self._cleanup_for_execute_sql(
-            spark_df, templated_name, physical_name
-        )
+        try:
+            sql = self._setup_for_execute_sql(sql, physical_name)
+            result = self._log_and_run_sql_execution(sql, templated_name, physical_name)
+            output_df = self._cleanup_for_execute_sql(
+                result, templated_name, physical_name
+            )
+        except BaseException:
+            try:
+                self._cleanup_failed_sql_execution(physical_name)
+            except Exception:
+                logger.warning(
+                    "Unable to clean up failed materialisation %s",
+                    physical_name,
+                    exc_info=True,
+                )
+            raise
         self._intermediate_table_cache.executed_queries.append(output_df)
         self._created_tables.add(physical_name)
         return output_df
@@ -326,6 +337,9 @@ class DatabaseAPI(ABC, Generic[TablishType]):
 
         self._table_registration(input_table, templated_name)
         return self.table_to_splink_dataframe(templated_name, templated_name)
+
+    def _cleanup_failed_sql_execution(self, physical_name: str) -> None:
+        pass
 
     def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
         # returns sql

--- a/splink/internals/database_api.py
+++ b/splink/internals/database_api.py
@@ -123,22 +123,9 @@ class DatabaseAPI(ABC, Generic[TablishType]):
 
         Returns a SplinkDataFrame which also uses templated_name
         """
-        try:
-            sql = self._setup_for_execute_sql(sql, physical_name)
-            result = self._log_and_run_sql_execution(sql, templated_name, physical_name)
-            output_df = self._cleanup_for_execute_sql(
-                result, templated_name, physical_name
-            )
-        except BaseException:
-            try:
-                self._cleanup_failed_sql_execution(physical_name)
-            except Exception:
-                logger.warning(
-                    "Unable to clean up failed materialisation %s",
-                    physical_name,
-                    exc_info=True,
-                )
-            raise
+        sql = self._setup_for_execute_sql(sql, physical_name)
+        result = self._log_and_run_sql_execution(sql, templated_name, physical_name)
+        output_df = self._cleanup_for_execute_sql(result, templated_name, physical_name)
         self._intermediate_table_cache.executed_queries.append(output_df)
         self._created_tables.add(physical_name)
         return output_df
@@ -337,9 +324,6 @@ class DatabaseAPI(ABC, Generic[TablishType]):
 
         self._table_registration(input_table, templated_name)
         return self.table_to_splink_dataframe(templated_name, templated_name)
-
-    def _cleanup_failed_sql_execution(self, physical_name: str) -> None:
-        pass
 
     def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
         # returns sql

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -137,6 +137,10 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
                 table, templated_name, physical_name
             )
 
+        # In parquet mode rather than just returning the
+        # table as a splink dataframe we
+        # 'create view {name} as select * from read_parquet()'
+        # and return that view as a Splink dataframe
         materialiser = self._get_parquet_materialiser()
         self._execute_sql_against_backend(materialiser.view_sql(physical_name))
         output_df = self.table_to_splink_dataframe(templated_name, physical_name)

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Union
+from os import PathLike
+from typing import Literal, Union
 
 import duckdb
 
@@ -16,6 +17,8 @@ from .duckdb_helpers.duckdb_helpers import (
     create_temporary_duckdb_connection,
     validate_duckdb_connection,
 )
+from .parquet_materialisation import _ParquetMaterialiser
+from .parquet_write_options import ParquetWriteOptions
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +30,42 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         self,
         connection: Union[str, duckdb.DuckDBPyConnection] = ":memory:",
         output_schema: str | None = None,
+        *,
+        materialisation: Literal["table", "parquet"] = "table",
+        materialisation_dir: str | PathLike[str] | None = None,
+        parquet_materialisation_options: ParquetWriteOptions | None = None,
     ):
+        """Create a backend, using native tables by default.
+
+        Parquet mode writes standard materialised SQL results directly to local
+        backing storage. Supply materialisation_dir (separate from DuckDB spill
+        storage); normal result deletion removes owned files. Do not modify live
+        backing files. Writer options apply only to internal materialisations.
+        """
+        self._parquet_materialiser: _ParquetMaterialiser | None = None
+        if materialisation not in ("table", "parquet"):
+            raise ValueError("materialisation must be 'table' or 'parquet'")
+        if materialisation == "table":
+            if (
+                materialisation_dir is not None
+                or parquet_materialisation_options is not None
+            ):
+                raise ValueError(
+                    "Parquet directory/options require materialisation='parquet'"
+                )
+        else:
+            if materialisation_dir is None:
+                raise ValueError("materialisation_dir is required for Parquet mode")
+            if parquet_materialisation_options is not None and not isinstance(
+                parquet_materialisation_options, ParquetWriteOptions
+            ):
+                raise TypeError(
+                    "parquet_materialisation_options must be ParquetWriteOptions"
+                )
+            self._parquet_materialiser = _ParquetMaterialiser(
+                materialisation_dir,
+                parquet_materialisation_options or ParquetWriteOptions(),
+            )
         super().__init__()
         validate_duckdb_connection(connection, logger)
 
@@ -66,6 +104,31 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         except duckdb.CatalogException:
             drop_sql = f"DROP VIEW IF EXISTS {name}"
             self._execute_sql_against_backend(drop_sql)
+
+        if self._parquet_materialiser is not None:
+            self._parquet_materialiser.delete_backing_files(name)
+
+    def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
+        if self._parquet_materialiser is None:
+            return super()._setup_for_execute_sql(sql, physical_name)
+        self.delete_table_from_database(physical_name)
+        return self._parquet_materialiser.prepare_sql(sql, physical_name)
+
+    def _cleanup_for_execute_sql(self, table, templated_name, physical_name):
+        materialiser = self._parquet_materialiser
+        if materialiser is None:
+            return super()._cleanup_for_execute_sql(
+                table, templated_name, physical_name
+            )
+        self._execute_sql_against_backend(materialiser.view_sql(physical_name))
+        output_df = self.table_to_splink_dataframe(templated_name, physical_name)
+        materialiser.complete(physical_name)
+        return output_df
+
+    def _cleanup_failed_sql_execution(self, physical_name: str) -> None:
+        materialiser = self._parquet_materialiser
+        if materialiser is not None and materialiser.has_pending_write(physical_name):
+            self.delete_table_from_database(physical_name)
 
     def _table_registration(
         self, input: AcceptableInputTableType, table_name: str

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -96,6 +96,12 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
     def duckdb_con(self) -> duckdb.DuckDBPyConnection:
         return self._con
 
+    def _get_parquet_materialiser(self) -> _ParquetMaterialiser:
+        materialiser = self._parquet_materialiser
+        if materialiser is None:
+            raise RuntimeError("Parquet materialisation was not initialised")
+        return materialiser
+
     def delete_table_from_database(self, name: str) -> None:
         # If the table is in fact a pandas dataframe that's been registered using
         # duckdb con.register() then DROP TABLE will fail with
@@ -108,14 +114,12 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
             self._execute_sql_against_backend(drop_sql)
 
         if self._materialisation == "parquet":
-            materialiser = self._parquet_materialiser
-            assert materialiser is not None
+            materialiser = self._get_parquet_materialiser()
             materialiser.delete_backing_files(name)
 
     def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
         if self._materialisation == "parquet":
-            materialiser = self._parquet_materialiser
-            assert materialiser is not None
+            materialiser = self._get_parquet_materialiser()
 
             self.delete_table_from_database(physical_name)
             return materialiser.prepare_sql(sql, physical_name)
@@ -128,8 +132,7 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
                 table, templated_name, physical_name
             )
 
-        materialiser = self._parquet_materialiser
-        assert materialiser is not None
+        materialiser = self._get_parquet_materialiser()
         self._execute_sql_against_backend(materialiser.view_sql(physical_name))
         output_df = self.table_to_splink_dataframe(templated_name, physical_name)
         materialiser.complete(physical_name)
@@ -139,8 +142,7 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         if self._materialisation == "table":
             return
 
-        materialiser = self._parquet_materialiser
-        assert materialiser is not None
+        materialiser = self._get_parquet_materialiser()
         if materialiser.has_pending_write(physical_name):
             self.delete_table_from_database(physical_name)
 

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -35,12 +35,11 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         materialisation_dir: str | PathLike[str] | None = None,
         parquet_materialisation_options: ParquetWriteOptions | None = None,
     ):
-        """Create a backend, using native tables by default.
-
-        Parquet mode writes standard materialised SQL results directly to local
-        backing storage. Supply materialisation_dir (separate from DuckDB spill
-        storage); normal result deletion removes owned files. Do not modify live
-        backing files. Writer options apply only to internal materialisations.
+        """
+        Parquet mode writes SQL results directly to parquet files rather
+        than DuckDB storage.  This can be significantly faster for
+        very large linkages if you're using an in-memory connection
+        and you hit memory limits.
         """
         if materialisation not in ("table", "parquet"):
             raise ValueError("materialisation must be 'table' or 'parquet'")
@@ -118,6 +117,12 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
             materialiser.delete_backing_files(name)
 
     def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
+
+        # In parquet mode, rather than 'create table as'
+        # we need to remove any parquet files and then
+        # 'COPY ({query}) to {dir} FORMAT PARQUET
+        # instead of the normal 'DROP TABLE IF EXISTS'
+        # then 'CREATE TABLE {name} as {query}'
         if self._materialisation == "parquet":
             materialiser = self._get_parquet_materialiser()
 

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -42,10 +42,12 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         storage); normal result deletion removes owned files. Do not modify live
         backing files. Writer options apply only to internal materialisations.
         """
-        self._parquet_materialiser: _ParquetMaterialiser | None = None
         if materialisation not in ("table", "parquet"):
             raise ValueError("materialisation must be 'table' or 'parquet'")
-        if materialisation == "table":
+        self._materialisation: Literal["table", "parquet"] = materialisation
+        self._parquet_materialiser: _ParquetMaterialiser | None = None
+
+        if self._materialisation == "table":
             if (
                 materialisation_dir is not None
                 or parquet_materialisation_options is not None
@@ -105,29 +107,41 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
             drop_sql = f"DROP VIEW IF EXISTS {name}"
             self._execute_sql_against_backend(drop_sql)
 
-        if self._parquet_materialiser is not None:
-            self._parquet_materialiser.delete_backing_files(name)
+        if self._materialisation == "parquet":
+            materialiser = self._parquet_materialiser
+            assert materialiser is not None
+            materialiser.delete_backing_files(name)
 
     def _setup_for_execute_sql(self, sql: str, physical_name: str) -> str:
-        if self._parquet_materialiser is None:
-            return super()._setup_for_execute_sql(sql, physical_name)
-        self.delete_table_from_database(physical_name)
-        return self._parquet_materialiser.prepare_sql(sql, physical_name)
+        if self._materialisation == "parquet":
+            materialiser = self._parquet_materialiser
+            assert materialiser is not None
+
+            self.delete_table_from_database(physical_name)
+            return materialiser.prepare_sql(sql, physical_name)
+
+        return super()._setup_for_execute_sql(sql, physical_name)
 
     def _cleanup_for_execute_sql(self, table, templated_name, physical_name):
-        materialiser = self._parquet_materialiser
-        if materialiser is None:
+        if self._materialisation == "table":
             return super()._cleanup_for_execute_sql(
                 table, templated_name, physical_name
             )
+
+        materialiser = self._parquet_materialiser
+        assert materialiser is not None
         self._execute_sql_against_backend(materialiser.view_sql(physical_name))
         output_df = self.table_to_splink_dataframe(templated_name, physical_name)
         materialiser.complete(physical_name)
         return output_df
 
     def _cleanup_failed_sql_execution(self, physical_name: str) -> None:
+        if self._materialisation == "table":
+            return
+
         materialiser = self._parquet_materialiser
-        if materialiser is not None and materialiser.has_pending_write(physical_name):
+        assert materialiser is not None
+        if materialiser.has_pending_write(physical_name):
             self.delete_table_from_database(physical_name)
 
     def _table_registration(

--- a/splink/internals/duckdb/database_api.py
+++ b/splink/internals/duckdb/database_api.py
@@ -147,14 +147,6 @@ class DuckDBAPI(DatabaseAPI[duckdb.DuckDBPyRelation]):
         materialiser.complete(physical_name)
         return output_df
 
-    def _cleanup_failed_sql_execution(self, physical_name: str) -> None:
-        if self._materialisation == "table":
-            return
-
-        materialiser = self._get_parquet_materialiser()
-        if materialiser.has_pending_write(physical_name):
-            self.delete_table_from_database(physical_name)
-
     def _table_registration(
         self, input: AcceptableInputTableType, table_name: str
     ) -> None:

--- a/splink/internals/duckdb/database_api_with_profiling.py
+++ b/splink/internals/duckdb/database_api_with_profiling.py
@@ -9,6 +9,7 @@ from typing import Literal, Union
 import duckdb
 
 from .database_api import DuckDBAPI
+from .parquet_write_options import ParquetWriteOptions
 
 DuckDBProfilingType = Literal["query_tree", "json", "query_tree_optimizer", "no_output"]
 DuckDBProfilingMode = Literal["standard", "detailed", "all"]
@@ -26,6 +27,10 @@ class DuckDBAPIWithProfiling(DuckDBAPI):
         enable_profiling: DuckDBProfilingType = "json",
         profiling_mode: DuckDBProfilingMode = "standard",
         profiling_coverage: DuckDBProfilingCoverage = "ALL",
+        *,
+        materialisation: Literal["table", "parquet"] = "table",
+        materialisation_dir: str | PathLike[str] | None = None,
+        parquet_materialisation_options: ParquetWriteOptions | None = None,
     ):
         """Create a DuckDB API that profiles table-creating queries.
 
@@ -60,7 +65,13 @@ class DuckDBAPIWithProfiling(DuckDBAPI):
             raise ValueError("profiling_coverage must be either 'SELECT' or 'ALL'")
 
         self._profiling_active = False
-        super().__init__(connection=connection, output_schema=output_schema)
+        super().__init__(
+            connection=connection,
+            output_schema=output_schema,
+            materialisation=materialisation,
+            materialisation_dir=materialisation_dir,
+            parquet_materialisation_options=parquet_materialisation_options,
+        )
         self.query_profiling_dir = Path(query_profiling_dir)
         self.query_profiling_dir.mkdir(parents=True, exist_ok=True)
         self.enable_profiling = enable_profiling

--- a/splink/internals/duckdb/parquet_materialisation.py
+++ b/splink/internals/duckdb/parquet_materialisation.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from .parquet_write_options import ParquetWriteOptions
+
+
+def _quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _writer_options_sql(options: ParquetWriteOptions) -> str:
+    rendered = ["FORMAT PARQUET"]
+    for field, keyword in (
+        ("compression", "COMPRESSION"),
+        ("compression_level", "COMPRESSION_LEVEL"),
+        ("per_thread_output", "PER_THREAD_OUTPUT"),
+        ("file_size_bytes", "FILE_SIZE_BYTES"),
+        ("row_group_size", "ROW_GROUP_SIZE"),
+    ):
+        value = getattr(options, field)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            literal = "TRUE" if value else "FALSE"
+        elif isinstance(value, str):
+            literal = _quote(value)
+        else:
+            literal = str(value)
+        rendered.append(f"{keyword} {literal}")
+    return ", ".join(rendered)
+
+
+class _ParquetMaterialiser:
+    """Own backing files and generate SQL; never execute queries."""
+
+    def __init__(
+        self, directory: str | os.PathLike[str], write_options: ParquetWriteOptions
+    ):
+        directory = os.fspath(directory)
+        if not isinstance(directory, str):
+            raise TypeError("materialisation_dir must be a string or PathLike[str]")
+        if not directory.strip() or re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", directory):
+            raise ValueError("materialisation_dir must be a non-empty local path")
+        self._directory = Path(directory).resolve()
+        self._write_options = write_options
+        self._workspace: Path | None = None
+        self._owned_paths: dict[str, Path] = {}
+        self._pending_queries: dict[str, str] = {}
+
+    def prepare_sql(self, sql: str, physical_name: str) -> str:
+        if physical_name in self._owned_paths:
+            raise ValueError(f"Backing files still owned for {physical_name}")
+        if self._workspace is None:
+            self._directory.mkdir(parents=True, exist_ok=True)
+            self._workspace = Path(
+                tempfile.mkdtemp(prefix="splink-", dir=self._directory)
+            )
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", physical_name)[:80]
+        path = Path(tempfile.mkdtemp(prefix=f"{safe_name}-", dir=self._workspace))
+        self._owned_paths[physical_name] = path
+        self._pending_queries[physical_name] = sql
+        options = self._write_options
+        multiple = options.per_thread_output or options.file_size_bytes is not None
+        destination = path if multiple else path / "data.parquet"
+        return (
+            f"COPY ({sql}) TO {_quote(str(destination))} "
+            f"({_writer_options_sql(options)})"
+        )
+
+    def view_sql(self, physical_name: str) -> str:
+        glob = _quote(str(self._owned_paths[physical_name] / "*.parquet"))
+        return (
+            f"CREATE VIEW {physical_name} AS "
+            f"SELECT * FROM read_parquet({glob}, hive_partitioning = false)"
+        )
+
+    def complete(self, physical_name: str) -> None:
+        del self._pending_queries[physical_name]
+
+    def has_pending_write(self, physical_name: str) -> bool:
+        return physical_name in self._pending_queries
+
+    def delete_backing_files(self, physical_name: str) -> None:
+        path = self._owned_paths.get(physical_name)
+        if path is None:
+            return
+        try:
+            shutil.rmtree(path)
+        except FileNotFoundError:
+            if path.exists():
+                raise
+        except OSError as exc:
+            raise OSError(
+                f"Unable to remove Parquet backing files at {path}: {exc}"
+            ) from exc
+        del self._owned_paths[physical_name]
+        self._pending_queries.pop(physical_name, None)

--- a/splink/internals/duckdb/parquet_materialisation.py
+++ b/splink/internals/duckdb/parquet_materialisation.py
@@ -36,8 +36,6 @@ def _writer_options_sql(options: ParquetWriteOptions) -> str:
 
 
 class _ParquetMaterialiser:
-    """Own backing files and generate SQL; never execute queries."""
-
     def __init__(
         self, directory: str | os.PathLike[str], write_options: ParquetWriteOptions
     ):
@@ -92,6 +90,8 @@ class _ParquetMaterialiser:
         try:
             shutil.rmtree(path)
         except FileNotFoundError:
+            # No need to raise error if whole directory alredy gome
+            # but preserve errors for missing child paths.
             if path.exists():
                 raise
         except OSError as exc:

--- a/splink/internals/duckdb/parquet_write_options.py
+++ b/splink/internals/duckdb/parquet_write_options.py
@@ -3,14 +3,6 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, kw_only=True)
 class ParquetWriteOptions:
-    """Writer options for Splink-owned Parquet materialisations.
-
-    None-valued options are omitted from COPY. These options do not
-    configure DuckDBDataFrame.to_parquet(). File-size rollover is approximate;
-    neither exact part counts nor physical row order are guaranteed.
-    DuckDB validates codecs, compression levels and size-unit strings.
-    """
-
     compression: str | None = None
     compression_level: int | None = None
     per_thread_output: bool = True

--- a/splink/internals/duckdb/parquet_write_options.py
+++ b/splink/internals/duckdb/parquet_write_options.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class ParquetWriteOptions:
+    """Writer options for Splink-owned Parquet materialisations.
+
+    None-valued options are omitted from COPY. These options do not
+    configure DuckDBDataFrame.to_parquet(). File-size rollover is approximate;
+    neither exact part counts nor physical row order are guaranteed.
+    DuckDB validates codecs, compression levels and size-unit strings.
+    """
+
+    compression: str | None = None
+    compression_level: int | None = None
+    per_thread_output: bool = True
+    file_size_bytes: str | int | None = None
+    row_group_size: int | None = None
+
+    def __post_init__(self):
+        for name in (
+            "compression",
+            "compression_level",
+            "file_size_bytes",
+            "row_group_size",
+        ):
+            value = getattr(self, name)
+            if value is None:
+                continue
+            allowed = {
+                "compression": (str,),
+                "compression_level": (int,),
+                "file_size_bytes": (str, int),
+                "row_group_size": (int,),
+            }[name]
+            if isinstance(value, bool) or not isinstance(value, allowed):
+                raise TypeError(f"{name} has an invalid type")
+            if isinstance(value, str) and not value.strip():
+                raise ValueError(f"{name} must not be empty")
+            if name in ("file_size_bytes", "row_group_size"):
+                if isinstance(value, int) and value <= 0:
+                    raise ValueError(f"{name} must be positive")
+        if not isinstance(self.per_thread_output, bool):
+            raise TypeError("per_thread_output must be a boolean")

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -95,19 +95,6 @@ def _duckdb_comparison_viewer_table_sqls(
     uid_col_lr_names = uid_cols_l + uid_cols_r
     uid_expr = " || '-' ||".join(f"pred.{name}" for name in uid_col_lr_names)
 
-    # Logical pair keys also work for registered and Parquet-backed views,
-    # which have no DuckDB hidden rowid. Keep the bounded arg_min sampling.
-    pair_key = (
-        "struct_pack("
-        + ", ".join(f"key_{i} := {name}" for i, name in enumerate(uid_col_lr_names))
-        + ")"
-    )
-    pair_join = " AND ".join(
-        f"pred.{name} IS NOT DISTINCT FROM keys.example_key.key_{i}"
-        for i, name in enumerate(uid_col_lr_names)
-    )
-    pair_order = ", ".join(f"pred.{name}" for name in uid_col_lr_names)
-
     gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
     gam_concat = " || ',' || ".join(gamma_columns)
     groupby_cols = " , ".join(gamma_columns)
@@ -130,7 +117,7 @@ def _duckdb_comparison_viewer_table_sqls(
            {mw_final_no_tf} as sort_avg_match_weight,
            random() as rand_order,
            row_number() over (
-               partition by keys.gam_concat order by {pair_order}
+               partition by keys.gam_concat order by pred.rowid
            ) as row_example_index,
            cvd.sum_gam,
            cvd.count_rows_in_comparison_vector_group as count,
@@ -138,14 +125,14 @@ def _duckdb_comparison_viewer_table_sqls(
     from (
         select
             {gam_concat} as gam_concat,
-            unnest(arg_min({pair_key}, {pair_key}, {example_rows_per_category}))
-                as example_key
+            unnest(arg_min(rowid, rowid, {example_rows_per_category}))
+                as example_rowid
         from __splink__df_predict
         group by {groupby_cols}
         having count(*) >= {minimum_comparison_vector_count}
     ) as keys
     inner join __splink__df_predict as pred
-        on {pair_join}
+        on pred.rowid = keys.example_rowid
     left join __splink__df_comparison_vector_distribution as cvd
         on keys.gam_concat = cvd.gam_concat
     """
@@ -163,7 +150,10 @@ def comparison_viewer_table_sqls(
     example_rows_per_category: int = 2,
     minimum_comparison_vector_count: int = 0,
 ) -> list[dict[str, str]]:
-    if linker._db_api.sql_dialect.sql_dialect_str == "duckdb":
+    if (
+        linker._db_api.sql_dialect.sql_dialect_str == "duckdb"
+        and linker._db_api._materialisation == "table"
+    ):
         return _duckdb_comparison_viewer_table_sqls(
             linker,
             example_rows_per_category,

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -95,6 +95,19 @@ def _duckdb_comparison_viewer_table_sqls(
     uid_col_lr_names = uid_cols_l + uid_cols_r
     uid_expr = " || '-' ||".join(f"pred.{name}" for name in uid_col_lr_names)
 
+    # Logical pair keys also work for registered and Parquet-backed views,
+    # which have no DuckDB hidden rowid. Keep the bounded arg_min sampling.
+    pair_key = (
+        "struct_pack("
+        + ", ".join(f"key_{i} := {name}" for i, name in enumerate(uid_col_lr_names))
+        + ")"
+    )
+    pair_join = " AND ".join(
+        f"pred.{name} IS NOT DISTINCT FROM keys.example_key.key_{i}"
+        for i, name in enumerate(uid_col_lr_names)
+    )
+    pair_order = ", ".join(f"pred.{name}" for name in uid_col_lr_names)
+
     gamma_columns = [c._gamma_column_name for c in linker._settings_obj.comparisons]
     gam_concat = " || ',' || ".join(gamma_columns)
     groupby_cols = " , ".join(gamma_columns)
@@ -117,7 +130,7 @@ def _duckdb_comparison_viewer_table_sqls(
            {mw_final_no_tf} as sort_avg_match_weight,
            random() as rand_order,
            row_number() over (
-               partition by keys.gam_concat order by pred.rowid
+               partition by keys.gam_concat order by {pair_order}
            ) as row_example_index,
            cvd.sum_gam,
            cvd.count_rows_in_comparison_vector_group as count,
@@ -125,14 +138,14 @@ def _duckdb_comparison_viewer_table_sqls(
     from (
         select
             {gam_concat} as gam_concat,
-            unnest(arg_min(rowid, rowid, {example_rows_per_category}))
-                as example_rowid
+            unnest(arg_min({pair_key}, {pair_key}, {example_rows_per_category}))
+                as example_key
         from __splink__df_predict
         group by {groupby_cols}
         having count(*) >= {minimum_comparison_vector_count}
     ) as keys
     inner join __splink__df_predict as pred
-        on pred.rowid = keys.example_rowid
+        on {pair_join}
     left join __splink__df_comparison_vector_distribution as cvd
         on keys.gam_concat = cvd.gam_concat
     """

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -4,6 +4,7 @@ import json
 import os
 from typing import TYPE_CHECKING, Any
 
+from splink.internals.duckdb.database_api import DuckDBAPI
 from splink.internals.misc import EverythingEncoder, read_resource
 
 from .predict import _combine_prior_and_mws
@@ -154,7 +155,7 @@ def comparison_viewer_table_sqls(
     # this optimisation path relies on rowid but
     # that's only available for duckdb tables
     if (
-        linker._db_api.sql_dialect.sql_dialect_str == "duckdb"
+        isinstance(linker._db_api, DuckDBAPI)
         and linker._db_api._materialisation == "table"
     ):
         return _duckdb_comparison_viewer_table_sqls(

--- a/splink/internals/splink_comparison_viewer.py
+++ b/splink/internals/splink_comparison_viewer.py
@@ -150,6 +150,9 @@ def comparison_viewer_table_sqls(
     example_rows_per_category: int = 2,
     minimum_comparison_vector_count: int = 0,
 ) -> list[dict[str, str]]:
+
+    # this optimisation path relies on rowid but
+    # that's only available for duckdb tables
     if (
         linker._db_api.sql_dialect.sql_dialect_str == "duckdb"
         and linker._db_api._materialisation == "table"

--- a/tests/test_comparison_viewer_dashboard.py
+++ b/tests/test_comparison_viewer_dashboard.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 import splink.comparison_library as cl
 from splink import DuckDBAPI, Linker
 from splink.internals.comparison_vector_distribution import (
@@ -38,7 +40,8 @@ def test_comparison_viewer_dashboard(tmp_path, fake_1000):
 
 
 @mark_with_dialects_including("duckdb")
-def test_comparison_viewer_table():
+@pytest.mark.parametrize("materialisation", ["table", "parquet"])
+def test_comparison_viewer_table(tmp_path, materialisation):
     # contrived input data to get 10 name agreements
     # and 5 name disagreements.
     data = {
@@ -65,7 +68,12 @@ def test_comparison_viewer_table():
         "retain_intermediate_calculation_columns": True,
     }
 
-    db_api = DuckDBAPI()
+    db_api = DuckDBAPI(
+        materialisation=materialisation,
+        materialisation_dir=tmp_path / "backing"
+        if materialisation == "parquet"
+        else None,
+    )
     df_sdf = db_api.register(data)
 
     linker = Linker(
@@ -84,6 +92,12 @@ def test_comparison_viewer_table():
         4,
         minimum_comparison_vector_count=0,
     )
+    if materialisation == "table":
+        assert len(sqls) == 1
+        assert "pred.rowid = keys.example_rowid" in sqls[0]["sql"]
+    else:
+        assert len(sqls) == 4
+        assert all("rowid" not in sql_info["sql"] for sql_info in sqls)
     pipeline.enqueue_list_of_sqls(sqls)
 
     df = linker._db_api.sql_pipeline_to_splink_dataframe(pipeline)

--- a/tests/test_duckdb_parquet_materialisation.py
+++ b/tests/test_duckdb_parquet_materialisation.py
@@ -1,0 +1,383 @@
+import shutil
+from dataclasses import FrozenInstanceError
+
+import duckdb
+import pytest
+
+from splink import DuckDBAPI, Linker
+from splink.backends.duckdb import DuckDBAPIWithProfiling, ParquetWriteOptions
+from splink.internals.duckdb.dataframe import DuckDBDataFrame
+from splink.internals.duckdb.parquet_materialisation import (
+    _ParquetMaterialiser,
+    _writer_options_sql,
+)
+from splink.internals.exceptions import SplinkException
+from splink.internals.pipeline import CTEPipeline
+
+from .basic_settings import get_settings_dict
+from .decorator import mark_with_dialects_including
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"compression": ""},
+        {"compression": 1},
+        {"compression_level": True},
+        {"compression_level": "3"},
+        {"per_thread_output": 1},
+        {"file_size_bytes": False},
+        {"file_size_bytes": 0},
+        {"file_size_bytes": " "},
+        {"row_group_size": -1},
+        {"row_group_size": 1.5},
+    ],
+)
+def test_invalid_options(kwargs):
+    with pytest.raises((TypeError, ValueError)):
+        ParquetWriteOptions(**kwargs)
+
+
+def test_options_rendering_and_immutability():
+    options = ParquetWriteOptions(per_thread_output=False, compression="a'b")
+    with pytest.raises(FrozenInstanceError):
+        options.compression = "zstd"
+    assert _writer_options_sql(options) == (
+        "FORMAT PARQUET, COMPRESSION 'a''b', PER_THREAD_OUTPUT FALSE"
+    )
+    assert _writer_options_sql(ParquetWriteOptions()) == (
+        "FORMAT PARQUET, PER_THREAD_OUTPUT TRUE"
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"materialisation": "unknown"},
+        {"materialisation": "parquet"},
+        {"materialisation_dir": "unused"},
+        {"parquet_materialisation_options": ParquetWriteOptions()},
+        {"materialisation": "parquet", "materialisation_dir": "s3://bucket"},
+        {
+            "materialisation": "parquet",
+            "materialisation_dir": "unused",
+            "parquet_materialisation_options": {},
+        },
+    ],
+)
+def test_validation_precedes_connections(kwargs, monkeypatch):
+    def connect(*args, **kwargs):
+        pytest.fail("opened a connection before validation")
+
+    monkeypatch.setattr(duckdb, "connect", connect)
+    with pytest.raises((TypeError, ValueError)):
+        DuckDBAPI(**kwargs)
+
+
+def test_helper_ownership(tmp_path):
+    helper = _ParquetMaterialiser(tmp_path / "new", ParquetWriteOptions())
+    assert not (tmp_path / "new").exists()
+    sql = helper.prepare_sql("SELECT 1", "result")
+    path = helper._owned_paths["result"]
+    assert sql.startswith("COPY (SELECT 1)")
+    assert path.is_absolute()
+    assert helper.has_pending_write("result")
+    assert "hive_partitioning = false" in helper.view_sql("result")
+    helper.complete("result")
+    assert not helper.has_pending_write("result")
+    helper.delete_backing_files("untracked")
+    assert path.exists()
+    helper.delete_backing_files("result")
+    assert not path.exists()
+    helper.prepare_sql("SELECT 2", "result")
+    assert helper._owned_paths["result"] != path
+    shutil.rmtree(helper._owned_paths["result"])
+    helper.delete_backing_files("result")
+    assert not helper._owned_paths
+
+
+@pytest.fixture
+def api(tmp_path):
+    backend = DuckDBAPI(materialisation="parquet", materialisation_dir=tmp_path)
+    yield backend
+    backend.delete_tables_created_by_splink_from_db()
+
+
+@mark_with_dialects_including("duckdb")
+@pytest.mark.parametrize(
+    "options",
+    [
+        None,
+        ParquetWriteOptions(),
+        ParquetWriteOptions(per_thread_output=False),
+        ParquetWriteOptions(file_size_bytes="100KB", row_group_size=2048),
+        ParquetWriteOptions(
+            per_thread_output=False,
+            file_size_bytes=100_000,
+            compression="zstd",
+            compression_level=3,
+            row_group_size=2048,
+        ),
+    ],
+)
+@pytest.mark.parametrize("empty", [False, True])
+def test_layout_schema_and_direct_copy(tmp_path, options, empty, monkeypatch):
+    backend = DuckDBAPI(
+        materialisation="parquet",
+        materialisation_dir=tmp_path / "run=example" / "it's local",
+        parquet_materialisation_options=options,
+    )
+    statements = []
+    execute = backend._execute_sql_against_backend
+
+    def record(sql):
+        statements.append(sql)
+        return execute(sql)
+
+    monkeypatch.setattr(backend, "_execute_sql_against_backend", record)
+    sql = """WITH source AS (SELECT i FROM range(10000) t(i))
+        SELECT i, NULL::VARCHAR AS n, [i, NULL] AS a, {'x': i} AS s,
+        DATE '2024-01-01' AS d, 1.25::DECIMAL(10,2) AS money FROM source"""
+    if empty:
+        sql += " WHERE FALSE"
+    result = backend._execute_sql(sql, "__splink__test")
+    assert isinstance(result, DuckDBDataFrame)
+    assert result.created_by_splink and result.sql_used_to_create == sql
+    assert result.physical_name in backend._created_tables
+    assert backend._intermediate_table_cache.executed_queries[-1] is result
+    assert not any("CREATE TABLE" in statement for statement in statements)
+    assert any(statement.startswith(f"COPY ({sql})") for statement in statements)
+    assert result.as_duckdbpyrelation().types == execute(sql).types
+    assert (
+        result.as_duckdbpyrelation().order("i").fetchall()
+        == execute(sql).order("i").fetchall()
+    )
+    path = backend._parquet_materialiser._owned_paths[result.physical_name]
+    files = list(path.glob("*.parquet"))
+    assert files
+    if options and not options.per_thread_output and options.file_size_bytes is None:
+        assert [p.name for p in files] == ["data.parquet"]
+    if options and options.compression:
+        codecs = backend.duckdb_con.sql(
+            "SELECT DISTINCT compression FROM parquet_metadata(?)",
+            params=[str(files[0])],
+        ).fetchall()
+        if not empty:
+            assert codecs == [("ZSTD",)]
+    backend.delete_tables_created_by_splink_from_db()
+    assert not path.exists()
+
+
+@mark_with_dialects_including("duckdb")
+def test_ownership_replacement_exports_and_shared_root(api, tmp_path):
+    other = DuckDBAPI(materialisation="parquet", materialisation_dir=tmp_path)
+    other_result = other._execute_sql("SELECT 7 AS x", "other")
+    unrelated = tmp_path / "unrelated.txt"
+    unrelated.write_text("keep")
+    registered = api.register([{"x": 1}])
+    first = api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
+    old_path = api._parquet_materialiser._owned_paths["result"]
+    result = api._sql_to_splink_dataframe("SELECT 2 AS x", "result", "result")
+    assert not old_path.exists()
+    assert result.as_record_list() == [{"x": 2}]
+    api._bind_templated_alias_to_physical("alias", "result")
+    api.delete_table_from_database("alias")
+    assert result.as_record_list() == [{"x": 2}]
+    export = tmp_path / "export.parquet"
+    first.to_parquet(str(export))
+    result.created_by_splink = True
+    result.drop_table_from_database_and_remove_from_cache()
+    api.delete_tables_created_by_splink_from_db()
+    assert export.exists() and unrelated.read_text() == "keep"
+    assert registered.as_record_list() == [{"x": 1}]
+    assert other_result.as_record_list() == [{"x": 7}]
+    other.delete_tables_created_by_splink_from_db()
+
+
+@mark_with_dialects_including("duckdb")
+@pytest.mark.parametrize("stage", ["setup", "copy", "view", "wrapper", "interrupt"])
+def test_failed_attempt_cleanup_and_retry(api, monkeypatch, stage):
+    materialiser = api._parquet_materialiser
+    execute = api._execute_sql_against_backend
+    prepare = materialiser.prepare_sql
+    with monkeypatch.context() as patch:
+        if stage == "setup":
+
+            def fail_setup(sql, name):
+                prepare(sql, name)
+                raise RuntimeError("injected")
+
+            patch.setattr(materialiser, "prepare_sql", fail_setup)
+        elif stage == "wrapper":
+
+            def fail_wrapper(*args):
+                raise RuntimeError("injected")
+
+            patch.setattr(api, "table_to_splink_dataframe", fail_wrapper)
+        else:
+
+            def fail_sql(sql):
+                if (stage in ("copy", "interrupt") and sql.startswith("COPY")) or (
+                    stage == "view" and sql.startswith("CREATE VIEW")
+                ):
+                    for path in materialiser._owned_paths.values():
+                        (path / "partial.parquet").write_bytes(b"partial")
+                    if stage == "interrupt":
+                        raise KeyboardInterrupt("injected")
+                    raise RuntimeError("injected")
+                return execute(sql)
+
+            patch.setattr(api, "_execute_sql_against_backend", fail_sql)
+        with pytest.raises(
+            (RuntimeError, SplinkException, KeyboardInterrupt), match="injected"
+        ):
+            api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
+    assert not materialiser._owned_paths and not materialiser._pending_queries
+    assert not api._created_tables
+    assert not api._intermediate_table_cache.executed_queries
+    assert not api.table_exists_in_database("result")
+    assert api._sql_to_splink_dataframe(
+        "SELECT 2 AS x", "result", "result"
+    ).as_record_list() == [{"x": 2}]
+
+
+@mark_with_dialects_including("duckdb")
+def test_cleanup_failure_retains_tracking_and_original_error(api, monkeypatch, caplog):
+    with monkeypatch.context() as patch:
+
+        def fail_remove(path):
+            raise PermissionError("injected delete failure")
+
+        patch.setattr(shutil, "rmtree", fail_remove)
+        with pytest.raises(SplinkException, match="missing_column"):
+            api._sql_to_splink_dataframe("SELECT missing_column", "result", "result")
+    path = api._parquet_materialiser._owned_paths["result"]
+    assert path.exists() and str(path) in caplog.text
+    assert api._parquet_materialiser.has_pending_write("result")
+    assert not api._created_tables
+    api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
+    assert not path.exists()
+
+
+@mark_with_dialects_including("duckdb")
+def test_failure_before_allocation_preserves_live_result(api, monkeypatch):
+    api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
+    path = api._parquet_materialiser._owned_paths["result"]
+    with monkeypatch.context() as patch:
+
+        def fail_drop(name):
+            raise RuntimeError("before allocation")
+
+        patch.setattr(api, "delete_table_from_database", fail_drop)
+        with pytest.raises(RuntimeError, match="before allocation"):
+            api._sql_to_splink_dataframe("SELECT 2", "result", "result")
+    assert path.exists()
+    assert api.duckdb_con.sql("SELECT * FROM result").fetchall() == [(1,)]
+
+
+@mark_with_dialects_including("duckdb")
+def test_native_mode_and_schema_connection_profiling(tmp_path):
+    native = DuckDBAPI()
+    assert native._materialisation == "table"
+    assert native._parquet_materialiser is None
+    native.query_sql("SELECT 1 AS x")
+    con = duckdb.connect(str(tmp_path / "db.duckdb"))
+    api = DuckDBAPIWithProfiling(
+        con,
+        "results",
+        tmp_path / "profiles",
+        materialisation="parquet",
+        materialisation_dir=tmp_path / "backing",
+    )
+    assert api._materialisation == "parquet"
+    result = api._execute_sql("SELECT 1 AS x", "result")
+    assert con.sql(
+        "SELECT table_type FROM information_schema.tables WHERE table_schema='results'"
+    ).fetchall() == [("VIEW",)]
+    profiles = list((tmp_path / "profiles").glob("*.json"))
+    assert profiles and "COPY" in profiles[0].read_text()
+    assert result.as_record_list() == [{"x": 1}]
+    with pytest.raises(SplinkException):
+        api._execute_sql("SELECT missing", "bad")
+    assert not api._profiling_active
+    assert not api._parquet_materialiser._pending_queries
+    api.delete_tables_created_by_splink_from_db()
+
+
+@mark_with_dialects_including("duckdb")
+def test_debug_pipeline(api):
+    api.debug_mode = True
+    pipeline = CTEPipeline()
+    pipeline.enqueue_sql("SELECT 1 AS x", "__splink__first")
+    pipeline.enqueue_sql("SELECT x + 1 AS x FROM __splink__first", "__splink__last")
+    result = api.sql_pipeline_to_splink_dataframe(pipeline)
+    assert result.as_record_list() == [{"x": 2}]
+    assert set(api._parquet_materialiser._owned_paths) == {result.physical_name}
+    assert not api.table_exists_in_database("__splink__first")
+
+
+@mark_with_dialects_including("duckdb")
+def test_prediction_cached_blocking_and_chunks(api, fake_1000):
+    settings = get_settings_dict()
+    native = DuckDBAPI()
+    baseline = Linker(native.register(fake_1000), settings).inference.predict()
+
+    def canonical(result):
+        return (
+            result.as_duckdbpyrelation()
+            .project("unique_id_l, unique_id_r, match_weight")
+            .order("unique_id_l, unique_id_r")
+            .fetchall()
+        )
+
+    expected = canonical(baseline)
+    linker = Linker(api.register(fake_1000), settings)
+    for cached, chunks in [(False, 1), (True, 1), (False, 2), (True, 2)]:
+        linker.table_management.invalidate_cache()
+        if cached:
+            for left in range(1, chunks + 1):
+                for right in range(1, chunks + 1):
+                    linker.inference.compute_blocked_pairs_for_predict_chunk(
+                        left_chunk=(left, chunks), right_chunk=(right, chunks)
+                    )
+        result = linker.inference.predict(
+            num_chunks_left=chunks, num_chunks_right=chunks
+        )
+        actual = canonical(result)
+        assert [row[:2] for row in actual] == [row[:2] for row in expected]
+        assert [w for _, _, w in actual] == pytest.approx([w for _, _, w in expected])
+        assert not api._parquet_materialiser._pending_queries
+
+
+@mark_with_dialects_including("duckdb")
+@pytest.mark.parametrize("parallel", [False, True])
+def test_file_rollover(tmp_path, parallel):
+    api = DuckDBAPI(
+        materialisation="parquet",
+        materialisation_dir=tmp_path,
+        parquet_materialisation_options=ParquetWriteOptions(
+            per_thread_output=parallel,
+            file_size_bytes="100KB",
+            row_group_size=2048,
+            compression="uncompressed",
+        ),
+    )
+    # One writer thread demonstrates rollover rather than thread count.
+    api.duckdb_con.execute("SET threads=1")
+    result = api._execute_sql(
+        "SELECT i, md5(i::VARCHAR) AS text FROM range(100000) t(i)", "rollover"
+    )
+    path = api._parquet_materialiser._owned_paths[result.physical_name]
+    assert len(list(path.glob("*.parquet"))) > 1
+    assert result.as_duckdbpyrelation().count("*").fetchone() == (100000,)
+    api.delete_tables_created_by_splink_from_db()
+
+
+@mark_with_dialects_including("duckdb")
+def test_invalid_writer_setting_is_not_ignored(api):
+    api._parquet_materialiser._write_options = ParquetWriteOptions(
+        compression="not_a_codec"
+    )
+    with pytest.raises(SplinkException, match="not_a_codec"):
+        api._execute_sql("SELECT 1 AS x", "invalid_codec")
+    assert not api._parquet_materialiser._owned_paths

--- a/tests/test_duckdb_parquet_materialisation.py
+++ b/tests/test_duckdb_parquet_materialisation.py
@@ -1,307 +1,68 @@
-import shutil
-from dataclasses import FrozenInstanceError
-
-import duckdb
-import pytest
-
-from splink import DuckDBAPI, Linker
-from splink.backends.duckdb import DuckDBAPIWithProfiling, ParquetWriteOptions
-from splink.internals.duckdb.dataframe import DuckDBDataFrame
-from splink.internals.duckdb.parquet_materialisation import (
-    _ParquetMaterialiser,
-    _writer_options_sql,
-)
-from splink.internals.exceptions import SplinkException
-from splink.internals.pipeline import CTEPipeline
-
-from .basic_settings import get_settings_dict
-from .decorator import mark_with_dialects_including
+import splink.comparison_library as cl
+from splink import DuckDBAPI, Linker, SettingsCreator, block_on
+from splink.backends.duckdb import DuckDBAPIWithProfiling
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"compression": ""},
-        {"compression": 1},
-        {"compression_level": True},
-        {"compression_level": "3"},
-        {"per_thread_output": 1},
-        {"file_size_bytes": False},
-        {"file_size_bytes": 0},
-        {"file_size_bytes": " "},
-        {"row_group_size": -1},
-        {"row_group_size": 1.5},
-    ],
-)
-def test_invalid_options(kwargs):
-    with pytest.raises((TypeError, ValueError)):
-        ParquetWriteOptions(**kwargs)
-
-
-def test_options_rendering_and_immutability():
-    options = ParquetWriteOptions(per_thread_output=False, compression="a'b")
-    with pytest.raises(FrozenInstanceError):
-        options.compression = "zstd"
-    assert _writer_options_sql(options) == (
-        "FORMAT PARQUET, COMPRESSION 'a''b', PER_THREAD_OUTPUT FALSE"
-    )
-    assert _writer_options_sql(ParquetWriteOptions()) == (
-        "FORMAT PARQUET, PER_THREAD_OUTPUT TRUE"
-    )
-
-
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"materialisation": "unknown"},
-        {"materialisation": "parquet"},
-        {"materialisation_dir": "unused"},
-        {"parquet_materialisation_options": ParquetWriteOptions()},
-        {"materialisation": "parquet", "materialisation_dir": "s3://bucket"},
-        {
-            "materialisation": "parquet",
-            "materialisation_dir": "unused",
-            "parquet_materialisation_options": {},
-        },
-    ],
-)
-def test_validation_precedes_connections(kwargs, monkeypatch):
-    def connect(*args, **kwargs):
-        pytest.fail("opened a connection before validation")
-
-    monkeypatch.setattr(duckdb, "connect", connect)
-    with pytest.raises((TypeError, ValueError)):
-        DuckDBAPI(**kwargs)
-
-
-def test_helper_ownership(tmp_path):
-    helper = _ParquetMaterialiser(tmp_path / "new", ParquetWriteOptions())
-    assert not (tmp_path / "new").exists()
-    sql = helper.prepare_sql("SELECT 1", "result")
-    path = helper._owned_paths["result"]
-    assert sql.startswith("COPY (SELECT 1)")
-    assert path.is_absolute()
-    assert helper.has_pending_write("result")
-    assert "hive_partitioning = false" in helper.view_sql("result")
-    helper.complete("result")
-    assert not helper.has_pending_write("result")
-    helper.delete_backing_files("untracked")
-    assert path.exists()
-    helper.delete_backing_files("result")
-    assert not path.exists()
-    helper.prepare_sql("SELECT 2", "result")
-    assert helper._owned_paths["result"] != path
-    shutil.rmtree(helper._owned_paths["result"])
-    helper.delete_backing_files("result")
-    assert not helper._owned_paths
-
-
-@pytest.fixture
-def api(tmp_path):
-    backend = DuckDBAPI(materialisation="parquet", materialisation_dir=tmp_path)
-    yield backend
-    backend.delete_tables_created_by_splink_from_db()
-
-
-@mark_with_dialects_including("duckdb")
-@pytest.mark.parametrize(
-    "options",
-    [
-        None,
-        ParquetWriteOptions(),
-        ParquetWriteOptions(per_thread_output=False),
-        ParquetWriteOptions(file_size_bytes="100KB", row_group_size=2048),
-        ParquetWriteOptions(
-            per_thread_output=False,
-            file_size_bytes=100_000,
-            compression="zstd",
-            compression_level=3,
-            row_group_size=2048,
-        ),
-    ],
-)
-@pytest.mark.parametrize("empty", [False, True])
-def test_layout_schema_and_direct_copy(tmp_path, options, empty, monkeypatch):
-    backend = DuckDBAPI(
-        materialisation="parquet",
-        materialisation_dir=tmp_path / "run=example" / "it's local",
-        parquet_materialisation_options=options,
-    )
-    statements = []
-    execute = backend._execute_sql_against_backend
-
-    def record(sql):
-        statements.append(sql)
-        return execute(sql)
-
-    monkeypatch.setattr(backend, "_execute_sql_against_backend", record)
-    sql = """WITH source AS (SELECT i FROM range(10000) t(i))
-        SELECT i, NULL::VARCHAR AS n, [i, NULL] AS a, {'x': i} AS s,
-        DATE '2024-01-01' AS d, 1.25::DECIMAL(10,2) AS money FROM source"""
-    if empty:
-        sql += " WHERE FALSE"
-    result = backend._execute_sql(sql, "__splink__test")
-    assert isinstance(result, DuckDBDataFrame)
-    assert result.created_by_splink and result.sql_used_to_create == sql
-    assert result.physical_name in backend._created_tables
-    assert backend._intermediate_table_cache.executed_queries[-1] is result
-    assert not any("CREATE TABLE" in statement for statement in statements)
-    assert any(statement.startswith(f"COPY ({sql})") for statement in statements)
-    assert result.as_duckdbpyrelation().types == execute(sql).types
-    assert (
-        result.as_duckdbpyrelation().order("i").fetchall()
-        == execute(sql).order("i").fetchall()
-    )
-    path = backend._parquet_materialiser._owned_paths[result.physical_name]
-    files = list(path.glob("*.parquet"))
-    assert files
-    if options and not options.per_thread_output and options.file_size_bytes is None:
-        assert [p.name for p in files] == ["data.parquet"]
-    if options and options.compression:
-        codecs = backend.duckdb_con.sql(
-            "SELECT DISTINCT compression FROM parquet_metadata(?)",
-            params=[str(files[0])],
-        ).fetchall()
-        if not empty:
-            assert codecs == [("ZSTD",)]
-    backend.delete_tables_created_by_splink_from_db()
-    assert not path.exists()
-
-
-@mark_with_dialects_including("duckdb")
-def test_ownership_replacement_exports_and_shared_root(api, tmp_path):
-    other = DuckDBAPI(materialisation="parquet", materialisation_dir=tmp_path)
-    other_result = other._execute_sql("SELECT 7 AS x", "other")
-    unrelated = tmp_path / "unrelated.txt"
-    unrelated.write_text("keep")
-    registered = api.register([{"x": 1}])
-    first = api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
-    old_path = api._parquet_materialiser._owned_paths["result"]
-    result = api._sql_to_splink_dataframe("SELECT 2 AS x", "result", "result")
-    assert not old_path.exists()
-    assert result.as_record_list() == [{"x": 2}]
-    api._bind_templated_alias_to_physical("alias", "result")
-    api.delete_table_from_database("alias")
-    assert result.as_record_list() == [{"x": 2}]
-    export = tmp_path / "export.parquet"
-    first.to_parquet(str(export))
-    result.created_by_splink = True
-    result.drop_table_from_database_and_remove_from_cache()
-    api.delete_tables_created_by_splink_from_db()
-    assert export.exists() and unrelated.read_text() == "keep"
-    assert registered.as_record_list() == [{"x": 1}]
-    assert other_result.as_record_list() == [{"x": 7}]
-    other.delete_tables_created_by_splink_from_db()
-
-
-@mark_with_dialects_including("duckdb")
-def test_native_mode_and_schema_connection_profiling(tmp_path):
-    native = DuckDBAPI()
-    assert native._materialisation == "table"
-    assert native._parquet_materialiser is None
-    native.query_sql("SELECT 1 AS x")
-    con = duckdb.connect(str(tmp_path / "db.duckdb"))
+def test_profiling_with_parquet_materialisation(tmp_path):
+    profiles = tmp_path / "profiles"
     api = DuckDBAPIWithProfiling(
-        con,
-        "results",
-        tmp_path / "profiles",
+        query_profiling_dir=profiles,
         materialisation="parquet",
         materialisation_dir=tmp_path / "backing",
     )
-    assert api._materialisation == "parquet"
-    result = api._execute_sql("SELECT 1 AS x", "result")
-    assert con.sql(
-        "SELECT table_type FROM information_schema.tables WHERE table_schema='results'"
-    ).fetchall() == [("VIEW",)]
-    profiles = list((tmp_path / "profiles").glob("*.json"))
-    assert profiles and "COPY" in profiles[0].read_text()
-    assert result.as_record_list() == [{"x": 1}]
-    with pytest.raises(SplinkException):
-        api._execute_sql("SELECT missing", "bad")
-    assert not api._profiling_active
-    assert len(api._parquet_materialiser._pending_queries) == 1
-    failed_name = next(iter(api._parquet_materialiser._pending_queries))
-    api.delete_table_from_database(failed_name)
-    api.delete_tables_created_by_splink_from_db()
+
+    result = api.query_sql("SELECT 1 AS value")
+
+    assert result.as_record_list() == [{"value": 1}]
+    profile_files = list(profiles.glob("*.json"))
+    assert len(profile_files) == 1
+    assert "COPY" in profile_files[0].read_text()
 
 
-@mark_with_dialects_including("duckdb")
-def test_debug_pipeline(api):
-    api.debug_mode = True
-    pipeline = CTEPipeline()
-    pipeline.enqueue_sql("SELECT 1 AS x", "__splink__first")
-    pipeline.enqueue_sql("SELECT x + 1 AS x FROM __splink__first", "__splink__last")
-    result = api.sql_pipeline_to_splink_dataframe(pipeline)
-    assert result.as_record_list() == [{"x": 2}]
-    assert set(api._parquet_materialiser._owned_paths) == {result.physical_name}
-    assert not api.table_exists_in_database("__splink__first")
-
-
-@mark_with_dialects_including("duckdb")
-def test_prediction_cached_blocking_and_chunks(api, fake_1000):
-    settings = get_settings_dict()
-    native = DuckDBAPI()
-    baseline = Linker(native.register(fake_1000), settings).inference.predict()
-
-    def canonical(result):
-        return (
-            result.as_duckdbpyrelation()
-            .project("unique_id_l, unique_id_r, match_weight")
-            .order("unique_id_l, unique_id_r")
-            .fetchall()
-        )
-
-    expected = canonical(baseline)
-    linker = Linker(api.register(fake_1000), settings)
-    for cached, chunks in [(False, 1), (True, 1), (False, 2), (True, 2)]:
-        linker.table_management.invalidate_cache()
-        if cached:
-            for left in range(1, chunks + 1):
-                for right in range(1, chunks + 1):
-                    linker.inference.compute_blocked_pairs_for_predict_chunk(
-                        left_chunk=(left, chunks), right_chunk=(right, chunks)
-                    )
-        result = linker.inference.predict(
-            num_chunks_left=chunks, num_chunks_right=chunks
-        )
-        actual = canonical(result)
-        assert [row[:2] for row in actual] == [row[:2] for row in expected]
-        assert [w for _, _, w in actual] == pytest.approx([w for _, _, w in expected])
-        assert not api._parquet_materialiser._pending_queries
-
-
-@mark_with_dialects_including("duckdb")
-@pytest.mark.parametrize("parallel", [False, True])
-def test_file_rollover(tmp_path, parallel):
+def test_training_and_prediction_leave_only_owned_parquet_files(tmp_path):
+    data = [
+        {"unique_id": 1, "name": "Robin", "surname": "Smith", "city": "London"},
+        {"unique_id": 2, "name": "Robin", "surname": "Smyth", "city": "London"},
+        {"unique_id": 3, "name": "Alice", "surname": "Smith", "city": "London"},
+        {"unique_id": 4, "name": "Alice", "surname": "Jones", "city": "London"},
+        {"unique_id": 5, "name": "Bob", "surname": "Brown", "city": "Leeds"},
+        {"unique_id": 6, "name": "Bobby", "surname": "Brown", "city": "Leeds"},
+        {"unique_id": 7, "name": "Carol", "surname": "White", "city": "Leeds"},
+        {"unique_id": 8, "name": "Carol", "surname": "Brown", "city": "Leeds"},
+    ]
+    backing = tmp_path / "backing"
+    user_parquet = backing / "user.parquet"
+    backing.mkdir()
+    user_parquet.write_bytes(b"user data")
     api = DuckDBAPI(
         materialisation="parquet",
-        materialisation_dir=tmp_path,
-        parquet_materialisation_options=ParquetWriteOptions(
-            per_thread_output=parallel,
-            file_size_bytes="100KB",
-            row_group_size=2048,
-            compression="uncompressed",
-        ),
+        materialisation_dir=backing,
     )
-    # One writer thread demonstrates rollover rather than thread count.
-    api.duckdb_con.execute("SET threads=1")
-    result = api._execute_sql(
-        "SELECT i, md5(i::VARCHAR) AS text FROM range(100000) t(i)", "rollover"
+    settings = SettingsCreator(
+        link_type="dedupe_only",
+        comparisons=[cl.ExactMatch("name"), cl.ExactMatch("surname")],
+        blocking_rules_to_generate_predictions=[block_on("city")],
+        max_iterations=1,
     )
-    path = api._parquet_materialiser._owned_paths[result.physical_name]
-    assert len(list(path.glob("*.parquet"))) > 1
-    assert result.as_duckdbpyrelation().count("*").fetchone() == (100000,)
+    linker = Linker(api.register(data), settings)
+
+    linker.training.estimate_parameters_using_expectation_maximisation(block_on("city"))
+    prediction = linker.inference.predict()
+
+    materialiser = api._get_parquet_materialiser()
+    assert prediction.physical_name in materialiser._owned_paths
+    assert not materialiser._pending_queries
+    tracked_files = {
+        file.resolve()
+        for path in materialiser._owned_paths.values()
+        for file in path.glob("*.parquet")
+    }
+    files_on_disk = {
+        file.resolve() for file in backing.rglob("*.parquet") if file != user_parquet
+    }
+    assert tracked_files
+    assert files_on_disk == tracked_files
+
     api.delete_tables_created_by_splink_from_db()
-
-
-@mark_with_dialects_including("duckdb")
-def test_invalid_writer_setting_is_not_ignored(api):
-    api._parquet_materialiser._write_options = ParquetWriteOptions(
-        compression="not_a_codec"
-    )
-    with pytest.raises(SplinkException, match="not_a_codec"):
-        api._execute_sql("SELECT 1 AS x", "invalid_codec")
-    assert len(api._parquet_materialiser._owned_paths) == 1
-    failed_name = next(iter(api._parquet_materialiser._owned_paths))
-    api.delete_table_from_database(failed_name)
-    assert not api._parquet_materialiser._owned_paths
+    assert user_parquet.read_bytes() == b"user data"
+    assert list(backing.rglob("*.parquet")) == [user_parquet]

--- a/tests/test_duckdb_parquet_materialisation.py
+++ b/tests/test_duckdb_parquet_materialisation.py
@@ -195,87 +195,6 @@ def test_ownership_replacement_exports_and_shared_root(api, tmp_path):
 
 
 @mark_with_dialects_including("duckdb")
-@pytest.mark.parametrize("stage", ["setup", "copy", "view", "wrapper", "interrupt"])
-def test_failed_attempt_cleanup_and_retry(api, monkeypatch, stage):
-    materialiser = api._parquet_materialiser
-    execute = api._execute_sql_against_backend
-    prepare = materialiser.prepare_sql
-    with monkeypatch.context() as patch:
-        if stage == "setup":
-
-            def fail_setup(sql, name):
-                prepare(sql, name)
-                raise RuntimeError("injected")
-
-            patch.setattr(materialiser, "prepare_sql", fail_setup)
-        elif stage == "wrapper":
-
-            def fail_wrapper(*args):
-                raise RuntimeError("injected")
-
-            patch.setattr(api, "table_to_splink_dataframe", fail_wrapper)
-        else:
-
-            def fail_sql(sql):
-                if (stage in ("copy", "interrupt") and sql.startswith("COPY")) or (
-                    stage == "view" and sql.startswith("CREATE VIEW")
-                ):
-                    for path in materialiser._owned_paths.values():
-                        (path / "partial.parquet").write_bytes(b"partial")
-                    if stage == "interrupt":
-                        raise KeyboardInterrupt("injected")
-                    raise RuntimeError("injected")
-                return execute(sql)
-
-            patch.setattr(api, "_execute_sql_against_backend", fail_sql)
-        with pytest.raises(
-            (RuntimeError, SplinkException, KeyboardInterrupt), match="injected"
-        ):
-            api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
-    assert not materialiser._owned_paths and not materialiser._pending_queries
-    assert not api._created_tables
-    assert not api._intermediate_table_cache.executed_queries
-    assert not api.table_exists_in_database("result")
-    assert api._sql_to_splink_dataframe(
-        "SELECT 2 AS x", "result", "result"
-    ).as_record_list() == [{"x": 2}]
-
-
-@mark_with_dialects_including("duckdb")
-def test_cleanup_failure_retains_tracking_and_original_error(api, monkeypatch, caplog):
-    with monkeypatch.context() as patch:
-
-        def fail_remove(path):
-            raise PermissionError("injected delete failure")
-
-        patch.setattr(shutil, "rmtree", fail_remove)
-        with pytest.raises(SplinkException, match="missing_column"):
-            api._sql_to_splink_dataframe("SELECT missing_column", "result", "result")
-    path = api._parquet_materialiser._owned_paths["result"]
-    assert path.exists() and str(path) in caplog.text
-    assert api._parquet_materialiser.has_pending_write("result")
-    assert not api._created_tables
-    api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
-    assert not path.exists()
-
-
-@mark_with_dialects_including("duckdb")
-def test_failure_before_allocation_preserves_live_result(api, monkeypatch):
-    api._sql_to_splink_dataframe("SELECT 1 AS x", "result", "result")
-    path = api._parquet_materialiser._owned_paths["result"]
-    with monkeypatch.context() as patch:
-
-        def fail_drop(name):
-            raise RuntimeError("before allocation")
-
-        patch.setattr(api, "delete_table_from_database", fail_drop)
-        with pytest.raises(RuntimeError, match="before allocation"):
-            api._sql_to_splink_dataframe("SELECT 2", "result", "result")
-    assert path.exists()
-    assert api.duckdb_con.sql("SELECT * FROM result").fetchall() == [(1,)]
-
-
-@mark_with_dialects_including("duckdb")
 def test_native_mode_and_schema_connection_profiling(tmp_path):
     native = DuckDBAPI()
     assert native._materialisation == "table"
@@ -300,7 +219,9 @@ def test_native_mode_and_schema_connection_profiling(tmp_path):
     with pytest.raises(SplinkException):
         api._execute_sql("SELECT missing", "bad")
     assert not api._profiling_active
-    assert not api._parquet_materialiser._pending_queries
+    assert len(api._parquet_materialiser._pending_queries) == 1
+    failed_name = next(iter(api._parquet_materialiser._pending_queries))
+    api.delete_table_from_database(failed_name)
     api.delete_tables_created_by_splink_from_db()
 
 
@@ -380,4 +301,7 @@ def test_invalid_writer_setting_is_not_ignored(api):
     )
     with pytest.raises(SplinkException, match="not_a_codec"):
         api._execute_sql("SELECT 1 AS x", "invalid_codec")
+    assert len(api._parquet_materialiser._owned_paths) == 1
+    failed_name = next(iter(api._parquet_materialiser._owned_paths))
+    api.delete_table_from_database(failed_name)
     assert not api._parquet_materialiser._owned_paths

--- a/tests/test_full_example_duckdb.py
+++ b/tests/test_full_example_duckdb.py
@@ -21,7 +21,8 @@ simple_settings = {
 
 
 @mark_with_dialects_including("duckdb")
-def test_full_example_duckdb(tmp_path, fake_1000):
+@pytest.mark.parametrize("materialisation", ["table", "parquet"])
+def test_full_example_duckdb(tmp_path, fake_1000, materialisation):
     df = fake_1000.rename_columns({"surname": "SUR name"})
     settings_dict = get_settings_dict()
 
@@ -33,7 +34,13 @@ def test_full_example_duckdb(tmp_path, fake_1000):
         'l."SUR name" = r."SUR name"',
     ]
 
-    db_api = DuckDBAPI(connection=os.path.join(tmp_path, "duckdb.db"))
+    db_api = DuckDBAPI(
+        connection=os.path.join(tmp_path, "duckdb.db"),
+        materialisation=materialisation,
+        materialisation_dir=tmp_path / "backing"
+        if materialisation == "parquet"
+        else None,
+    )
     df_sdf = db_api.register(df)
 
     count_comparisons_from_blocking_rules(


### PR DESCRIPTION
Testing on large EC2 instances has shown that performance drops substantially on large datasets when memory is exhausted.   This causes spill to disk which in turn causes two problems:

- First, everything runs slower when memory is exhausted because spill to disk is expensive
- Second, the specific job of writing very large parquet outputs to disk on high-cpu machines is very slow if duckdb has spilt to disk.

In particular, I never successfully managed a full run of a 1bn input, 10bn comparison job.  `predict()` completed successfully, but the final 'to_parquet()` was taking so long I had to cancel the job (after around an hour).

## What does this PR do?

Rather than storing intermediate results as duckdb tables, this introduces the option of saving results to parquet. 

In tests this dramatically reduces memory requirements, and increases speed.  The same 1bn/10bn job completed in 8 minutes. It completely avoids a  duckdb table -> parquet step, because the output of each step is already in parquet

See below comment for further evidence