### PR TITLE
Include chart definitions in direct wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,10 @@ build-backend = "hatchling.build"
 only-include = ["splink"]
 ignore-vcs = true
 
+[tool.hatch.build.targets.wheel]
+packages = ["splink"]
+artifacts = ["splink/internals/files/chart_defs/*.json"]
+
 [tool.isort]
 profile = "black"
 


### PR DESCRIPTION
Direct Hatch wheel builds from a Git checkout omit `splink/internals/files/chart_defs/*.json`, so installed charts cannot load their Vega-Lite specifications. Wheels built from the source distribution already contain these files.

Declare the chart definitions as wheel artifacts so both build paths produce the same installable package. `packages = ["splink"]` preserves normal package discovery after defining the wheel target.

Validated by building a wheel directly from this checkout: it contains all 19 chart-definition JSON files.
